### PR TITLE
feat: issue#5 Post基本CRUD実装（PetDetail/Location/Image対応）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test
+
       - name: API tests
         run: npm test
         working-directory: apps/api
@@ -150,6 +156,10 @@ jobs:
 
       - run: npm ci
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+        working-directory: apps/api
+
       # API checks
       - name: API Lint
         run: npm run lint:api
@@ -167,7 +177,6 @@ jobs:
       - name: Web Build
         run: npm run build
         working-directory: apps/web
-
 
   review-ready:
     name: Ready for Review

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+npx lint-staged
+npm run typecheck:api
+npm run typecheck:web
+npm run test

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,3 @@
+{
+  "*": "prettier --ignore-unknown --write"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "printWidth": 80,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "semi": true,
+  "arrowParens": "always"
+}

--- a/apps/api/prisma/migrations/20260419030534_init_lostcat/migration.sql
+++ b/apps/api/prisma/migrations/20260419030534_init_lostcat/migration.sql
@@ -1,0 +1,215 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `authorId` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `content` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `image` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `name` on the `User` table. All the data in the column will be lost.
+  - Added the required column `description` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `lostDate` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `nickname` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "PostStatus" AS ENUM ('lost', 'resolved');
+
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('male', 'female', 'unknown');
+
+-- CreateEnum
+CREATE TYPE "Prefecture" AS ENUM ('saitama');
+
+-- DropForeignKey
+ALTER TABLE "Post" DROP CONSTRAINT "Post_authorId_fkey";
+
+-- AlterTable
+ALTER TABLE "Post" DROP COLUMN "authorId",
+DROP COLUMN "content",
+DROP COLUMN "image",
+ADD COLUMN     "description" TEXT NOT NULL,
+ADD COLUMN     "lostDate" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "resolvedAt" TIMESTAMP(3),
+ADD COLUMN     "status" "PostStatus" NOT NULL DEFAULT 'lost',
+ADD COLUMN     "userId" TEXT NOT NULL,
+ALTER COLUMN "title" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "name",
+ADD COLUMN     "nickname" TEXT NOT NULL;
+
+-- CreateTable
+CREATE TABLE "PetDetail" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "age" TEXT NOT NULL,
+    "features" TEXT NOT NULL,
+    "gender" "Gender",
+    "breed" TEXT,
+    "size" TEXT,
+    "collar" TEXT,
+    "microchip" BOOLEAN,
+    "neutered" BOOLEAN,
+
+    CONSTRAINT "PetDetail_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Location" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "prefecture" "Prefecture" NOT NULL,
+    "city" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "lat" DOUBLE PRECISION NOT NULL,
+    "lng" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "Location_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Image" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Image_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Sighting" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "lat" DOUBLE PRECISION NOT NULL,
+    "lng" DOUBLE PRECISION NOT NULL,
+    "address" TEXT,
+    "sightedAt" TIMESTAMP(3) NOT NULL,
+    "comment" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Sighting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SightingImage" (
+    "id" TEXT NOT NULL,
+    "sightingId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SightingImage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Conversation" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "sightingId" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "sighterId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostFavorite" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostFavorite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SightingFavorite" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sightingId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SightingFavorite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PetDetail_postId_key" ON "PetDetail"("postId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Location_postId_key" ON "Location"("postId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Conversation_postId_sightingId_key" ON "Conversation"("postId", "sightingId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostFavorite_userId_postId_key" ON "PostFavorite"("userId", "postId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SightingFavorite_userId_sightingId_key" ON "SightingFavorite"("userId", "sightingId");
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PetDetail" ADD CONSTRAINT "PetDetail_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Location" ADD CONSTRAINT "Location_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Image" ADD CONSTRAINT "Image_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Sighting" ADD CONSTRAINT "Sighting_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Sighting" ADD CONSTRAINT "Sighting_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SightingImage" ADD CONSTRAINT "SightingImage_sightingId_fkey" FOREIGN KEY ("sightingId") REFERENCES "Sighting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_sightingId_fkey" FOREIGN KEY ("sightingId") REFERENCES "Sighting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_sighterId_fkey" FOREIGN KEY ("sighterId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostFavorite" ADD CONSTRAINT "PostFavorite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostFavorite" ADD CONSTRAINT "PostFavorite_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SightingFavorite" ADD CONSTRAINT "SightingFavorite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SightingFavorite" ADD CONSTRAINT "SightingFavorite_sightingId_fkey" FOREIGN KEY ("sightingId") REFERENCES "Sighting"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -7,25 +7,163 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum PostStatus {
+  lost
+  resolved
+}
+
+enum Gender {
+  male
+  female
+  unknown
+}
+
+enum Prefecture {
+  saitama
+}
+
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  password  String
-  name      String?
-  posts     Post[]
+  id            String         @id @default(cuid())
+  email         String         @unique
+  password      String
+  nickname      String
+  posts         Post[]
+  sightings     Sighting[]
   refreshTokens RefreshToken[]
-  createdAt DateTime @default(now())
+  conversations Conversation[] @relation("ConversationOwner")
+  sighterConversations Conversation[] @relation("ConversationSighter")
+  messages      Message[]
+  postFavorites    PostFavorite[]
+  sightingFavorites SightingFavorite[]
+  createdAt     DateTime       @default(now())
 }
 
 model Post {
+  id          String     @id @default(cuid())
+  user        User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String
+  status      PostStatus @default(lost)
+  title       String?
+  description String
+  lostDate    DateTime
+  resolvedAt  DateTime?
+  petDetail   PetDetail?
+  location    Location?
+  images      Image[]
+  sightings   Sighting[]
+  conversations Conversation[]
+  favorites   PostFavorite[]
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+}
+
+model PetDetail {
+  id         String   @id @default(cuid())
+  post       Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  postId     String   @unique
+  name       String
+  color      String
+  age        String
+  features   String
+  gender     Gender?
+  breed      String?
+  size       String?
+  collar     String?
+  microchip  Boolean?
+  neutered   Boolean?
+}
+
+model Location {
+  id         String     @id @default(cuid())
+  post       Post       @relation(fields: [postId], references: [id], onDelete: Cascade)
+  postId     String     @unique
+  prefecture Prefecture
+  city       String
+  address    String
+  lat        Float
+  lng        Float
+}
+
+model Image {
   id        String   @id @default(cuid())
-  title     String
-  content   String
-  image     String?
-  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
-  authorId  String
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  postId    String
+  url       String
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+}
+
+model Sighting {
+  id        String           @id @default(cuid())
+  post      Post             @relation(fields: [postId], references: [id], onDelete: Cascade)
+  postId    String
+  user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  lat       Float
+  lng       Float
+  address   String?
+  sightedAt DateTime
+  comment   String?
+  images    SightingImage[]
+  conversations Conversation[]
+  favorites SightingFavorite[]
+  createdAt DateTime         @default(now())
+}
+
+model SightingImage {
+  id         String   @id @default(cuid())
+  sighting   Sighting @relation(fields: [sightingId], references: [id], onDelete: Cascade)
+  sightingId String
+  url        String
+  createdAt  DateTime @default(now())
+}
+
+model Conversation {
+  id        String    @id @default(cuid())
+  post      Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
+  postId    String
+  sighting  Sighting  @relation(fields: [sightingId], references: [id], onDelete: Cascade)
+  sightingId String
+  owner     User      @relation("ConversationOwner", fields: [ownerId], references: [id])
+  ownerId   String
+  sighter   User      @relation("ConversationSighter", fields: [sighterId], references: [id])
+  sighterId String
+  messages  Message[]
+  createdAt DateTime  @default(now())
+
+  @@unique([postId, sightingId])
+}
+
+model Message {
+  id             String       @id @default(cuid())
+  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  conversationId String
+  sender         User         @relation(fields: [senderId], references: [id])
+  senderId       String
+  body           String
+  readAt         DateTime?
+  createdAt      DateTime     @default(now())
+}
+
+model PostFavorite {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  postId    String
+  createdAt DateTime @default(now())
+
+  @@unique([userId, postId])
+}
+
+model SightingFavorite {
+  id         String   @id @default(cuid())
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     String
+  sighting   Sighting @relation(fields: [sightingId], references: [id], onDelete: Cascade)
+  sightingId String
+  createdAt  DateTime @default(now())
+
+  @@unique([userId, sightingId])
 }
 
 model RefreshToken {

--- a/apps/api/src/posts/dto/create-post.dto.ts
+++ b/apps/api/src/posts/dto/create-post.dto.ts
@@ -55,10 +55,9 @@ export class CreatePostDto {
   @MinLength(1)
   description: string;
 
-  @ApiProperty({ required: false, example: "2024-01-01" })
-  @IsOptional()
+  @ApiProperty({ example: "2024-01-01" })
   @IsDateString()
-  lostDate?: string;
+  lostDate: string;
 
   @ApiProperty({ required: false, type: CreatePetDetailDto })
   @IsOptional()

--- a/apps/api/src/posts/dto/create-post.dto.ts
+++ b/apps/api/src/posts/dto/create-post.dto.ts
@@ -1,20 +1,76 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString, MinLength, MaxLength, IsOptional } from "class-validator";
+import { Type, Transform } from "class-transformer";
+import {
+  IsString,
+  MinLength,
+  MaxLength,
+  IsOptional,
+  IsDateString,
+  ValidateNested,
+  IsNumber,
+  IsBoolean,
+  IsEnum,
+} from "class-validator";
+import { parseJsonField } from "../../utils/transform";
 
-export class CreatePostDto {
-  @ApiProperty({ example: "My first post" })
-  @IsString()
-  @MinLength(1)
-  @MaxLength(100)
-  title: string;
-
-  @ApiProperty({ example: "Hello world!" })
-  @IsString()
-  @MinLength(1)
-  content: string;
-
+export class CreatePetDetailDto {
+  @ApiProperty() @IsString() name: string;
+  @ApiProperty() @IsString() color: string;
+  @ApiProperty() @IsString() age: string;
+  @ApiProperty() @IsString() features: string;
+  @ApiProperty({ required: false, enum: ["male", "female", "unknown"] })
+  @IsOptional()
+  @IsEnum(["male", "female", "unknown"])
+  gender?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() breed?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() size?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() collar?: string;
   @ApiProperty({ required: false })
   @IsOptional()
+  @IsBoolean()
+  microchip?: boolean;
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  neutered?: boolean;
+}
+
+export class CreateLocationDto {
+  @ApiProperty({ enum: ["saitama"] }) @IsEnum(["saitama"]) prefecture: string;
+  @ApiProperty() @IsString() city: string;
+  @ApiProperty() @IsString() address: string;
+  @ApiProperty() @IsNumber() lat: number;
+  @ApiProperty() @IsNumber() lng: number;
+}
+
+export class CreatePostDto {
+  @ApiProperty({ required: false, example: "白猫のミケを探しています" })
+  @IsOptional()
   @IsString()
-  image?: string;
+  @MaxLength(100)
+  title?: string;
+
+  @ApiProperty({ example: "首輪なし、人懐こい性格" })
+  @IsString()
+  @MinLength(1)
+  description: string;
+
+  @ApiProperty({ required: false, example: "2024-01-01" })
+  @IsOptional()
+  @IsDateString()
+  lostDate?: string;
+
+  @ApiProperty({ required: false, type: CreatePetDetailDto })
+  @IsOptional()
+  @Transform(parseJsonField)
+  @ValidateNested()
+  @Type(() => CreatePetDetailDto)
+  petDetail?: CreatePetDetailDto;
+
+  @ApiProperty({ required: false, type: CreateLocationDto })
+  @IsOptional()
+  @Transform(parseJsonField)
+  @ValidateNested()
+  @Type(() => CreateLocationDto)
+  location?: CreateLocationDto;
 }

--- a/apps/api/src/posts/dto/post-response.dto.ts
+++ b/apps/api/src/posts/dto/post-response.dto.ts
@@ -1,23 +1,70 @@
 import { ApiProperty } from "@nestjs/swagger";
 
+export class ImageResponseDto {
+  @ApiProperty() id: string;
+  @ApiProperty() url: string;
+  @ApiProperty() createdAt: Date;
+}
+
+export class PetDetailResponseDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() color: string;
+  @ApiProperty() age: string;
+  @ApiProperty() features: string;
+  @ApiProperty({ required: false, nullable: true }) gender: string | null;
+  @ApiProperty({ required: false, nullable: true }) breed: string | null;
+  @ApiProperty({ required: false, nullable: true }) size: string | null;
+  @ApiProperty({ required: false, nullable: true }) collar: string | null;
+  @ApiProperty({ required: false, nullable: true }) microchip: boolean | null;
+  @ApiProperty({ required: false, nullable: true }) neutered: boolean | null;
+}
+
+export class LocationResponseDto {
+  @ApiProperty() id: string;
+  @ApiProperty() prefecture: string;
+  @ApiProperty() city: string;
+  @ApiProperty() address: string;
+  @ApiProperty() lat: number;
+  @ApiProperty() lng: number;
+}
+
 export class PostResponseDto {
   @ApiProperty()
   id: string;
 
-  @ApiProperty()
-  title: string;
+  @ApiProperty({ required: false, nullable: true })
+  title: string | null;
 
   @ApiProperty()
-  content: string;
+  description: string;
+
+  @ApiProperty()
+  userId: string;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty()
+  lostDate: Date;
 
   @ApiProperty({ required: false, nullable: true })
-  image: string | null;
+  resolvedAt: Date | null;
 
-  @ApiProperty()
-  authorId: string;
+  @ApiProperty({ required: false, nullable: true, type: PetDetailResponseDto })
+  petDetail: PetDetailResponseDto | null;
+
+  @ApiProperty({ required: false, nullable: true, type: LocationResponseDto })
+  location: LocationResponseDto | null;
+
+  @ApiProperty({ type: [ImageResponseDto] })
+  images: ImageResponseDto[];
 
   @ApiProperty()
   createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
 }
 
 export class PostListResponseDto {
@@ -26,4 +73,12 @@ export class PostListResponseDto {
 
   @ApiProperty()
   total: number;
+}
+
+export class AddImagesResponseDto {
+  @ApiProperty()
+  remainingSlots: number;
+
+  @ApiProperty({ type: [ImageResponseDto] })
+  images: ImageResponseDto[];
 }

--- a/apps/api/src/posts/dto/update-post.dto.ts
+++ b/apps/api/src/posts/dto/update-post.dto.ts
@@ -11,17 +11,7 @@ import {
   IsBoolean,
   IsEnum,
 } from "class-validator";
-
-const parseJsonField = ({ value }: { value: unknown }) => {
-  if (typeof value === "string") {
-    try {
-      return JSON.parse(value);
-    } catch {
-      return value;
-    }
-  }
-  return value;
-};
+import { parseJsonField } from "../../utils/transform";
 
 export class UpdatePetDetailDto {
   @ApiProperty({ required: false }) @IsOptional() @IsString() name?: string;

--- a/apps/api/src/posts/dto/update-post.dto.ts
+++ b/apps/api/src/posts/dto/update-post.dto.ts
@@ -1,5 +1,60 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString, MinLength, MaxLength, IsOptional } from "class-validator";
+import { Type, Transform } from "class-transformer";
+import {
+  IsString,
+  MinLength,
+  MaxLength,
+  IsOptional,
+  IsDateString,
+  ValidateNested,
+  IsNumber,
+  IsBoolean,
+  IsEnum,
+} from "class-validator";
+
+const parseJsonField = ({ value }: { value: unknown }) => {
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+};
+
+export class UpdatePetDetailDto {
+  @ApiProperty({ required: false }) @IsOptional() @IsString() name?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() color?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() age?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() features?: string;
+  @ApiProperty({ required: false, enum: ["male", "female", "unknown"] })
+  @IsOptional()
+  @IsEnum(["male", "female", "unknown"])
+  gender?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() breed?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() size?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() collar?: string;
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  microchip?: boolean;
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  neutered?: boolean;
+}
+
+export class UpdateLocationDto {
+  @ApiProperty({ required: false, enum: ["saitama"] })
+  @IsOptional()
+  @IsEnum(["saitama"])
+  prefecture?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() city?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() address?: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsNumber() lat?: number;
+  @ApiProperty({ required: false }) @IsOptional() @IsNumber() lng?: number;
+}
 
 export class UpdatePostDto {
   @ApiProperty({ required: false })
@@ -13,5 +68,29 @@ export class UpdatePostDto {
   @IsOptional()
   @IsString()
   @MinLength(1)
-  content?: string;
+  description?: string;
+
+  @ApiProperty({ required: false, example: "2024-01-01" })
+  @IsOptional()
+  @IsDateString()
+  lostDate?: string;
+
+  @ApiProperty({ required: false, enum: ["lost", "resolved"] })
+  @IsOptional()
+  @IsEnum(["lost", "resolved"])
+  status?: string;
+
+  @ApiProperty({ required: false, type: UpdatePetDetailDto })
+  @IsOptional()
+  @Transform(parseJsonField)
+  @ValidateNested()
+  @Type(() => UpdatePetDetailDto)
+  petDetail?: UpdatePetDetailDto;
+
+  @ApiProperty({ required: false, type: UpdateLocationDto })
+  @IsOptional()
+  @Transform(parseJsonField)
+  @ValidateNested()
+  @Type(() => UpdateLocationDto)
+  location?: UpdateLocationDto;
 }

--- a/apps/api/src/posts/post.controller.spec.ts
+++ b/apps/api/src/posts/post.controller.spec.ts
@@ -1,14 +1,24 @@
-import { BadRequestException, ForbiddenException, HttpException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  NotFoundException,
+} from "@nestjs/common";
 import { PostsController, imageFileFilter } from "./post.controller";
 import { PostsService } from "./post.service";
 
 const makePost = (overrides = {}) => ({
   id: "post1",
   title: "Title",
-  content: "Content",
-  authorId: "user1",
-  image: null,
+  description: "Content",
+  userId: "user1",
+  status: "lost",
+  lostDate: new Date("2024-01-01"),
   createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+  petDetail: null,
+  location: null,
+  images: [],
   ...overrides,
 });
 
@@ -18,13 +28,17 @@ const mockPostsService = {
   findById: jest.fn(),
   update: jest.fn(),
   remove: jest.fn(),
+  addImages: jest.fn(),
+  removeImage: jest.fn(),
 };
 
 describe("PostsController", () => {
   let controller: PostsController;
 
   beforeEach(() => {
-    controller = new PostsController(mockPostsService as unknown as PostsService);
+    controller = new PostsController(
+      mockPostsService as unknown as PostsService
+    );
     jest.clearAllMocks();
   });
 
@@ -79,41 +93,96 @@ describe("PostsController", () => {
 
   // ─── create ──────────────────────────────────────────────────
   describe("create", () => {
-    it("req.user.id を authorId として投稿を作成する", async () => {
+    it("dto と files をサービスに渡す", async () => {
       const post = makePost();
       mockPostsService.create.mockResolvedValue(post);
       const req = { user: { id: "user1" } };
-      const dto = { title: "Title", content: "Content" };
+      const dto = { title: "Title", description: "Content" };
 
-      const result = await controller.create(req, dto as any, undefined as any);
+      const result = await controller.create(req, dto as any, []);
 
-      expect(mockPostsService.create).toHaveBeenCalledWith("user1", "Title", "Content", undefined);
+      expect(mockPostsService.create).toHaveBeenCalledWith("user1", dto, []);
       expect(result).toEqual(post);
     });
 
     it("ファイル付きで作成できる", async () => {
-      const post = makePost({ image: "uploads/uuid.png" });
+      const post = makePost();
       mockPostsService.create.mockResolvedValue(post);
       const req = { user: { id: "user1" } };
-      const dto = { title: "Title", content: "Content" };
-      const file = { originalname: "img.png", mimetype: "image/png", buffer: Buffer.from("") } as any;
+      const dto = { title: "Title", description: "Content" };
+      const files = [
+        {
+          originalname: "img.png",
+          mimetype: "image/png",
+          buffer: Buffer.from(""),
+        } as any,
+      ];
 
-      await controller.create(req, dto as any, file);
+      await controller.create(req, dto as any, files);
 
-      expect(mockPostsService.create).toHaveBeenCalledWith("user1", "Title", "Content", file);
+      expect(mockPostsService.create).toHaveBeenCalledWith("user1", dto, files);
+    });
+
+    it("files が undefined の時は空配列を渡す", async () => {
+      const post = makePost();
+      mockPostsService.create.mockResolvedValue(post);
+      const req = { user: { id: "user1" } };
+
+      await controller.create(
+        req,
+        { description: "C" } as any,
+        undefined as any
+      );
+
+      expect(mockPostsService.create).toHaveBeenCalledWith(
+        "user1",
+        { description: "C" },
+        []
+      );
+    });
+
+    it("petDetail と location を含む dto をサービスに渡す", async () => {
+      const post = makePost();
+      mockPostsService.create.mockResolvedValue(post);
+      const req = { user: { id: "user1" } };
+      const dto = {
+        title: "Title",
+        description: "Content",
+        petDetail: {
+          name: "Mimi",
+          color: "white",
+          age: "2歳",
+          features: "人懐こい",
+        },
+        location: {
+          prefecture: "saitama",
+          city: "さいたま市",
+          address: "南区",
+          lat: 35.0,
+          lng: 139.0,
+        },
+      };
+
+      await controller.create(req, dto as any, []);
+
+      expect(mockPostsService.create).toHaveBeenCalledWith("user1", dto, []);
     });
   });
 
-  // ─── update ──────────────────────────────────────────────────
+  // ─── update (PATCH) ──────────────────────────────────────────
   describe("update", () => {
     it("オーナーが更新できる", async () => {
       const updated = makePost({ title: "New" });
       mockPostsService.update.mockResolvedValue(updated);
       const req = { user: { id: "user1" } };
 
-      const result = await controller.update(req, "post1", { title: "New" } as any, undefined as any);
+      const result = await controller.update(req, "post1", {
+        title: "New",
+      } as any);
 
-      expect(mockPostsService.update).toHaveBeenCalledWith("post1", "user1", { title: "New" }, undefined);
+      expect(mockPostsService.update).toHaveBeenCalledWith("post1", "user1", {
+        title: "New",
+      });
       expect(result).toEqual(updated);
     });
 
@@ -122,17 +191,142 @@ describe("PostsController", () => {
       const req = { user: { id: "other" } };
 
       await expect(
-        controller.update(req, "post1", { title: "X" } as any, undefined as any),
+        controller.update(req, "post1", { title: "X" } as any)
       ).rejects.toThrow(ForbiddenException);
     });
 
     it("存在しない投稿は HttpException を伝播する", async () => {
-      mockPostsService.update.mockRejectedValue(new HttpException("Not found", 404));
+      mockPostsService.update.mockRejectedValue(
+        new HttpException("Not found", 404)
+      );
       const req = { user: { id: "user1" } };
 
       await expect(
-        controller.update(req, "no-such", {} as any, undefined as any),
+        controller.update(req, "no-such", {} as any)
       ).rejects.toThrow(HttpException);
+    });
+
+    it("petDetail と location を含む dto をサービスに渡す", async () => {
+      const updated = makePost();
+      mockPostsService.update.mockResolvedValue(updated);
+      const req = { user: { id: "user1" } };
+      const dto = {
+        petDetail: {
+          name: "New",
+          color: "black",
+          age: "1歳",
+          features: "元気",
+        },
+        location: { city: "川口市" },
+      };
+
+      const result = await controller.update(req, "post1", dto as any);
+
+      expect(mockPostsService.update).toHaveBeenCalledWith(
+        "post1",
+        "user1",
+        dto
+      );
+      expect(result).toEqual(updated);
+    });
+  });
+
+  // ─── addImages ───────────────────────────────────────────────
+  describe("addImages", () => {
+    it("画像を追加できる", async () => {
+      const response = {
+        remainingSlots: 4,
+        images: [
+          { id: "img1", url: "uploads/post1/a.png", createdAt: new Date() },
+        ],
+      };
+      mockPostsService.addImages.mockResolvedValue(response);
+      const req = { user: { id: "user1" } };
+      const files = [{ originalname: "a.png", buffer: Buffer.from("") } as any];
+
+      const result = await controller.addImages(req, "post1", files);
+
+      expect(mockPostsService.addImages).toHaveBeenCalledWith(
+        "post1",
+        "user1",
+        files
+      );
+      expect(result).toEqual(response);
+    });
+
+    it("files が undefined の時は空配列を渡す", async () => {
+      mockPostsService.addImages.mockResolvedValue({
+        remainingSlots: 5,
+        images: [],
+      });
+      const req = { user: { id: "user1" } };
+
+      await controller.addImages(req, "post1", undefined as any);
+
+      expect(mockPostsService.addImages).toHaveBeenCalledWith(
+        "post1",
+        "user1",
+        []
+      );
+    });
+
+    it("オーナー以外は ForbiddenException を伝播する", async () => {
+      mockPostsService.addImages.mockRejectedValue(new ForbiddenException());
+      const req = { user: { id: "other" } };
+
+      await expect(controller.addImages(req, "post1", [])).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("枚数超過は BadRequestException を伝播する", async () => {
+      mockPostsService.addImages.mockRejectedValue(new BadRequestException());
+      const req = { user: { id: "user1" } };
+
+      await expect(controller.addImages(req, "post1", [])).rejects.toThrow(
+        BadRequestException
+      );
+    });
+  });
+
+  // ─── removeImage ─────────────────────────────────────────────
+  describe("removeImage", () => {
+    it("オーナーが画像を削除できる", async () => {
+      const image = {
+        id: "img1",
+        url: "uploads/post1/a.png",
+        postId: "post1",
+        createdAt: new Date(),
+      };
+      mockPostsService.removeImage.mockResolvedValue(image);
+      const req = { user: { id: "user1" } };
+
+      const result = await controller.removeImage(req, "post1", "img1");
+
+      expect(mockPostsService.removeImage).toHaveBeenCalledWith(
+        "post1",
+        "img1",
+        "user1"
+      );
+      expect(result).toEqual(image);
+    });
+
+    it("オーナー以外は ForbiddenException を伝播する", async () => {
+      mockPostsService.removeImage.mockRejectedValue(new ForbiddenException());
+      const req = { user: { id: "other" } };
+
+      await expect(
+        controller.removeImage(req, "post1", "img1")
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しない画像は NotFoundException を伝播する", async () => {
+      mockPostsService.removeImage.mockRejectedValue(new NotFoundException());
+      const req = { user: { id: "user1" } };
+
+      await expect(
+        controller.removeImage(req, "post1", "no-img")
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -152,13 +346,21 @@ describe("PostsController", () => {
 
     it("許可されたMIMEタイプの時、cb(null, true)を呼ぶこと", () => {
       const cb = jest.fn();
-      imageFileFilter({}, { originalname: "photo.png", mimetype: "image/png" } as any, cb);
+      imageFileFilter(
+        {},
+        { originalname: "photo.png", mimetype: "image/png" } as any,
+        cb
+      );
       expect(cb).toHaveBeenCalledWith(null, true);
     });
 
     it("許可されていないMIMEタイプの時、BadRequestExceptionを渡すこと", () => {
       const cb = jest.fn();
-      imageFileFilter({}, { originalname: "doc.pdf", mimetype: "application/pdf" } as any, cb);
+      imageFileFilter(
+        {},
+        { originalname: "doc.pdf", mimetype: "application/pdf" } as any,
+        cb
+      );
       expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
     });
   });
@@ -180,14 +382,20 @@ describe("PostsController", () => {
       mockPostsService.remove.mockRejectedValue(new ForbiddenException());
       const req = { user: { id: "other" } };
 
-      await expect(controller.remove(req, "post1")).rejects.toThrow(ForbiddenException);
+      await expect(controller.remove(req, "post1")).rejects.toThrow(
+        ForbiddenException
+      );
     });
 
     it("存在しない投稿は HttpException を伝播する", async () => {
-      mockPostsService.remove.mockRejectedValue(new HttpException("Not found", 404));
+      mockPostsService.remove.mockRejectedValue(
+        new HttpException("Not found", 404)
+      );
       const req = { user: { id: "user1" } };
 
-      await expect(controller.remove(req, "no-such")).rejects.toThrow(HttpException);
+      await expect(controller.remove(req, "no-such")).rejects.toThrow(
+        HttpException
+      );
     });
   });
 });

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -5,15 +5,15 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post as HttpPost,
-  Put,
   Query,
   Req,
   UseGuards,
   UseInterceptors,
-  UploadedFile,
+  UploadedFiles,
 } from "@nestjs/common";
-import { FileInterceptor } from "@nestjs/platform-express";
+import { FilesInterceptor } from "@nestjs/platform-express";
 import { memoryStorage } from "multer";
 import {
   ApiTags,
@@ -22,7 +22,12 @@ import {
   ApiBody,
   ApiResponse,
 } from "@nestjs/swagger";
-import { PostResponseDto, PostListResponseDto } from "./dto/post-response.dto";
+import {
+  PostResponseDto,
+  PostListResponseDto,
+  AddImagesResponseDto,
+  ImageResponseDto,
+} from "./dto/post-response.dto";
 import { CreatePostDto } from "./dto/create-post.dto";
 import { UpdatePostDto } from "./dto/update-post.dto";
 import { PostsService } from "./post.service";
@@ -43,7 +48,10 @@ export function imageFileFilter(_req: any, file: Express.Multer.File, cb: any) {
   if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
     cb(null, true);
   } else {
-    cb(new BadRequestException(`Unsupported file type: ${file.mimetype}`), false);
+    cb(
+      new BadRequestException(`Unsupported file type: ${file.mimetype}`),
+      false
+    );
   }
 }
 
@@ -61,7 +69,7 @@ export class PostsController {
 
   @HttpPost()
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FileInterceptor("image", imageUploadOptions))
+  @UseInterceptors(FilesInterceptor("images", 5, imageUploadOptions))
   @ApiConsumes("multipart/form-data")
   @ApiResponse({ status: 201, type: PostResponseDto })
   @ApiBody({
@@ -69,18 +77,20 @@ export class PostsController {
       type: "object",
       properties: {
         title: { type: "string" },
-        content: { type: "string" },
-        image: { type: "string", format: "binary" },
+        description: { type: "string" },
+        lostDate: { type: "string" },
+        petDetail: { type: "string", description: "JSON string" },
+        location: { type: "string", description: "JSON string" },
+        images: { type: "array", items: { type: "string", format: "binary" } },
       },
     },
   })
   async create(
     @Req() req: any,
     @Body() dto: CreatePostDto,
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFiles() files: Express.Multer.File[]
   ) {
-    const authorId = req.user.id;
-    return this.posts.create(authorId, dto.title, dto.content, file);
+    return this.posts.create(req.user.id, dto, files ?? []);
   }
 
   @Get()
@@ -97,29 +107,16 @@ export class PostsController {
     return this.posts.findById(id);
   }
 
-  @Put(":id")
+  @Patch(":id")
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FileInterceptor("image", imageUploadOptions))
-  @ApiConsumes("multipart/form-data")
   @ApiResponse({ status: 200, type: PostResponseDto })
   @ApiResponse({ status: 403, description: "Forbidden: not the post owner" })
-  @ApiBody({
-    schema: {
-      type: "object",
-      properties: {
-        title: { type: "string" },
-        content: { type: "string" },
-        image: { type: "string", format: "binary" },
-      },
-    },
-  })
   async update(
     @Req() req: any,
     @Param("id") id: string,
-    @Body() body: UpdatePostDto,
-    @UploadedFile() file: Express.Multer.File,
+    @Body() body: UpdatePostDto
   ) {
-    return this.posts.update(id, req.user.id, body, file);
+    return this.posts.update(id, req.user.id, body);
   }
 
   @Delete(":id")
@@ -128,5 +125,41 @@ export class PostsController {
   @ApiResponse({ status: 403, description: "Forbidden: not the post owner" })
   async remove(@Req() req: any, @Param("id") id: string) {
     return this.posts.remove(id, req.user.id);
+  }
+
+  @HttpPost(":id/images")
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(FilesInterceptor("images", 5, imageUploadOptions))
+  @ApiConsumes("multipart/form-data")
+  @ApiResponse({ status: 201, type: AddImagesResponseDto })
+  @ApiResponse({ status: 400, description: "画像枚数上限超過" })
+  @ApiResponse({ status: 403, description: "Forbidden: not the post owner" })
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        images: { type: "array", items: { type: "string", format: "binary" } },
+      },
+    },
+  })
+  async addImages(
+    @Req() req: any,
+    @Param("id") id: string,
+    @UploadedFiles() files: Express.Multer.File[]
+  ) {
+    return this.posts.addImages(id, req.user.id, files ?? []);
+  }
+
+  @Delete(":id/images/:imageId")
+  @UseGuards(JwtAuthGuard)
+  @ApiResponse({ status: 200, type: ImageResponseDto })
+  @ApiResponse({ status: 403, description: "Forbidden: not the post owner" })
+  @ApiResponse({ status: 404, description: "Image not found" })
+  async removeImage(
+    @Req() req: any,
+    @Param("id") id: string,
+    @Param("imageId") imageId: string
+  ) {
+    return this.posts.removeImage(id, imageId, req.user.id);
   }
 }

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -121,6 +121,14 @@ describe("PostsService", () => {
       });
       expect(result).toEqual(post);
     });
+
+    it("存在しない投稿は NotFoundException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(null);
+
+      await expect(service.findById("no-such")).rejects.toThrow(
+        NotFoundException
+      );
+    });
   });
 
   // ─── create ─────────────────────────────────────────────────
@@ -290,6 +298,28 @@ describe("PostsService", () => {
         data: expect.objectContaining({ lostDate: new Date("2024-06-15") }),
       });
     });
+
+    it("トランザクション失敗時に保存済みファイルを削除する", async () => {
+      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
+      // 1枚目は保存成功、2枚目でエラー
+      mockFs.writeFileSync
+        .mockReturnValueOnce(undefined)
+        .mockImplementationOnce(() => {
+          throw new Error("disk full");
+        });
+      mockPrisma.image.create.mockResolvedValue({});
+
+      const files = [
+        { originalname: "a.png", buffer: Buffer.from("") } as any,
+        { originalname: "b.png", buffer: Buffer.from("") } as any,
+      ];
+
+      await expect(
+        service.create("u1", { title: "T", description: "C" }, files)
+      ).rejects.toThrow("disk full");
+      // 1枚目の保存済みファイルがクリーンアップされること
+      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ─── addImages ──────────────────────────────────────────────
@@ -353,6 +383,18 @@ describe("PostsService", () => {
       await expect(service.addImages("post1", "user1", files)).rejects.toThrow(
         BadRequestException
       );
+    });
+
+    it("DB作成失敗時に保存済みファイルを削除する", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.image.create.mockRejectedValue(new Error("DB error"));
+
+      const files = [{ originalname: "a.png", buffer: Buffer.from("") } as any];
+
+      await expect(service.addImages("post1", "user1", files)).rejects.toThrow(
+        "DB error"
+      );
+      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -436,10 +478,18 @@ describe("PostsService", () => {
       updatedAt: new Date(),
     };
 
-    it("オーナーが更新できる", async () => {
-      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
-      const updated = { ...existingPost, title: "New" };
-      mockPrisma.post.update.mockResolvedValue(updated);
+    it("オーナーが更新でき、petDetail/location/images を含むレスポンスを返す", async () => {
+      const updatedWithIncludes = {
+        ...existingPost,
+        title: "New",
+        petDetail: null,
+        location: null,
+        images: [],
+      };
+      mockPrisma.post.findUnique
+        .mockResolvedValueOnce(existingPost) // オーナー確認
+        .mockResolvedValueOnce(updatedWithIncludes); // トランザクション内の再取得
+      mockPrisma.post.update.mockResolvedValue({});
 
       const result = await service.update("post1", "user1", { title: "New" });
 
@@ -447,7 +497,10 @@ describe("PostsService", () => {
         where: { id: "post1" },
         data: { title: "New" },
       });
-      expect(result.title).toBe("New");
+      expect(result?.title).toBe("New");
+      expect(result).toHaveProperty("petDetail");
+      expect(result).toHaveProperty("location");
+      expect(result).toHaveProperty("images");
     });
 
     it("オーナー以外は ForbiddenException", async () => {
@@ -467,11 +520,16 @@ describe("PostsService", () => {
     });
 
     it("lostDate を更新できる", async () => {
-      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
-      mockPrisma.post.update.mockResolvedValue({
-        ...existingPost,
-        lostDate: new Date("2024-06-15"),
-      });
+      mockPrisma.post.findUnique
+        .mockResolvedValueOnce(existingPost)
+        .mockResolvedValueOnce({
+          ...existingPost,
+          lostDate: new Date("2024-06-15"),
+          petDetail: null,
+          location: null,
+          images: [],
+        });
+      mockPrisma.post.update.mockResolvedValue({});
 
       await service.update("post1", "user1", { lostDate: "2024-06-15" });
 
@@ -483,11 +541,16 @@ describe("PostsService", () => {
     });
 
     it("status を更新できる", async () => {
-      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
-      mockPrisma.post.update.mockResolvedValue({
-        ...existingPost,
-        status: "resolved",
-      });
+      mockPrisma.post.findUnique
+        .mockResolvedValueOnce(existingPost)
+        .mockResolvedValueOnce({
+          ...existingPost,
+          status: "resolved",
+          petDetail: null,
+          location: null,
+          images: [],
+        });
+      mockPrisma.post.update.mockResolvedValue({});
 
       await service.update("post1", "user1", { status: "resolved" });
 
@@ -499,8 +562,15 @@ describe("PostsService", () => {
     });
 
     it("petDetail を upsert できる", async () => {
-      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
-      mockPrisma.post.update.mockResolvedValue(existingPost);
+      mockPrisma.post.findUnique
+        .mockResolvedValueOnce(existingPost)
+        .mockResolvedValueOnce({
+          ...existingPost,
+          petDetail: { name: "Mimi" },
+          location: null,
+          images: [],
+        });
+      mockPrisma.post.update.mockResolvedValue({});
       mockPrisma.petDetail.upsert.mockResolvedValue({});
 
       const petDetail = {
@@ -520,8 +590,15 @@ describe("PostsService", () => {
     });
 
     it("location を upsert できる", async () => {
-      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
-      mockPrisma.post.update.mockResolvedValue(existingPost);
+      mockPrisma.post.findUnique
+        .mockResolvedValueOnce(existingPost)
+        .mockResolvedValueOnce({
+          ...existingPost,
+          petDetail: null,
+          location: { city: "さいたま市" },
+          images: [],
+        });
+      mockPrisma.post.update.mockResolvedValue({});
       mockPrisma.location.upsert.mockResolvedValue({});
 
       const location = {

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -156,6 +156,7 @@ describe("PostsService", () => {
       const result = await service.create("u1", {
         title: "T",
         description: "C",
+        lostDate: "2024-01-01",
       });
 
       expect(mockPrisma.post.create).toHaveBeenCalledWith({
@@ -191,7 +192,11 @@ describe("PostsService", () => {
         { originalname: "photo.png", buffer: Buffer.from("") } as any,
       ];
 
-      await service.create("u1", { title: "T", description: "C" }, files);
+      await service.create(
+        "u1",
+        { title: "T", description: "C", lostDate: "2024-01-01" },
+        files
+      );
 
       expect(mockFs.writeFileSync).toHaveBeenCalled();
       expect(mockPrisma.image.create).toHaveBeenCalledWith({
@@ -213,9 +218,19 @@ describe("PostsService", () => {
         { originalname: "photo.png", buffer: Buffer.from("") } as any,
       ];
 
-      await service.create("u1", { title: "T", description: "C" }, files);
+      await service.create(
+        "u1",
+        { title: "T", description: "C", lostDate: "2024-01-01" },
+        files
+      );
 
       expect(mockFs.mkdirSync).toHaveBeenCalled();
+    });
+
+    it("lostDate なしは BadRequestException をスローする", async () => {
+      await expect(
+        service.create("u1", { description: "C" } as any)
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("画像が5枚超の場合 BadRequestException をスローする", async () => {
@@ -225,7 +240,11 @@ describe("PostsService", () => {
       );
 
       await expect(
-        service.create("u1", { description: "C" }, files)
+        service.create(
+          "u1",
+          { description: "C", lostDate: "2024-01-01" },
+          files
+        )
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -267,6 +286,7 @@ describe("PostsService", () => {
       await service.create("u1", {
         title: "T",
         description: "C",
+        lostDate: "2024-01-01",
         petDetail,
         location,
       });
@@ -315,7 +335,11 @@ describe("PostsService", () => {
       ];
 
       await expect(
-        service.create("u1", { title: "T", description: "C" }, files)
+        service.create(
+          "u1",
+          { title: "T", description: "C", lostDate: "2024-01-01" },
+          files
+        )
       ).rejects.toThrow("disk full");
       // 1枚目の保存済みファイルがクリーンアップされること
       expect(mockFs.unlinkSync).toHaveBeenCalledTimes(1);
@@ -476,6 +500,8 @@ describe("PostsService", () => {
       lostDate: new Date(),
       createdAt: new Date(),
       updatedAt: new Date(),
+      petDetail: null,
+      location: null,
     };
 
     it("オーナーが更新でき、petDetail/location/images を含むレスポンスを返す", async () => {
@@ -587,6 +613,22 @@ describe("PostsService", () => {
           create: expect.objectContaining({ postId: "post1", name: "Mimi" }),
         })
       );
+    });
+
+    it("petDetail 未存在かつ必須フィールドなしは BadRequestException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+
+      await expect(
+        service.update("post1", "user1", { petDetail: { name: "Mimi" } })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("location 未存在かつ必須フィールドなしは BadRequestException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+
+      await expect(
+        service.update("post1", "user1", { location: { city: "さいたま市" } })
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("location を upsert できる", async () => {

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -1,11 +1,15 @@
-import { ForbiddenException, HttpException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  NotFoundException,
+} from "@nestjs/common";
 import * as fs from "fs";
 import { PostsService } from "./post.service";
 
 jest.mock("fs");
 const mockFs = fs as jest.Mocked<typeof fs>;
 
-// PrismaService のモック
 const mockPrisma = {
   post: {
     create: jest.fn(),
@@ -15,6 +19,20 @@ const mockPrisma = {
     update: jest.fn(),
     delete: jest.fn(),
   },
+  petDetail: {
+    create: jest.fn(),
+    upsert: jest.fn(),
+  },
+  location: {
+    create: jest.fn(),
+    upsert: jest.fn(),
+  },
+  image: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    delete: jest.fn(),
+  },
+  $transaction: jest.fn(),
 };
 
 describe("PostsService", () => {
@@ -27,6 +45,9 @@ describe("PostsService", () => {
     mockFs.writeFileSync.mockReturnValue(undefined);
     mockFs.mkdirSync.mockReturnValue(undefined as any);
     mockFs.unlinkSync.mockReturnValue(undefined);
+    mockPrisma.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma)
+    );
   });
 
   // ─── findAll ────────────────────────────────────────────────
@@ -41,6 +62,7 @@ describe("PostsService", () => {
         skip: 0,
         take: 5,
         orderBy: { createdAt: "desc" },
+        include: { petDetail: true, location: true, images: true },
       });
     });
 
@@ -51,12 +73,26 @@ describe("PostsService", () => {
       await service.findAll(3, 5);
 
       expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ skip: 10, take: 5 }),
+        expect.objectContaining({ skip: 10, take: 5 })
       );
     });
 
     it("items と total を返す", async () => {
-      const posts = [{ id: "1", title: "T", content: "C", authorId: "u1", image: null, createdAt: new Date() }];
+      const posts = [
+        {
+          id: "1",
+          title: "T",
+          description: "C",
+          userId: "u1",
+          status: "lost",
+          lostDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          petDetail: null,
+          location: null,
+          images: [],
+        },
+      ];
       mockPrisma.post.findMany.mockResolvedValue(posts);
       mockPrisma.post.count.mockResolvedValue(1);
 
@@ -66,40 +102,324 @@ describe("PostsService", () => {
     });
   });
 
+  // ─── findById ───────────────────────────────────────────────
+  describe("findById", () => {
+    it("petDetail と location と images を include して取得する", async () => {
+      const post = {
+        id: "post1",
+        petDetail: { name: "Mimi" },
+        location: { city: "さいたま市" },
+        images: [],
+      };
+      mockPrisma.post.findUnique.mockResolvedValue(post);
+
+      const result = await service.findById("post1");
+
+      expect(mockPrisma.post.findUnique).toHaveBeenCalledWith({
+        where: { id: "post1" },
+        include: { petDetail: true, location: true, images: true },
+      });
+      expect(result).toEqual(post);
+    });
+  });
+
   // ─── create ─────────────────────────────────────────────────
   describe("create", () => {
     it("ファイルなしで投稿を作成する", async () => {
-      const created = { id: "1", title: "T", content: "C", authorId: "u1", image: null, createdAt: new Date() };
+      const created = {
+        id: "post1",
+        title: "T",
+        description: "C",
+        userId: "u1",
+        status: "lost",
+        lostDate: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const withIncludes = {
+        ...created,
+        petDetail: null,
+        location: null,
+        images: [],
+      };
       mockPrisma.post.create.mockResolvedValue(created);
+      mockPrisma.post.findUnique.mockResolvedValue(withIncludes);
 
-      const result = await service.create("u1", "T", "C");
+      const result = await service.create("u1", {
+        title: "T",
+        description: "C",
+      });
 
       expect(mockPrisma.post.create).toHaveBeenCalledWith({
-        data: { title: "T", content: "C", authorId: "u1", image: undefined },
+        data: expect.objectContaining({
+          title: "T",
+          description: "C",
+          userId: "u1",
+        }),
       });
-      expect(result).toEqual(created);
+      expect(result).toEqual(withIncludes);
     });
 
-    it("ファイルありで投稿を作成する時、imagePathが設定されること", async () => {
-      const created = { id: "1", title: "T", content: "C", authorId: "u1", image: "uploads/uuid.png", createdAt: new Date() };
+    it("ファイルありで投稿を作成する時、writeFileSyncが呼ばれること", async () => {
+      const created = {
+        id: "post1",
+        title: "T",
+        description: "C",
+        userId: "u1",
+        status: "lost",
+        lostDate: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
       mockPrisma.post.create.mockResolvedValue(created);
-      const file = { originalname: "photo.png", buffer: Buffer.from("") } as any;
+      mockPrisma.post.findUnique.mockResolvedValue({
+        ...created,
+        petDetail: null,
+        location: null,
+        images: [],
+      });
+      mockPrisma.image.create.mockResolvedValue({});
+      const files = [
+        { originalname: "photo.png", buffer: Buffer.from("") } as any,
+      ];
 
-      await service.create("u1", "T", "C", file);
+      await service.create("u1", { title: "T", description: "C" }, files);
 
-      expect(mockPrisma.post.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({ image: expect.stringMatching(/^uploads\//) }),
+      expect(mockFs.writeFileSync).toHaveBeenCalled();
+      expect(mockPrisma.image.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ postId: "post1" }),
       });
     });
 
     it("アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと", async () => {
       mockFs.existsSync.mockReturnValue(false);
-      mockPrisma.post.create.mockResolvedValue({} as any);
-      const file = { originalname: "photo.png", buffer: Buffer.from("") } as any;
+      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post1",
+        petDetail: null,
+        location: null,
+        images: [],
+      });
+      mockPrisma.image.create.mockResolvedValue({});
+      const files = [
+        { originalname: "photo.png", buffer: Buffer.from("") } as any,
+      ];
 
-      await service.create("u1", "T", "C", file);
+      await service.create("u1", { title: "T", description: "C" }, files);
 
       expect(mockFs.mkdirSync).toHaveBeenCalled();
+    });
+
+    it("画像が5枚超の場合 BadRequestException をスローする", async () => {
+      const files = Array.from(
+        { length: 6 },
+        () => ({ originalname: "p.png", buffer: Buffer.from("") }) as any
+      );
+
+      await expect(
+        service.create("u1", { description: "C" }, files)
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("petDetail と location を含む時、トランザクションで一括作成する", async () => {
+      const created = {
+        id: "post1",
+        title: "T",
+        description: "C",
+        userId: "u1",
+        status: "lost",
+        lostDate: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrisma.post.create.mockResolvedValue(created);
+      mockPrisma.post.findUnique.mockResolvedValue({
+        ...created,
+        petDetail: {},
+        location: {},
+        images: [],
+      });
+      mockPrisma.petDetail.create.mockResolvedValue({});
+      mockPrisma.location.create.mockResolvedValue({});
+
+      const petDetail = {
+        name: "Mimi",
+        color: "white",
+        age: "2歳",
+        features: "人懐こい",
+      };
+      const location = {
+        prefecture: "saitama",
+        city: "さいたま市",
+        address: "南区",
+        lat: 35.0,
+        lng: 139.0,
+      };
+
+      await service.create("u1", {
+        title: "T",
+        description: "C",
+        petDetail,
+        location,
+      });
+
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+      expect(mockPrisma.petDetail.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ postId: "post1", name: "Mimi" }),
+      });
+      expect(mockPrisma.location.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          postId: "post1",
+          prefecture: "saitama",
+        }),
+      });
+    });
+
+    it("lostDate を指定して作成できる", async () => {
+      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post1",
+        petDetail: null,
+        location: null,
+        images: [],
+      });
+
+      await service.create("u1", { description: "C", lostDate: "2024-06-15" });
+
+      expect(mockPrisma.post.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ lostDate: new Date("2024-06-15") }),
+      });
+    });
+  });
+
+  // ─── addImages ──────────────────────────────────────────────
+  describe("addImages", () => {
+    const existingPost = {
+      id: "post1",
+      userId: "user1",
+      images: [],
+    };
+
+    it("画像を追加できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      const newImage = {
+        id: "img1",
+        postId: "post1",
+        url: "uploads/post1/abc.png",
+        createdAt: new Date(),
+      };
+      mockPrisma.image.create.mockResolvedValue(newImage);
+      const files = [
+        { originalname: "photo.png", buffer: Buffer.from("") } as any,
+      ];
+
+      const result = await service.addImages("post1", "user1", files);
+
+      expect(mockFs.writeFileSync).toHaveBeenCalled();
+      expect(mockPrisma.image.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ postId: "post1" }),
+      });
+      expect(result.remainingSlots).toBe(4);
+      expect(result.images).toHaveLength(1);
+    });
+
+    it("オーナー以外は ForbiddenException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+
+      await expect(
+        service.addImages("post1", "other-user", [])
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しない投稿は NotFoundException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(null);
+
+      await expect(service.addImages("no-such", "user1", [])).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("5枚超になる場合は BadRequestException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        ...existingPost,
+        images: [1, 2, 3],
+      });
+      const files = [
+        { originalname: "a.png", buffer: Buffer.from("") } as any,
+        { originalname: "b.png", buffer: Buffer.from("") } as any,
+        { originalname: "c.png", buffer: Buffer.from("") } as any,
+      ];
+
+      await expect(service.addImages("post1", "user1", files)).rejects.toThrow(
+        BadRequestException
+      );
+    });
+  });
+
+  // ─── removeImage ────────────────────────────────────────────
+  describe("removeImage", () => {
+    const existingPost = {
+      id: "post1",
+      userId: "user1",
+    };
+    const existingImage = {
+      id: "img1",
+      postId: "post1",
+      url: "uploads/post1/abc.png",
+      createdAt: new Date(),
+    };
+
+    it("オーナーが画像を削除できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.image.findUnique.mockResolvedValue(existingImage);
+      mockPrisma.image.delete.mockResolvedValue(existingImage);
+
+      const result = await service.removeImage("post1", "img1", "user1");
+
+      expect(mockFs.unlinkSync).toHaveBeenCalled();
+      expect(mockPrisma.image.delete).toHaveBeenCalledWith({
+        where: { id: "img1" },
+      });
+      expect(result).toEqual(existingImage);
+    });
+
+    it("ファイルが存在しない場合 unlinkSync を呼ばない", async () => {
+      mockFs.existsSync.mockReturnValue(false);
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.image.findUnique.mockResolvedValue(existingImage);
+      mockPrisma.image.delete.mockResolvedValue(existingImage);
+
+      await service.removeImage("post1", "img1", "user1");
+
+      expect(mockFs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it("オーナー以外は ForbiddenException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+
+      await expect(
+        service.removeImage("post1", "img1", "other-user")
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しない投稿は NotFoundException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.removeImage("no-such", "img1", "user1")
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("別の投稿に属する画像は NotFoundException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.image.findUnique.mockResolvedValue({
+        ...existingImage,
+        postId: "other-post",
+      });
+
+      await expect(
+        service.removeImage("post1", "img1", "user1")
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -108,10 +428,12 @@ describe("PostsService", () => {
     const existingPost = {
       id: "post1",
       title: "Old",
-      content: "Old content",
-      authorId: "user1",
-      image: null,
+      description: "Old description",
+      userId: "user1",
+      status: "lost",
+      lostDate: new Date(),
       createdAt: new Date(),
+      updatedAt: new Date(),
     };
 
     it("オーナーが更新できる", async () => {
@@ -132,7 +454,7 @@ describe("PostsService", () => {
       mockPrisma.post.findUnique.mockResolvedValue(existingPost);
 
       await expect(
-        service.update("post1", "other-user", { title: "Hacked" }),
+        service.update("post1", "other-user", { title: "Hacked" })
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -140,29 +462,86 @@ describe("PostsService", () => {
       mockPrisma.post.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.update("no-such-post", "user1", { title: "X" }),
+        service.update("no-such-post", "user1", { title: "X" })
       ).rejects.toThrow(HttpException);
     });
 
-    it("ファイルありかつ既存画像がある時、古い画像ファイルが削除されること", async () => {
-      const postWithImage = { ...existingPost, image: "uploads/old.png" };
-      mockPrisma.post.findUnique.mockResolvedValue(postWithImage);
-      mockPrisma.post.update.mockResolvedValue({ ...postWithImage, image: "uploads/new.png" });
-      const file = { originalname: "new.png", buffer: Buffer.from("") } as any;
+    it("lostDate を更新できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.post.update.mockResolvedValue({
+        ...existingPost,
+        lostDate: new Date("2024-06-15"),
+      });
 
-      await service.update("post1", "user1", {}, file);
+      await service.update("post1", "user1", { lostDate: "2024-06-15" });
 
-      expect(mockFs.unlinkSync).toHaveBeenCalled();
+      expect(mockPrisma.post.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ lostDate: new Date("2024-06-15") }),
+        })
+      );
     });
 
-    it("ファイルありかつ既存画像がない時、unlinkSyncを呼ばないこと", async () => {
-      mockPrisma.post.findUnique.mockResolvedValue(existingPost); // image: null
-      mockPrisma.post.update.mockResolvedValue({ ...existingPost, image: "uploads/new.png" });
-      const file = { originalname: "new.png", buffer: Buffer.from("") } as any;
+    it("status を更新できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.post.update.mockResolvedValue({
+        ...existingPost,
+        status: "resolved",
+      });
 
-      await service.update("post1", "user1", {}, file);
+      await service.update("post1", "user1", { status: "resolved" });
 
-      expect(mockFs.unlinkSync).not.toHaveBeenCalled();
+      expect(mockPrisma.post.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: "resolved" }),
+        })
+      );
+    });
+
+    it("petDetail を upsert できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.post.update.mockResolvedValue(existingPost);
+      mockPrisma.petDetail.upsert.mockResolvedValue({});
+
+      const petDetail = {
+        name: "Mimi",
+        color: "white",
+        age: "2歳",
+        features: "人懐こい",
+      };
+      await service.update("post1", "user1", { petDetail });
+
+      expect(mockPrisma.petDetail.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { postId: "post1" },
+          create: expect.objectContaining({ postId: "post1", name: "Mimi" }),
+        })
+      );
+    });
+
+    it("location を upsert できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.post.update.mockResolvedValue(existingPost);
+      mockPrisma.location.upsert.mockResolvedValue({});
+
+      const location = {
+        prefecture: "saitama",
+        city: "さいたま市",
+        address: "南区",
+        lat: 35.0,
+        lng: 139.0,
+      };
+      await service.update("post1", "user1", { location });
+
+      expect(mockPrisma.location.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { postId: "post1" },
+          create: expect.objectContaining({
+            postId: "post1",
+            prefecture: "saitama",
+          }),
+        })
+      );
     });
   });
 
@@ -171,10 +550,13 @@ describe("PostsService", () => {
     const existingPost = {
       id: "post1",
       title: "T",
-      content: "C",
-      authorId: "user1",
-      image: null,
+      description: "C",
+      userId: "user1",
+      status: "lost",
+      lostDate: new Date(),
       createdAt: new Date(),
+      updatedAt: new Date(),
+      images: [],
     };
 
     it("オーナーが削除できる", async () => {
@@ -183,15 +565,37 @@ describe("PostsService", () => {
 
       const result = await service.remove("post1", "user1");
 
-      expect(mockPrisma.post.delete).toHaveBeenCalledWith({ where: { id: "post1" } });
+      expect(mockPrisma.post.delete).toHaveBeenCalledWith({
+        where: { id: "post1" },
+      });
       expect(result).toEqual(existingPost);
+    });
+
+    it("画像ファイルも削除する", async () => {
+      const postWithImages = {
+        ...existingPost,
+        images: [
+          {
+            id: "img1",
+            url: "uploads/post1/abc.png",
+            postId: "post1",
+            createdAt: new Date(),
+          },
+        ],
+      };
+      mockPrisma.post.findUnique.mockResolvedValue(postWithImages);
+      mockPrisma.post.delete.mockResolvedValue(postWithImages);
+
+      await service.remove("post1", "user1");
+
+      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(1);
     });
 
     it("オーナー以外は ForbiddenException", async () => {
       mockPrisma.post.findUnique.mockResolvedValue(existingPost);
 
       await expect(service.remove("post1", "other-user")).rejects.toThrow(
-        ForbiddenException,
+        ForbiddenException
       );
     });
 
@@ -199,7 +603,7 @@ describe("PostsService", () => {
       mockPrisma.post.findUnique.mockResolvedValue(null);
 
       await expect(service.remove("no-such-post", "user1")).rejects.toThrow(
-        HttpException,
+        HttpException
       );
     });
   });

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -47,7 +47,10 @@ export class PostsService {
       throw new BadRequestException(`最大${MAX_IMAGES}枚まで添付できます`);
     }
 
-    const lostDate = dto.lostDate ? new Date(dto.lostDate) : new Date();
+    if (!dto.lostDate) {
+      throw new BadRequestException("lostDateは必須です");
+    }
+    const lostDate = new Date(dto.lostDate);
     const savedUrls: string[] = [];
 
     // トランザクション失敗時に保存済みファイルを削除する
@@ -204,7 +207,10 @@ export class PostsService {
   }
 
   async update(id: string, userId: string, dto: UpdatePostDto) {
-    const post = await this.prisma.post.findUnique({ where: { id } });
+    const post = await this.prisma.post.findUnique({
+      where: { id },
+      include: { petDetail: true, location: true },
+    });
     if (!post) {
       throw new HttpException("Post not found", HttpStatus.NOT_FOUND);
     }
@@ -227,14 +233,23 @@ export class PostsService {
 
       if (petDetail !== undefined) {
         const pd = petDetail;
+        // petDetailが存在しない場合はcreateパスになるため、必須フィールドを検証する
+        if (
+          !post.petDetail &&
+          (!pd.name || !pd.color || !pd.age || !pd.features)
+        ) {
+          throw new BadRequestException(
+            "petDetailを新規作成する場合、name/color/age/featuresは必須です"
+          );
+        }
         await tx.petDetail.upsert({
           where: { postId: id },
           create: {
             postId: id,
-            name: pd.name ?? "",
-            color: pd.color ?? "",
-            age: pd.age ?? "",
-            features: pd.features ?? "",
+            name: pd.name!,
+            color: pd.color!,
+            age: pd.age!,
+            features: pd.features!,
             ...(pd.gender !== undefined && { gender: pd.gender as Gender }),
             ...(pd.breed !== undefined && { breed: pd.breed }),
             ...(pd.size !== undefined && { size: pd.size }),
@@ -259,15 +274,28 @@ export class PostsService {
 
       if (location !== undefined) {
         const loc = location;
+        // locationが存在しない場合はcreateパスになるため、必須フィールドを検証する
+        if (
+          !post.location &&
+          (!loc.prefecture ||
+            !loc.city ||
+            !loc.address ||
+            loc.lat === undefined ||
+            loc.lng === undefined)
+        ) {
+          throw new BadRequestException(
+            "locationを新規作成する場合、prefecture/city/address/lat/lngは必須です"
+          );
+        }
         await tx.location.upsert({
           where: { postId: id },
           create: {
             postId: id,
-            prefecture: (loc.prefecture ?? "saitama") as Prefecture,
-            city: loc.city ?? "",
-            address: loc.address ?? "",
-            lat: loc.lat ?? 0,
-            lng: loc.lng ?? 0,
+            prefecture: loc.prefecture! as Prefecture,
+            city: loc.city!,
+            address: loc.address!,
+            lat: loc.lat!,
+            lng: loc.lng!,
           },
           update: {
             ...(loc.prefecture !== undefined && {

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -48,60 +48,72 @@ export class PostsService {
     }
 
     const lostDate = dto.lostDate ? new Date(dto.lostDate) : new Date();
+    const savedUrls: string[] = [];
 
-    return this.prisma.$transaction(async (tx) => {
-      const post = await tx.post.create({
-        data: {
-          title: dto.title,
-          description: dto.description,
-          userId,
-          lostDate,
-        },
-      });
-
-      if (dto.petDetail) {
-        const pd = dto.petDetail;
-        await tx.petDetail.create({
+    // トランザクション失敗時に保存済みファイルを削除する
+    return this.prisma
+      .$transaction(async (tx) => {
+        const post = await tx.post.create({
           data: {
-            postId: post.id,
-            name: pd.name,
-            color: pd.color,
-            age: pd.age,
-            features: pd.features,
-            ...(pd.gender !== undefined && { gender: pd.gender as Gender }),
-            ...(pd.breed !== undefined && { breed: pd.breed }),
-            ...(pd.size !== undefined && { size: pd.size }),
-            ...(pd.collar !== undefined && { collar: pd.collar }),
-            ...(pd.microchip !== undefined && { microchip: pd.microchip }),
-            ...(pd.neutered !== undefined && { neutered: pd.neutered }),
+            title: dto.title,
+            description: dto.description,
+            userId,
+            lostDate,
           },
         });
-      }
 
-      if (dto.location) {
-        const loc = dto.location;
-        await tx.location.create({
-          data: {
-            postId: post.id,
-            prefecture: loc.prefecture as Prefecture,
-            city: loc.city,
-            address: loc.address,
-            lat: loc.lat,
-            lng: loc.lng,
-          },
+        if (dto.petDetail) {
+          const pd = dto.petDetail;
+          await tx.petDetail.create({
+            data: {
+              postId: post.id,
+              name: pd.name,
+              color: pd.color,
+              age: pd.age,
+              features: pd.features,
+              ...(pd.gender !== undefined && { gender: pd.gender as Gender }),
+              ...(pd.breed !== undefined && { breed: pd.breed }),
+              ...(pd.size !== undefined && { size: pd.size }),
+              ...(pd.collar !== undefined && { collar: pd.collar }),
+              ...(pd.microchip !== undefined && { microchip: pd.microchip }),
+              ...(pd.neutered !== undefined && { neutered: pd.neutered }),
+            },
+          });
+        }
+
+        if (dto.location) {
+          const loc = dto.location;
+          await tx.location.create({
+            data: {
+              postId: post.id,
+              prefecture: loc.prefecture as Prefecture,
+              city: loc.city,
+              address: loc.address,
+              lat: loc.lat,
+              lng: loc.lng,
+            },
+          });
+        }
+
+        for (const file of files) {
+          const url = this.saveFile(post.id, file);
+          savedUrls.push(url);
+          await tx.image.create({ data: { postId: post.id, url } });
+        }
+
+        return tx.post.findUnique({
+          where: { id: post.id },
+          include: { petDetail: true, location: true, images: true },
         });
-      }
-
-      for (const file of files) {
-        const url = this.saveFile(post.id, file);
-        await tx.image.create({ data: { postId: post.id, url } });
-      }
-
-      return tx.post.findUnique({
-        where: { id: post.id },
-        include: { petDetail: true, location: true, images: true },
+      })
+      .catch((e) => {
+        for (const url of savedUrls) {
+          try {
+            this.deleteFile(url);
+          } catch {}
+        }
+        throw e;
       });
-    });
   }
 
   async findAll(page = 1, perPage = 10) {
@@ -119,10 +131,12 @@ export class PostsService {
   }
 
   async findById(id: string) {
-    return this.prisma.post.findUnique({
+    const post = await this.prisma.post.findUnique({
       where: { id },
       include: { petDetail: true, location: true, images: true },
     });
+    if (!post) throw new NotFoundException("Post not found");
+    return post;
   }
 
   async addImages(
@@ -145,17 +159,32 @@ export class PostsService {
       );
     }
 
-    const newImages = await Promise.all(
-      files.map(async (file) => {
+    // ファイルを先に保存し、DB作成失敗時はクリーンアップする
+    const savedUrls: string[] = [];
+    try {
+      for (const file of files) {
         const url = this.saveFile(postId, file);
-        return this.prisma.image.create({ data: { postId, url } });
-      })
-    );
+        savedUrls.push(url);
+      }
 
-    return {
-      remainingSlots: MAX_IMAGES - currentCount - files.length,
-      images: newImages,
-    };
+      const newImages = await this.prisma.$transaction(async (tx) => {
+        return Promise.all(
+          savedUrls.map((url) => tx.image.create({ data: { postId, url } }))
+        );
+      });
+
+      return {
+        remainingSlots: MAX_IMAGES - currentCount - files.length,
+        images: newImages,
+      };
+    } catch (error) {
+      for (const url of savedUrls) {
+        try {
+          this.deleteFile(url);
+        } catch {}
+      }
+      throw error;
+    }
   }
 
   async removeImage(postId: string, imageId: string, userId: string) {
@@ -186,7 +215,7 @@ export class PostsService {
     return this.prisma.$transaction(async (tx) => {
       const { petDetail, location, lostDate, status, title, description } = dto;
 
-      const updated = await tx.post.update({
+      await tx.post.update({
         where: { id },
         data: {
           ...(title !== undefined && { title }),
@@ -252,7 +281,11 @@ export class PostsService {
         });
       }
 
-      return updated;
+      // すべての更新後に include 付きで再取得してレスポンス形状を統一する
+      return tx.post.findUnique({
+        where: { id },
+        include: { petDetail: true, location: true, images: true },
+      });
     });
   }
 

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -1,28 +1,107 @@
-import { Injectable, HttpException, HttpStatus, ForbiddenException } from "@nestjs/common";
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+  ForbiddenException,
+  BadRequestException,
+  NotFoundException,
+} from "@nestjs/common";
 import { PrismaService } from "../prisma.service";
+import type { PostStatus, Gender, Prefecture } from "@prisma/client";
 import * as fs from "fs";
 import * as path from "path";
 import { v4 as uuidv4 } from "uuid";
+import { CreatePostDto } from "./dto/create-post.dto";
+import { UpdatePostDto } from "./dto/update-post.dto";
+
+const MAX_IMAGES = 5;
 
 @Injectable()
 export class PostsService {
   constructor(private prisma: PrismaService) {}
 
-  private saveUploadedFile(file?: Express.Multer.File): string | undefined {
-    if (!file) return undefined;
-    const uploadDir = path.join(__dirname, "../../uploads");
+  private saveFile(postId: string, file: Express.Multer.File): string {
+    const uploadDir = path.join(__dirname, "../../uploads", postId);
     if (!fs.existsSync(uploadDir)) {
       fs.mkdirSync(uploadDir, { recursive: true });
     }
-    const ext = path.extname(file.originalname).toLowerCase();
+    const ext = path.extname(file.originalname).toLowerCase() || ".jpg";
     const fileName = `${uuidv4()}${ext}`;
     fs.writeFileSync(path.join(uploadDir, fileName), file.buffer);
-    return `uploads/${fileName}`;
+    return `uploads/${postId}/${fileName}`;
   }
 
-  async create(authorId: string, title: string, content: string, file?: Express.Multer.File) {
-    const imagePath = this.saveUploadedFile(file);
-    return this.prisma.post.create({ data: { title, content, authorId, image: imagePath } });
+  private deleteFile(url: string): void {
+    const filePath = path.join(__dirname, "../../", url);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+
+  async create(
+    userId: string,
+    dto: CreatePostDto,
+    files: Express.Multer.File[] = []
+  ) {
+    if (files.length > MAX_IMAGES) {
+      throw new BadRequestException(`最大${MAX_IMAGES}枚まで添付できます`);
+    }
+
+    const lostDate = dto.lostDate ? new Date(dto.lostDate) : new Date();
+
+    return this.prisma.$transaction(async (tx) => {
+      const post = await tx.post.create({
+        data: {
+          title: dto.title,
+          description: dto.description,
+          userId,
+          lostDate,
+        },
+      });
+
+      if (dto.petDetail) {
+        const pd = dto.petDetail;
+        await tx.petDetail.create({
+          data: {
+            postId: post.id,
+            name: pd.name,
+            color: pd.color,
+            age: pd.age,
+            features: pd.features,
+            ...(pd.gender !== undefined && { gender: pd.gender as Gender }),
+            ...(pd.breed !== undefined && { breed: pd.breed }),
+            ...(pd.size !== undefined && { size: pd.size }),
+            ...(pd.collar !== undefined && { collar: pd.collar }),
+            ...(pd.microchip !== undefined && { microchip: pd.microchip }),
+            ...(pd.neutered !== undefined && { neutered: pd.neutered }),
+          },
+        });
+      }
+
+      if (dto.location) {
+        const loc = dto.location;
+        await tx.location.create({
+          data: {
+            postId: post.id,
+            prefecture: loc.prefecture as Prefecture,
+            city: loc.city,
+            address: loc.address,
+            lat: loc.lat,
+            lng: loc.lng,
+          },
+        });
+      }
+
+      for (const file of files) {
+        const url = this.saveFile(post.id, file);
+        await tx.image.create({ data: { postId: post.id, url } });
+      }
+
+      return tx.post.findUnique({
+        where: { id: post.id },
+        include: { petDetail: true, location: true, images: true },
+      });
+    });
   }
 
   async findAll(page = 1, perPage = 10) {
@@ -32,6 +111,7 @@ export class PostsService {
         skip,
         take: perPage,
         orderBy: { createdAt: "desc" },
+        include: { petDetail: true, location: true, images: true },
       }),
       this.prisma.post.count(),
     ]);
@@ -39,49 +119,159 @@ export class PostsService {
   }
 
   async findById(id: string) {
-    return this.prisma.post.findUnique({ where: { id } });
+    return this.prisma.post.findUnique({
+      where: { id },
+      include: { petDetail: true, location: true, images: true },
+    });
   }
 
-  private deleteUploadedFile(imagePath: string | null) {
-    if (!imagePath) return;
-    const fullPath = path.join(__dirname, "../../", imagePath);
-    try {
-      if (fs.existsSync(fullPath)) fs.unlinkSync(fullPath);
-    } catch {
-      // ignore cleanup errors
-    }
-  }
-
-  async update(
-    id: string,
+  async addImages(
+    postId: string,
     userId: string,
-    data: { title?: string; content?: string },
-    file?: Express.Multer.File,
+    files: Express.Multer.File[]
   ) {
+    const post = await this.prisma.post.findUnique({
+      where: { id: postId },
+      include: { images: true },
+    });
+    if (!post) throw new NotFoundException("Post not found");
+    if (post.userId !== userId)
+      throw new ForbiddenException("You are not the owner of this post");
+
+    const currentCount = post.images.length;
+    if (currentCount + files.length > MAX_IMAGES) {
+      throw new BadRequestException(
+        `画像は最大${MAX_IMAGES}枚です（現在${currentCount}枚、追加可能: ${MAX_IMAGES - currentCount}枚）`
+      );
+    }
+
+    const newImages = await Promise.all(
+      files.map(async (file) => {
+        const url = this.saveFile(postId, file);
+        return this.prisma.image.create({ data: { postId, url } });
+      })
+    );
+
+    return {
+      remainingSlots: MAX_IMAGES - currentCount - files.length,
+      images: newImages,
+    };
+  }
+
+  async removeImage(postId: string, imageId: string, userId: string) {
+    const post = await this.prisma.post.findUnique({ where: { id: postId } });
+    if (!post) throw new NotFoundException("Post not found");
+    if (post.userId !== userId)
+      throw new ForbiddenException("You are not the owner of this post");
+
+    const image = await this.prisma.image.findUnique({
+      where: { id: imageId },
+    });
+    if (!image || image.postId !== postId)
+      throw new NotFoundException("Image not found");
+
+    this.deleteFile(image.url);
+    return this.prisma.image.delete({ where: { id: imageId } });
+  }
+
+  async update(id: string, userId: string, dto: UpdatePostDto) {
     const post = await this.prisma.post.findUnique({ where: { id } });
     if (!post) {
       throw new HttpException("Post not found", HttpStatus.NOT_FOUND);
     }
-    if (post.authorId !== userId) {
+    if (post.userId !== userId) {
       throw new ForbiddenException("You are not the owner of this post");
     }
-    const imagePath = this.saveUploadedFile(file);
-    const updated = await this.prisma.post.update({
-      where: { id },
-      data: { ...data, ...(imagePath ? { image: imagePath } : {}) },
+
+    return this.prisma.$transaction(async (tx) => {
+      const { petDetail, location, lostDate, status, title, description } = dto;
+
+      const updated = await tx.post.update({
+        where: { id },
+        data: {
+          ...(title !== undefined && { title }),
+          ...(description !== undefined && { description }),
+          ...(lostDate !== undefined && { lostDate: new Date(lostDate) }),
+          ...(status !== undefined && { status: status as PostStatus }),
+        },
+      });
+
+      if (petDetail !== undefined) {
+        const pd = petDetail;
+        await tx.petDetail.upsert({
+          where: { postId: id },
+          create: {
+            postId: id,
+            name: pd.name ?? "",
+            color: pd.color ?? "",
+            age: pd.age ?? "",
+            features: pd.features ?? "",
+            ...(pd.gender !== undefined && { gender: pd.gender as Gender }),
+            ...(pd.breed !== undefined && { breed: pd.breed }),
+            ...(pd.size !== undefined && { size: pd.size }),
+            ...(pd.collar !== undefined && { collar: pd.collar }),
+            ...(pd.microchip !== undefined && { microchip: pd.microchip }),
+            ...(pd.neutered !== undefined && { neutered: pd.neutered }),
+          },
+          update: {
+            ...(pd.name !== undefined && { name: pd.name }),
+            ...(pd.color !== undefined && { color: pd.color }),
+            ...(pd.age !== undefined && { age: pd.age }),
+            ...(pd.features !== undefined && { features: pd.features }),
+            ...(pd.gender !== undefined && { gender: pd.gender as Gender }),
+            ...(pd.breed !== undefined && { breed: pd.breed }),
+            ...(pd.size !== undefined && { size: pd.size }),
+            ...(pd.collar !== undefined && { collar: pd.collar }),
+            ...(pd.microchip !== undefined && { microchip: pd.microchip }),
+            ...(pd.neutered !== undefined && { neutered: pd.neutered }),
+          },
+        });
+      }
+
+      if (location !== undefined) {
+        const loc = location;
+        await tx.location.upsert({
+          where: { postId: id },
+          create: {
+            postId: id,
+            prefecture: (loc.prefecture ?? "saitama") as Prefecture,
+            city: loc.city ?? "",
+            address: loc.address ?? "",
+            lat: loc.lat ?? 0,
+            lng: loc.lng ?? 0,
+          },
+          update: {
+            ...(loc.prefecture !== undefined && {
+              prefecture: loc.prefecture as Prefecture,
+            }),
+            ...(loc.city !== undefined && { city: loc.city }),
+            ...(loc.address !== undefined && { address: loc.address }),
+            ...(loc.lat !== undefined && { lat: loc.lat }),
+            ...(loc.lng !== undefined && { lng: loc.lng }),
+          },
+        });
+      }
+
+      return updated;
     });
-    if (imagePath && post.image) this.deleteUploadedFile(post.image);
-    return updated;
   }
 
   async remove(id: string, userId: string) {
-    const post = await this.prisma.post.findUnique({ where: { id } });
+    const post = await this.prisma.post.findUnique({
+      where: { id },
+      include: { images: true },
+    });
     if (!post) {
       throw new HttpException("Post not found", HttpStatus.NOT_FOUND);
     }
-    if (post.authorId !== userId) {
+    if (post.userId !== userId) {
       throw new ForbiddenException("You are not the owner of this post");
     }
+
+    for (const image of post.images) {
+      this.deleteFile(image.url);
+    }
+
     return this.prisma.post.delete({ where: { id } });
   }
 }

--- a/apps/api/src/users/dto/register.dto.ts
+++ b/apps/api/src/users/dto/register.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsString, MinLength, MaxLength, IsOptional } from "class-validator";
+import { IsEmail, IsString, MinLength, MaxLength } from "class-validator";
 
 export class RegisterDto {
   @ApiProperty({ example: "user@example.com" })
@@ -12,9 +12,8 @@ export class RegisterDto {
   @MaxLength(100)
   password: string;
 
-  @ApiProperty({ required: false, example: "Alice" })
-  @IsOptional()
+  @ApiProperty({ example: "Alice" })
   @IsString()
   @MaxLength(50)
-  name?: string;
+  nickname: string;
 }

--- a/apps/api/src/users/dto/user-response.dto.ts
+++ b/apps/api/src/users/dto/user-response.dto.ts
@@ -7,8 +7,8 @@ export class UserResponseDto {
   @ApiProperty()
   email: string;
 
-  @ApiProperty({ required: false, nullable: true })
-  name: string | null;
+  @ApiProperty()
+  nickname: string;
 
   @ApiProperty()
   createdAt: Date;

--- a/apps/api/src/users/user.controller.ts
+++ b/apps/api/src/users/user.controller.ts
@@ -11,7 +11,7 @@ import { UsersService } from "./user.service";
 import { UserResponseDto } from "./dto/user-response.dto";
 import { RegisterDto } from "./dto/register.dto";
 
-@ApiTags('users')
+@ApiTags("users")
 @Controller("users")
 export class UsersController {
   constructor(private users: UsersService) {}
@@ -31,20 +31,20 @@ export class UsersController {
       const user = await this.users.createUser(
         dto.email,
         dto.password,
-        dto.name,
+        dto.nickname
       );
-      return { id: user.id, email: user.email, name: user.name };
+      return { id: user.id, email: user.email, nickname: user.nickname };
     } catch (e: any) {
       // Handle unique constraint (Prisma P2002) as bad request
       if (e?.code === "P2002" || (e?.meta && /unique/i.test(String(e.meta)))) {
         throw new HttpException(
           { error: "Email already exists" },
-          HttpStatus.BAD_REQUEST,
+          HttpStatus.BAD_REQUEST
         );
       }
       throw new HttpException(
         { error: "Internal server error" },
-        HttpStatus.INTERNAL_SERVER_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR
       );
     }
   }

--- a/apps/api/src/users/user.service.spec.ts
+++ b/apps/api/src/users/user.service.spec.ts
@@ -20,7 +20,13 @@ describe("UsersService", () => {
   // ─── createUser ──────────────────────────────────────────────
   describe("createUser", () => {
     it("パスワードをハッシュ化して保存する", async () => {
-      const created = { id: "u1", email: "a@b.com", name: "Alice", password: "hashed", createdAt: new Date() };
+      const created = {
+        id: "u1",
+        email: "a@b.com",
+        nickname: "Alice",
+        password: "hashed",
+        createdAt: new Date(),
+      };
       mockPrisma.user.create.mockResolvedValue(created);
 
       await service.createUser("a@b.com", "plainpass", "Alice");
@@ -33,20 +39,28 @@ describe("UsersService", () => {
     it("平文パスワードを DB に保存しない", async () => {
       mockPrisma.user.create.mockResolvedValue({ id: "u1", email: "a@b.com" });
 
-      await service.createUser("a@b.com", "secret");
+      await service.createUser("a@b.com", "secret", "Bob");
 
       const call = mockPrisma.user.create.mock.calls[0][0];
       expect(call.data.password).not.toBe("secret");
     });
 
-    it("name なしで作成できる", async () => {
-      const created = { id: "u1", email: "a@b.com", name: null, password: "hashed", createdAt: new Date() };
+    it("nickname を DB に保存する", async () => {
+      const created = {
+        id: "u1",
+        email: "a@b.com",
+        nickname: "Alice",
+        password: "hashed",
+        createdAt: new Date(),
+      };
       mockPrisma.user.create.mockResolvedValue(created);
 
-      const result = await service.createUser("a@b.com", "pass");
+      const result = await service.createUser("a@b.com", "pass12345", "Alice");
 
       expect(mockPrisma.user.create).toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ name: undefined }) }),
+        expect.objectContaining({
+          data: expect.objectContaining({ nickname: "Alice" }),
+        })
       );
       expect(result).toEqual(created);
     });
@@ -54,7 +68,9 @@ describe("UsersService", () => {
     it("Prisma がエラーを投げたら再スローする", async () => {
       mockPrisma.user.create.mockRejectedValue(new Error("DB error"));
 
-      await expect(service.createUser("a@b.com", "pass")).rejects.toThrow("DB error");
+      await expect(
+        service.createUser("a@b.com", "pass12345", "Alice")
+      ).rejects.toThrow("DB error");
     });
   });
 
@@ -66,7 +82,9 @@ describe("UsersService", () => {
 
       const result = await service.findByEmail("a@b.com");
 
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({ where: { email: "a@b.com" } });
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { email: "a@b.com" },
+      });
       expect(result).toEqual(user);
     });
 
@@ -87,7 +105,9 @@ describe("UsersService", () => {
 
       const result = await service.findById("u1");
 
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({ where: { id: "u1" } });
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: "u1" },
+      });
       expect(result).toEqual(user);
     });
 
@@ -104,15 +124,20 @@ describe("UsersService", () => {
   describe("findAll", () => {
     it("パスワードを含まないユーザー一覧を返す", async () => {
       const users = [
-        { id: "u1", email: "a@b.com", name: "Alice", createdAt: new Date() },
-        { id: "u2", email: "b@b.com", name: "Bob", createdAt: new Date() },
+        {
+          id: "u1",
+          email: "a@b.com",
+          nickname: "Alice",
+          createdAt: new Date(),
+        },
+        { id: "u2", email: "b@b.com", nickname: "Bob", createdAt: new Date() },
       ];
       mockPrisma.user.findMany.mockResolvedValue(users);
 
       const result = await service.findAll();
 
       expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
-        select: { id: true, email: true, name: true, createdAt: true },
+        select: { id: true, email: true, nickname: true, createdAt: true },
       });
       expect(result).toEqual(users);
     });

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -6,9 +6,11 @@ import * as bcrypt from "bcrypt";
 export class UsersService {
   constructor(private prisma: PrismaService) {}
 
-  async createUser(email: string, password: string, name?: string) {
+  async createUser(email: string, password: string, nickname: string) {
     const hashed = await bcrypt.hash(password, 10);
-    return this.prisma.user.create({ data: { email, password: hashed, name } });
+    return this.prisma.user.create({
+      data: { email, password: hashed, nickname },
+    });
   }
 
   async findByEmail(email: string) {
@@ -24,7 +26,7 @@ export class UsersService {
   // NestJS:  この1行が「サーバー関数の中身」に相当する
   async findAll() {
     return this.prisma.user.findMany({
-      select: { id: true, email: true, name: true, createdAt: true },
+      select: { id: true, email: true, nickname: true, createdAt: true },
     });
   }
 }

--- a/apps/api/src/utils/transform.spec.ts
+++ b/apps/api/src/utils/transform.spec.ts
@@ -1,0 +1,23 @@
+import { parseJsonField } from "./transform";
+
+describe("parseJsonField", () => {
+  it("有効なJSON文字列の時、パースされたオブジェクトを返す", () => {
+    const result = parseJsonField({ value: '{"name":"Mimi","color":"white"}' });
+    expect(result).toEqual({ name: "Mimi", color: "white" });
+  });
+
+  it("無効なJSON文字列の時、元の文字列をそのまま返す", () => {
+    const result = parseJsonField({ value: "invalid json {" });
+    expect(result).toBe("invalid json {");
+  });
+
+  it("文字列でない値の時、そのまま返す", () => {
+    const obj = { name: "Mimi" };
+    const result = parseJsonField({ value: obj });
+    expect(result).toBe(obj);
+  });
+
+  it("nullの時、そのまま返す", () => {
+    expect(parseJsonField({ value: null })).toBeNull();
+  });
+});

--- a/apps/api/src/utils/transform.ts
+++ b/apps/api/src/utils/transform.ts
@@ -1,0 +1,10 @@
+export const parseJsonField = ({ value }: { value: unknown }): unknown => {
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "eslint": "^10.2.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
+        "prettier": "^3.8.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.1.0"
       },
@@ -1253,7 +1256,7 @@
     },
     "apps/api/node_modules/@prisma/config": {
       "version": "6.19.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -1264,12 +1267,12 @@
     },
     "apps/api/node_modules/@prisma/debug": {
       "version": "6.19.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "apps/api/node_modules/@prisma/engines": {
       "version": "6.19.0",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1281,12 +1284,12 @@
     },
     "apps/api/node_modules/@prisma/engines-version": {
       "version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "apps/api/node_modules/@prisma/fetch-engine": {
       "version": "6.19.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.0",
@@ -1296,7 +1299,7 @@
     },
     "apps/api/node_modules/@prisma/get-platform": {
       "version": "6.19.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.0"
@@ -1898,7 +1901,7 @@
     },
     "apps/api/node_modules/c12": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -1983,7 +1986,7 @@
     },
     "apps/api/node_modules/chokidar": {
       "version": "4.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -2015,7 +2018,7 @@
     },
     "apps/api/node_modules/citty": {
       "version": "0.1.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -2122,7 +2125,7 @@
     },
     "apps/api/node_modules/confbox": {
       "version": "0.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/console-control-strings": {
@@ -2183,7 +2186,7 @@
     },
     "apps/api/node_modules/deepmerge-ts": {
       "version": "7.1.5",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -2191,7 +2194,7 @@
     },
     "apps/api/node_modules/defu": {
       "version": "6.1.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/delegates": {
@@ -2200,7 +2203,7 @@
     },
     "apps/api/node_modules/destr": {
       "version": "2.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/detect-libc": {
@@ -2231,7 +2234,7 @@
     },
     "apps/api/node_modules/dotenv": {
       "version": "16.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -2262,7 +2265,7 @@
     },
     "apps/api/node_modules/effect": {
       "version": "3.18.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -2292,7 +2295,7 @@
     },
     "apps/api/node_modules/empathic": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -2382,12 +2385,12 @@
     },
     "apps/api/node_modules/exsolve": {
       "version": "1.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/fast-check": {
       "version": "3.23.2",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -2525,7 +2528,7 @@
     },
     "apps/api/node_modules/giget": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -3542,7 +3545,7 @@
     },
     "apps/api/node_modules/jiti": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -3828,7 +3831,7 @@
     },
     "apps/api/node_modules/node-fetch-native": {
       "version": "1.6.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/node-int64": {
@@ -3936,7 +3939,7 @@
     },
     "apps/api/node_modules/nypm": {
       "version": "0.6.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.0",
@@ -3952,12 +3955,12 @@
     },
     "apps/api/node_modules/nypm/node_modules/citty": {
       "version": "0.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/ohash": {
       "version": "2.0.11",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/onetime": {
@@ -4130,7 +4133,7 @@
     },
     "apps/api/node_modules/perfect-debounce": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "apps/api/node_modules/picomatch": {
@@ -4165,7 +4168,7 @@
     },
     "apps/api/node_modules/pkg-types": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -4199,7 +4202,7 @@
     },
     "apps/api/node_modules/prisma": {
       "version": "6.19.0",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4227,7 +4230,7 @@
     },
     "apps/api/node_modules/pure-rand": {
       "version": "6.1.0",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -4255,7 +4258,7 @@
     },
     "apps/api/node_modules/rc9": {
       "version": "2.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -4269,7 +4272,7 @@
     },
     "apps/api/node_modules/readdirp": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -5220,7 +5223,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
-        "@types/leaflet": "^1.9.21",
         "axios": "^1.15.0",
         "leaflet": "^1.9.4",
         "react": "^18.0.0",
@@ -5234,6 +5236,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/leaflet": "^1.9.21",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@vitejs/plugin-react": "^4.0.0",
@@ -6996,7 +6999,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/dom": {
@@ -7172,6 +7175,7 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -7185,6 +7189,7 @@
       "version": "1.9.21",
       "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
       "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
@@ -7682,6 +7687,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -7902,6 +7923,46 @@
         "validator": "^13.15.22"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -7912,6 +7973,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/component-emitter": {
@@ -8215,6 +8286,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -8235,6 +8313,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -8514,6 +8605,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -8831,6 +8929,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -8965,6 +9076,22 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -9054,6 +9181,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-glob": {
@@ -9463,6 +9606,48 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/load-esm": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
@@ -9503,6 +9688,56 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -9625,6 +9860,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -9798,6 +10046,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9908,7 +10172,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -9968,6 +10232,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -10131,6 +10411,30 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
@@ -10429,6 +10733,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -10442,6 +10759,36 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/source-map-js": {
@@ -10492,6 +10839,62 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/strip-indent": {
@@ -10577,7 +10980,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
       "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10774,7 +11177,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11126,6 +11529,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -11148,6 +11600,22 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -13773,14 +14241,6 @@
         "node": ">= 0.4"
       }
     },
-    "packages/api-client/node_modules/string-argv": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
     "packages/api-client/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
@@ -14171,20 +14631,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/api-client/node_modules/yaml": {
-      "version": "2.8.3",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "packages/api-client/node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "generate": "npm run generate --workspace=packages/api-client",
     "lint:api": "eslint \"apps/api/{src,test}/**/*.ts\" --config apps/api/eslint.config.js",
     "typecheck:api": "tsc --noEmit --project apps/api/tsconfig.json",
-    "typecheck:web": "tsc --noEmit --project apps/web/tsconfig.json"
+    "typecheck:web": "tsc --noEmit --project apps/web/tsconfig.json",
+    "prepare": "husky"
   },
   "engines": {
     "node": ">=18"
@@ -26,9 +27,12 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
-    "eslint": "^10.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "eslint": "^10.2.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
+    "prettier": "^3.8.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.1.0"
   }

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -5,24 +5,53 @@
 ### PostsService (`src/posts/post.service.spec.ts`)
 
 #### findAll
+
 - [x] ページ1・perPage5 で skip=0 / take=5 を渡す
 - [x] ページ3・perPage5 で skip=10 を渡す
 - [x] items と total を返す
 
+#### findById
+
+- [x] petDetail と location と images を include して取得する
+
 #### create
+
 - [x] ファイルなしで投稿を作成する
-- [x] ファイルありで投稿を作成する時、imagePathが設定されること
+- [x] ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
 - [x] アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
+- [x] 画像が5枚超の場合 BadRequestException をスローする
+- [x] petDetail と location を含む時、トランザクションで一括作成する
+- [x] lostDate を指定して作成できる
+
+#### addImages
+
+- [x] 画像を追加できる
+- [x] オーナー以外は ForbiddenException
+- [x] 存在しない投稿は NotFoundException
+- [x] 5枚超になる場合は BadRequestException
+
+#### removeImage
+
+- [x] オーナーが画像を削除できる
+- [x] ファイルが存在しない場合 unlinkSync を呼ばない
+- [x] オーナー以外は ForbiddenException
+- [x] 存在しない投稿は NotFoundException
+- [x] 別の投稿に属する画像は NotFoundException
 
 #### update
+
 - [x] オーナーが更新できる
 - [x] オーナー以外は ForbiddenException
 - [x] 存在しない投稿は HttpException (404)
-- [x] ファイルありかつ既存画像がある時、古い画像ファイルが削除されること
-- [x] ファイルありかつ既存画像がない時、unlinkSyncを呼ばないこと
+- [x] lostDate を更新できる
+- [x] status を更新できる
+- [x] petDetail を upsert できる
+- [x] location を upsert できる
 
 #### remove
+
 - [x] オーナーが削除できる
+- [x] 画像ファイルも削除する
 - [x] オーナー以外は ForbiddenException
 - [x] 存在しない投稿は HttpException (404)
 
@@ -31,30 +60,52 @@
 ### PostsController (`src/posts/post.controller.spec.ts`)
 
 #### list
+
 - [x] デフォルト（page=1, perPage=10）で findAll を呼ぶ
 - [x] 文字列クエリを数値に変換して渡す
 - [x] 不正な文字列は 1 / 10 にフォールバックする
 - [x] items と total を返す
 
 #### get
+
 - [x] 指定 ID の投稿を返す
 
 #### create
-- [x] req.user.id を authorId として投稿を作成する
+
+- [x] dto と files をサービスに渡す
 - [x] ファイル付きで作成できる
+- [x] files が undefined の時は空配列を渡す
+- [x] petDetail と location を含む dto をサービスに渡す
 
 #### update
+
 - [x] オーナーが更新できる
 - [x] オーナー以外は ForbiddenException を伝播する
 - [x] 存在しない投稿は HttpException を伝播する
+- [x] petDetail と location を含む dto をサービスに渡す
+
+#### addImages
+
+- [x] 画像を追加できる
+- [x] files が undefined の時は空配列を渡す
+- [x] オーナー以外は ForbiddenException を伝播する
+- [x] 枚数超過は BadRequestException を伝播する
+
+#### removeImage
+
+- [x] オーナーが画像を削除できる
+- [x] オーナー以外は ForbiddenException を伝播する
+- [x] 存在しない画像は NotFoundException を伝播する
 
 #### imageFileFilter
+
 - [x] fileがnullの時、cb(null, false)を呼ぶこと
 - [x] originalnameがない時、cb(null, false)を呼ぶこと
 - [x] 許可されたMIMEタイプの時、cb(null, true)を呼ぶこと
 - [x] 許可されていないMIMEタイプの時、BadRequestExceptionを渡すこと
 
 #### remove
+
 - [x] オーナーが削除できる
 - [x] オーナー以外は ForbiddenException を伝播する
 - [x] 存在しない投稿は HttpException を伝播する

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -11,18 +11,37 @@ apps/api/src/
 │   │   │   ├── ページ1・perPage5 で skip=0 / take=5 を渡す
 │   │   │   ├── ページ3・perPage5 で skip=10 を渡す
 │   │   │   └── items と total を返す
+│   │   ├── findById
+│   │   │   └── petDetail と location と images を include して取得する
 │   │   ├── create
 │   │   │   ├── ファイルなしで投稿を作成する
-│   │   │   ├── ファイルありで投稿を作成する時、imagePathが設定されること
-│   │   │   └── アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
+│   │   │   ├── ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
+│   │   │   ├── アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
+│   │   │   ├── 画像が5枚超の場合 BadRequestException をスローする
+│   │   │   ├── petDetail と location を含む時、トランザクションで一括作成する
+│   │   │   └── lostDate を指定して作成できる
+│   │   ├── addImages
+│   │   │   ├── 画像を追加できる
+│   │   │   ├── オーナー以外は ForbiddenException
+│   │   │   ├── 存在しない投稿は NotFoundException
+│   │   │   └── 5枚超になる場合は BadRequestException
+│   │   ├── removeImage
+│   │   │   ├── オーナーが画像を削除できる
+│   │   │   ├── ファイルが存在しない場合 unlinkSync を呼ばない
+│   │   │   ├── オーナー以外は ForbiddenException
+│   │   │   ├── 存在しない投稿は NotFoundException
+│   │   │   └── 別の投稿に属する画像は NotFoundException
 │   │   ├── update
 │   │   │   ├── オーナーが更新できる
 │   │   │   ├── オーナー以外は ForbiddenException
 │   │   │   ├── 存在しない投稿は HttpException (404)
-│   │   │   ├── ファイルありかつ既存画像がある時、古い画像ファイルが削除されること
-│   │   │   └── ファイルありかつ既存画像がない時、unlinkSyncを呼ばないこと
+│   │   │   ├── lostDate を更新できる
+│   │   │   ├── status を更新できる
+│   │   │   ├── petDetail を upsert できる
+│   │   │   └── location を upsert できる
 │   │   └── remove
 │   │       ├── オーナーが削除できる
+│   │       ├── 画像ファイルも削除する
 │   │       ├── オーナー以外は ForbiddenException
 │   │       └── 存在しない投稿は HttpException (404)
 │   └── post.controller.spec.ts
@@ -34,12 +53,24 @@ apps/api/src/
 │       ├── get
 │       │   └── 指定 ID の投稿を返す
 │       ├── create
-│       │   ├── req.user.id を authorId として投稿を作成する
-│       │   └── ファイル付きで作成できる
+│       │   ├── dto と files をサービスに渡す
+│       │   ├── ファイル付きで作成できる
+│       │   ├── files が undefined の時は空配列を渡す
+│       │   └── petDetail と location を含む dto をサービスに渡す
 │       ├── update
 │       │   ├── オーナーが更新できる
 │       │   ├── オーナー以外は ForbiddenException を伝播する
-│       │   └── 存在しない投稿は HttpException を伝播する
+│       │   ├── 存在しない投稿は HttpException を伝播する
+│       │   └── petDetail と location を含む dto をサービスに渡す
+│       ├── addImages
+│       │   ├── 画像を追加できる
+│       │   ├── files が undefined の時は空配列を渡す
+│       │   ├── オーナー以外は ForbiddenException を伝播する
+│       │   └── 枚数超過は BadRequestException を伝播する
+│       ├── removeImage
+│       │   ├── オーナーが画像を削除できる
+│       │   ├── オーナー以外は ForbiddenException を伝播する
+│       │   └── 存在しない画像は NotFoundException を伝播する
 │       ├── imageFileFilter
 │       │   ├── fileがnullの時、cb(null, false)を呼ぶこと
 │       │   ├── originalnameがない時、cb(null, false)を呼ぶこと


### PR DESCRIPTION
## Summary

- Prismaスキーマを迷い猫アプリ用に全面更新（Post/PetDetail/Location/Image/Sighting/Conversation等）
- Post CRUD: `POST /posts`・`GET /posts`・`GET /posts/:id`・`PATCH /posts/:id`・`DELETE /posts/:id` を実装
- 複数画像対応: `POST /posts/:id/images`（最大5枚）・`DELETE /posts/:id/images/:imageId`
- User.name → nickname 必須に変更
- `parseJsonField` ユーティリティを `src/utils/transform.ts` に切り出し

## Acceptance criteria

- [x] `POST /posts` で Post / PetDetail / Location が1トランザクションで作成される
- [x] `GET /posts` で投稿一覧が取得できる（ゲスト可）
- [x] `GET /posts/:id` で投稿詳細が取得できる（ゲスト可）
- [x] `PATCH /posts/:id` で title / description / lostDate / status / PetDetail / Location が更新できる
- [x] `DELETE /posts/:id` で Post と関連レコードがカスケード削除される
- [x] DTO / service / controller / tests が揃っている

## Test plan

- 全82テストパス（`npm run test`）
- 型エラーなし（`npm run typecheck:api`）
- カバレッジ閾値80%維持

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)