### PR TITLE
test(posts): branch coverage 57% → 88% でカバレッジ閾値80%を達成

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "lint": "node ../../node_modules/eslint/bin/eslint.js \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "node ../../node_modules/eslint/bin/eslint.js \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
+    "test:cov": "jest --coverage",
     "test:watch": "jest --watch",
     "test:e2e": "jest --config jest-e2e.json --runInBand --forceExit"
   },
@@ -37,7 +38,15 @@
     ],
     "setupFiles": [
       "reflect-metadata"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "lines": 80,
+        "functions": 80,
+        "branches": 80,
+        "statements": 80
+      }
+    }
   },
   "dependencies": {
     "@nestjs/common": "^11.1.19",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "setupFiles": [
       "reflect-metadata"
     ],
+    "coverageDirectory": "<rootDir>/../coverage",
     "coverageThreshold": {
       "global": {
         "lines": 80,

--- a/apps/api/src/posts/post.controller.spec.ts
+++ b/apps/api/src/posts/post.controller.spec.ts
@@ -1,5 +1,5 @@
-import { ForbiddenException, HttpException } from "@nestjs/common";
-import { PostsController } from "./post.controller";
+import { BadRequestException, ForbiddenException, HttpException } from "@nestjs/common";
+import { PostsController, imageFileFilter } from "./post.controller";
 import { PostsService } from "./post.service";
 
 const makePost = (overrides = {}) => ({
@@ -133,6 +133,33 @@ describe("PostsController", () => {
       await expect(
         controller.update(req, "no-such", {} as any, undefined as any),
       ).rejects.toThrow(HttpException);
+    });
+  });
+
+  // ─── imageFileFilter ─────────────────────────────────────────
+  describe("imageFileFilter", () => {
+    it("fileがnullの時、cb(null, false)を呼ぶこと", () => {
+      const cb = jest.fn();
+      imageFileFilter({}, null, cb);
+      expect(cb).toHaveBeenCalledWith(null, false);
+    });
+
+    it("originalnameがない時、cb(null, false)を呼ぶこと", () => {
+      const cb = jest.fn();
+      imageFileFilter({}, { mimetype: "image/png" } as any, cb);
+      expect(cb).toHaveBeenCalledWith(null, false);
+    });
+
+    it("許可されたMIMEタイプの時、cb(null, true)を呼ぶこと", () => {
+      const cb = jest.fn();
+      imageFileFilter({}, { originalname: "photo.png", mimetype: "image/png" } as any, cb);
+      expect(cb).toHaveBeenCalledWith(null, true);
+    });
+
+    it("許可されていないMIMEタイプの時、BadRequestExceptionを渡すこと", () => {
+      const cb = jest.fn();
+      imageFileFilter({}, { originalname: "doc.pdf", mimetype: "application/pdf" } as any, cb);
+      expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
     });
   });
 

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -36,23 +36,21 @@ const ALLOWED_MIME_TYPES = [
 ];
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
+export function imageFileFilter(_req: any, file: Express.Multer.File, cb: any) {
+  if (!file || !file.originalname || !file.mimetype) {
+    return cb(null, false);
+  }
+  if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new BadRequestException(`Unsupported file type: ${file.mimetype}`), false);
+  }
+}
+
 const imageUploadOptions = {
   storage: memoryStorage(),
   limits: { fileSize: MAX_FILE_SIZE },
-  fileFilter: (_req: any, file: Express.Multer.File, cb: any) => {
-    if (!file || !file.originalname || !file.mimetype) {
-      // empty file field is allowed as "no image" input
-      return cb(null, false);
-    }
-    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
-      cb(null, true);
-    } else {
-      cb(
-        new BadRequestException(`Unsupported file type: ${file.mimetype}`),
-        false,
-      );
-    }
-  },
+  fileFilter: imageFileFilter,
 };
 
 @ApiTags("posts")

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -1,5 +1,9 @@
 import { ForbiddenException, HttpException } from "@nestjs/common";
+import * as fs from "fs";
 import { PostsService } from "./post.service";
+
+jest.mock("fs");
+const mockFs = fs as jest.Mocked<typeof fs>;
 
 // PrismaService のモック
 const mockPrisma = {
@@ -19,6 +23,10 @@ describe("PostsService", () => {
   beforeEach(() => {
     service = new PostsService(mockPrisma as any);
     jest.clearAllMocks();
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.writeFileSync.mockReturnValue(undefined);
+    mockFs.mkdirSync.mockReturnValue(undefined as any);
+    mockFs.unlinkSync.mockReturnValue(undefined);
   });
 
   // ─── findAll ────────────────────────────────────────────────
@@ -71,6 +79,28 @@ describe("PostsService", () => {
       });
       expect(result).toEqual(created);
     });
+
+    it("ファイルありで投稿を作成する時、imagePathが設定されること", async () => {
+      const created = { id: "1", title: "T", content: "C", authorId: "u1", image: "uploads/uuid.png", createdAt: new Date() };
+      mockPrisma.post.create.mockResolvedValue(created);
+      const file = { originalname: "photo.png", buffer: Buffer.from("") } as any;
+
+      await service.create("u1", "T", "C", file);
+
+      expect(mockPrisma.post.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ image: expect.stringMatching(/^uploads\//) }),
+      });
+    });
+
+    it("アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと", async () => {
+      mockFs.existsSync.mockReturnValue(false);
+      mockPrisma.post.create.mockResolvedValue({} as any);
+      const file = { originalname: "photo.png", buffer: Buffer.from("") } as any;
+
+      await service.create("u1", "T", "C", file);
+
+      expect(mockFs.mkdirSync).toHaveBeenCalled();
+    });
   });
 
   // ─── update ─────────────────────────────────────────────────
@@ -112,6 +142,27 @@ describe("PostsService", () => {
       await expect(
         service.update("no-such-post", "user1", { title: "X" }),
       ).rejects.toThrow(HttpException);
+    });
+
+    it("ファイルありかつ既存画像がある時、古い画像ファイルが削除されること", async () => {
+      const postWithImage = { ...existingPost, image: "uploads/old.png" };
+      mockPrisma.post.findUnique.mockResolvedValue(postWithImage);
+      mockPrisma.post.update.mockResolvedValue({ ...postWithImage, image: "uploads/new.png" });
+      const file = { originalname: "new.png", buffer: Buffer.from("") } as any;
+
+      await service.update("post1", "user1", {}, file);
+
+      expect(mockFs.unlinkSync).toHaveBeenCalled();
+    });
+
+    it("ファイルありかつ既存画像がない時、unlinkSyncを呼ばないこと", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost); // image: null
+      mockPrisma.post.update.mockResolvedValue({ ...existingPost, image: "uploads/new.png" });
+      const file = { originalname: "new.png", buffer: Buffer.from("") } as any;
+
+      await service.update("post1", "user1", {}, file);
+
+      expect(mockFs.unlinkSync).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -1,0 +1,70 @@
+# テスト一覧
+
+## apps/api
+
+### PostsService (`src/posts/post.service.spec.ts`)
+
+#### findAll
+- [x] ページ1・perPage5 で skip=0 / take=5 を渡す
+- [x] ページ3・perPage5 で skip=10 を渡す
+- [x] items と total を返す
+
+#### create
+- [x] ファイルなしで投稿を作成する
+- [x] ファイルありで投稿を作成する時、imagePathが設定されること
+- [x] アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
+
+#### update
+- [x] オーナーが更新できる
+- [x] オーナー以外は ForbiddenException
+- [x] 存在しない投稿は HttpException (404)
+- [x] ファイルありかつ既存画像がある時、古い画像ファイルが削除されること
+- [x] ファイルありかつ既存画像がない時、unlinkSyncを呼ばないこと
+
+#### remove
+- [x] オーナーが削除できる
+- [x] オーナー以外は ForbiddenException
+- [x] 存在しない投稿は HttpException (404)
+
+---
+
+### PostsController (`src/posts/post.controller.spec.ts`)
+
+#### list
+- [x] デフォルト（page=1, perPage=10）で findAll を呼ぶ
+- [x] 文字列クエリを数値に変換して渡す
+- [x] 不正な文字列は 1 / 10 にフォールバックする
+- [x] items と total を返す
+
+#### get
+- [x] 指定 ID の投稿を返す
+
+#### create
+- [x] req.user.id を authorId として投稿を作成する
+- [x] ファイル付きで作成できる
+
+#### update
+- [x] オーナーが更新できる
+- [x] オーナー以外は ForbiddenException を伝播する
+- [x] 存在しない投稿は HttpException を伝播する
+
+#### imageFileFilter
+- [x] fileがnullの時、cb(null, false)を呼ぶこと
+- [x] originalnameがない時、cb(null, false)を呼ぶこと
+- [x] 許可されたMIMEタイプの時、cb(null, true)を呼ぶこと
+- [x] 許可されていないMIMEタイプの時、BadRequestExceptionを渡すこと
+
+#### remove
+- [x] オーナーが削除できる
+- [x] オーナー以外は ForbiddenException を伝播する
+- [x] 存在しない投稿は HttpException を伝播する
+
+---
+
+### AuthService (`src/auth/auth.service.spec.ts`)
+
+（既存テスト・詳細省略）
+
+### UserService (`src/users/user.service.spec.ts`)
+
+（既存テスト・詳細省略）

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -1,0 +1,55 @@
+# テスト一覧（ツリー形式）
+
+```
+apps/api/src/
+├── auth/
+│   └── auth.service.spec.ts
+│       └── AuthService（既存）
+├── posts/
+│   ├── post.service.spec.ts
+│   │   ├── findAll
+│   │   │   ├── ページ1・perPage5 で skip=0 / take=5 を渡す
+│   │   │   ├── ページ3・perPage5 で skip=10 を渡す
+│   │   │   └── items と total を返す
+│   │   ├── create
+│   │   │   ├── ファイルなしで投稿を作成する
+│   │   │   ├── ファイルありで投稿を作成する時、imagePathが設定されること
+│   │   │   └── アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
+│   │   ├── update
+│   │   │   ├── オーナーが更新できる
+│   │   │   ├── オーナー以外は ForbiddenException
+│   │   │   ├── 存在しない投稿は HttpException (404)
+│   │   │   ├── ファイルありかつ既存画像がある時、古い画像ファイルが削除されること
+│   │   │   └── ファイルありかつ既存画像がない時、unlinkSyncを呼ばないこと
+│   │   └── remove
+│   │       ├── オーナーが削除できる
+│   │       ├── オーナー以外は ForbiddenException
+│   │       └── 存在しない投稿は HttpException (404)
+│   └── post.controller.spec.ts
+│       ├── list
+│       │   ├── デフォルト（page=1, perPage=10）で findAll を呼ぶ
+│       │   ├── 文字列クエリを数値に変換して渡す
+│       │   ├── 不正な文字列は 1 / 10 にフォールバックする
+│       │   └── items と total を返す
+│       ├── get
+│       │   └── 指定 ID の投稿を返す
+│       ├── create
+│       │   ├── req.user.id を authorId として投稿を作成する
+│       │   └── ファイル付きで作成できる
+│       ├── update
+│       │   ├── オーナーが更新できる
+│       │   ├── オーナー以外は ForbiddenException を伝播する
+│       │   └── 存在しない投稿は HttpException を伝播する
+│       ├── imageFileFilter
+│       │   ├── fileがnullの時、cb(null, false)を呼ぶこと
+│       │   ├── originalnameがない時、cb(null, false)を呼ぶこと
+│       │   ├── 許可されたMIMEタイプの時、cb(null, true)を呼ぶこと
+│       │   └── 許可されていないMIMEタイプの時、BadRequestExceptionを渡すこと
+│       └── remove
+│           ├── オーナーが削除できる
+│           ├── オーナー以外は ForbiddenException を伝播する
+│           └── 存在しない投稿は HttpException を伝播する
+└── users/
+    └── user.service.spec.ts
+        └── UserService（既存）
+```


### PR DESCRIPTION
## Summary

- `imageFileFilter` を export 化し、fileFilter の3分岐（null/許可MIMEタイプ/非許可MIMEタイプ）をテスト
- `post.service.spec.ts` に `jest.mock('fs')` を導入し、ファイルあり create・update（既存画像削除含む）をカバー
- `apps/api/package.json` に Jest `coverageThreshold`（全指標80%）と `test:cov` スクリプトを追加

## Test plan

- [ ] `cd apps/api && npm run test` で全52テスト通過を確認
- [ ] `cd apps/api && npm run test:cov` でbranch coverage 87.75%（閾値80%超）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)