### PR TITLE
feat: improve image processing with error handling

### DIFF
--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -366,6 +366,13 @@ describe("PostsService", () => {
     });
 
     it("トランザクション失敗時に保存済みファイルを削除する", async () => {
+      const sharpMock = jest.requireMock("sharp") as jest.Mock;
+      sharpMock.mockReturnValue({
+        resize: jest.fn().mockReturnThis(),
+        jpeg: jest.fn().mockReturnThis(),
+        toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed-image")),
+      });
+
       mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
       // 1枚目は保存成功、2枚目でエラー
       mockFs.writeFileSync
@@ -376,8 +383,8 @@ describe("PostsService", () => {
       mockPrisma.image.create.mockResolvedValue({});
 
       const files = [
-        { originalname: "a.png", buffer: Buffer.from("") } as any,
-        { originalname: "b.png", buffer: Buffer.from("") } as any,
+        { originalname: "a.png", buffer: Buffer.from("raw") } as any,
+        { originalname: "b.png", buffer: Buffer.from("raw") } as any,
       ];
 
       await expect(

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -771,5 +771,23 @@ describe("PostsService", () => {
         HttpException
       );
     });
+
+    it("画像処理でSharpエラーが発生した場合 BadRequestException をスローする", async () => {
+      const sharpMock = jest.requireMock("sharp") as jest.Mock;
+      sharpMock.mockImplementation(() => {
+        throw new Error("Sharp processing failed");
+      });
+
+      const rawBuf = Buffer.from("raw");
+      const files = [{ originalname: "photo.png", buffer: rawBuf } as any];
+
+      await expect(
+        service.create(
+          "u1",
+          { description: "C", lostDate: "2024-01-01" },
+          files
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -366,13 +366,6 @@ describe("PostsService", () => {
     });
 
     it("トランザクション失敗時に保存済みファイルを削除する", async () => {
-      const sharpMock = jest.requireMock("sharp") as jest.Mock;
-      sharpMock.mockReturnValue({
-        resize: jest.fn().mockReturnThis(),
-        jpeg: jest.fn().mockReturnThis(),
-        toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed-image")),
-      });
-
       mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
       // 1枚目は保存成功、2枚目でエラー
       mockFs.writeFileSync

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -29,19 +29,23 @@ export class PostsService {
     if (!fs.existsSync(uploadDir)) {
       fs.mkdirSync(uploadDir, { recursive: true });
     }
+
+    let processedBuffer: Buffer;
     try {
-      const processedBuffer = await sharp(file.buffer)
+      processedBuffer = await sharp(file.buffer)
         .resize({ width: 1200, withoutEnlargement: true })
         .jpeg({ quality: 80 })
         .toBuffer();
-      const fileName = `${uuidv4()}.jpg`;
-      fs.writeFileSync(path.join(uploadDir, fileName), processedBuffer);
-      return `uploads/${postId}/${fileName}`;
-    } catch (error) {
+    } catch (err) {
       throw new BadRequestException(
         "画像処理に失敗しました。ファイルが破損または無効な形式です。"
       );
     }
+
+    const fileName = `${uuidv4()}.jpg`;
+    // 書き込みエラー（例: disk full）はここでそのまま例外として伝播させる
+    fs.writeFileSync(path.join(uploadDir, fileName), processedBuffer);
+    return `uploads/${postId}/${fileName}`;
   }
 
   private deleteFile(url: string): void {

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -29,13 +29,19 @@ export class PostsService {
     if (!fs.existsSync(uploadDir)) {
       fs.mkdirSync(uploadDir, { recursive: true });
     }
-    const processedBuffer = await sharp(file.buffer)
-      .resize({ width: 1200, withoutEnlargement: true })
-      .jpeg({ quality: 80 })
-      .toBuffer();
-    const fileName = `${uuidv4()}.jpg`;
-    fs.writeFileSync(path.join(uploadDir, fileName), processedBuffer);
-    return `uploads/${postId}/${fileName}`;
+    try {
+      const processedBuffer = await sharp(file.buffer)
+        .resize({ width: 1200, withoutEnlargement: true })
+        .jpeg({ quality: 80 })
+        .toBuffer();
+      const fileName = `${uuidv4()}.jpg`;
+      fs.writeFileSync(path.join(uploadDir, fileName), processedBuffer);
+      return `uploads/${postId}/${fileName}`;
+    } catch (error) {
+      throw new BadRequestException(
+        "画像処理に失敗しました。ファイルが破損または無効な形式です。"
+      );
+    }
   }
 
   private deleteFile(url: string): void {

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -20,6 +20,7 @@
 - [x] ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
 - [x] アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
 - [x] 画像が sharp でリサイズ・JPEG変換されること
+- [x] 画像処理でSharpエラーが発生した場合 BadRequestException をスローする
 - [x] lostDate なしは BadRequestException をスローする
 - [x] 画像が5枚超の場合 BadRequestException をスローする
 - [x] petDetail と location を含む時、トランザクションで一括作成する

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -18,6 +18,7 @@ apps/api/src/
 │   │   │   ├── ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
 │   │   │   ├── アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
 │   │   │   ├── 画像が sharp でリサイズ・JPEG変換されること
+│   │   │   ├── 画像処理でSharpエラーが発生した場合 BadRequestException をスローする
 │   │   │   ├── 画像が5枚超の場合 BadRequestException をスローする
 │   │   │   ├── petDetail と location を含む時、トランザクションで一括作成する
 │   │   │   └── lostDate を指定して作成できる


### PR DESCRIPTION
## Summary
- Sharpライブラリで画像リサイズ・JPEG変換を実装（既存コミット）。
- エラーハンドリングを追加し、破損画像時のBadRequestExceptionをスロー。
- テストを更新し、エラーケースをカバー。

## Changes
- apps/api/src/posts/post.service.ts: saveFileメソッドにtry-catch追加。
- apps/api/src/posts/post.service.spec.ts: Sharpエラーケースのテスト追加。
- tests/TESTS.md, tests/TESTS_TREE.md: テスト一覧更新。