### PR TITLE
feat: Sighting CRUD（作成・一覧・削除）APIを実装

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { UsersModule } from "./users/user.module";
 import { PostsModule } from "./posts/post.module";
 import { AuthModule } from "./auth/auth.module";
 import { MapModule } from "./map/map.module";
+import { SightingsModule } from "./sightings/sighting.module";
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { MapModule } from "./map/map.module";
     PostsModule,
     AuthModule,
     MapModule,
+    SightingsModule,
   ],
   providers: [PrismaService],
 })

--- a/apps/api/src/sightings/dto/create-sighting.dto.ts
+++ b/apps/api/src/sightings/dto/create-sighting.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsDateString, IsNumber, IsOptional, IsString } from "class-validator";
+
+export class CreateSightingDto {
+  @ApiProperty() @IsString() postId: string;
+  @ApiProperty() @IsNumber() lat: number;
+  @ApiProperty() @IsNumber() lng: number;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() address?: string;
+  @ApiProperty() @IsDateString() sightedAt: string;
+  @ApiProperty({ required: false }) @IsOptional() @IsString() comment?: string;
+}

--- a/apps/api/src/sightings/sighting.controller.ts
+++ b/apps/api/src/sightings/sighting.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { CreateSightingDto } from "./dto/create-sighting.dto";
+import { SightingsService } from "./sighting.service";
+
+@ApiTags("sightings")
+@Controller("sightings")
+export class SightingsController {
+  constructor(private readonly sightingsService: SightingsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "目撃情報を作成する" })
+  create(
+    @Request() req: { user: { userId: string } },
+    @Body() dto: CreateSightingDto
+  ) {
+    return this.sightingsService.create(req.user.userId, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: "postId別の目撃情報一覧を取得する" })
+  @ApiQuery({ name: "postId", required: true })
+  findByPost(@Query("postId") postId: string) {
+    return this.sightingsService.findByPost(postId);
+  }
+
+  @Delete(":id")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "目撃情報を削除する（本人のみ）" })
+  @ApiResponse({ status: 204 })
+  remove(
+    @Request() req: { user: { userId: string } },
+    @Param("id") id: string
+  ) {
+    return this.sightingsService.remove(req.user.userId, id);
+  }
+}

--- a/apps/api/src/sightings/sighting.module.ts
+++ b/apps/api/src/sightings/sighting.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../prisma.service";
+import { SightingsController } from "./sighting.controller";
+import { SightingsService } from "./sighting.service";
+
+@Module({
+  controllers: [SightingsController],
+  providers: [SightingsService, PrismaService],
+})
+export class SightingsModule {}

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -1,0 +1,128 @@
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
+import { SightingsService } from "./sighting.service";
+
+const mockPrisma = {
+  post: { findUnique: jest.fn() },
+  sighting: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
+describe("SightingsService", () => {
+  let service: SightingsService;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service = new SightingsService(mockPrisma as any);
+    jest.clearAllMocks();
+  });
+
+  // ─── create ────────────────────────────────────────────────
+  describe("create", () => {
+    const dto = {
+      postId: "post-1",
+      lat: 35.9,
+      lng: 139.6,
+      sightedAt: "2026-04-19T10:00:00.000Z",
+    };
+
+    it("有効なデータでSightingを作成できること", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post-1",
+        userId: "owner-1",
+      });
+      mockPrisma.sighting.create.mockResolvedValue({ id: "s-1", ...dto });
+
+      const result = await service.create("other-user", dto);
+
+      expect(mockPrisma.sighting.create).toHaveBeenCalledWith({
+        data: {
+          postId: "post-1",
+          userId: "other-user",
+          lat: 35.9,
+          lng: 139.6,
+          address: undefined,
+          sightedAt: new Date("2026-04-19T10:00:00.000Z"),
+          comment: undefined,
+        },
+      });
+      expect(result).toMatchObject({ id: "s-1" });
+    });
+
+    it("投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post-1",
+        userId: "owner-1",
+      });
+
+      await expect(service.create("owner-1", dto)).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("存在しないPostにSightingを作成しようとすると NotFoundException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(null);
+
+      await expect(service.create("other-user", dto)).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  // ─── findByPost ─────────────────────────────────────────────
+  describe("findByPost", () => {
+    it("postIdに紐づくSighting一覧をcreatedAt降順で返すこと", async () => {
+      const sightings = [
+        { id: "s-2", postId: "post-1" },
+        { id: "s-1", postId: "post-1" },
+      ];
+      mockPrisma.sighting.findMany.mockResolvedValue(sightings);
+
+      const result = await service.findByPost("post-1");
+
+      expect(mockPrisma.sighting.findMany).toHaveBeenCalledWith({
+        where: { postId: "post-1" },
+        orderBy: { createdAt: "desc" },
+      });
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // ─── remove ─────────────────────────────────────────────────
+  describe("remove", () => {
+    it("本人がSightingを削除できること", async () => {
+      mockPrisma.sighting.findUnique.mockResolvedValue({
+        id: "s-1",
+        userId: "user-1",
+      });
+
+      await service.remove("user-1", "s-1");
+
+      expect(mockPrisma.sighting.delete).toHaveBeenCalledWith({
+        where: { id: "s-1" },
+      });
+    });
+
+    it("他者が削除しようとすると ForbiddenException", async () => {
+      mockPrisma.sighting.findUnique.mockResolvedValue({
+        id: "s-1",
+        userId: "user-1",
+      });
+
+      await expect(service.remove("other-user", "s-1")).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("存在しないSightingを削除しようとすると NotFoundException", async () => {
+      mockPrisma.sighting.findUnique.mockResolvedValue(null);
+
+      await expect(service.remove("user-1", "s-1")).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+});

--- a/apps/api/src/sightings/sighting.service.ts
+++ b/apps/api/src/sightings/sighting.service.ts
@@ -1,0 +1,49 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { PrismaService } from "../prisma.service";
+import { CreateSightingDto } from "./dto/create-sighting.dto";
+
+@Injectable()
+export class SightingsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(userId: string, dto: CreateSightingDto) {
+    const post = await this.prisma.post.findUnique({
+      where: { id: dto.postId },
+    });
+    if (!post) throw new NotFoundException("Post not found");
+    if (post.userId === userId)
+      throw new ForbiddenException("投稿者本人はSightingを作成できません");
+
+    return this.prisma.sighting.create({
+      data: {
+        postId: dto.postId,
+        userId,
+        lat: dto.lat,
+        lng: dto.lng,
+        address: dto.address,
+        sightedAt: new Date(dto.sightedAt),
+        comment: dto.comment,
+      },
+    });
+  }
+
+  async findByPost(postId: string) {
+    return this.prisma.sighting.findMany({
+      where: { postId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async remove(userId: string, id: string) {
+    const sighting = await this.prisma.sighting.findUnique({ where: { id } });
+    if (!sighting) throw new NotFoundException("Sighting not found");
+    if (sighting.userId !== userId)
+      throw new ForbiddenException("削除できるのは本人のみです");
+
+    await this.prisma.sighting.delete({ where: { id } });
+  }
+}

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -118,6 +118,26 @@
 
 ---
 
+### SightingsService (`src/sightings/sighting.service.spec.ts`)
+
+#### create
+
+- [x] 有効なデータでSightingを作成できること
+- [x] 投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException
+- [x] 存在しないPostにSightingを作成しようとすると NotFoundException
+
+#### findByPost
+
+- [x] postIdに紐づくSighting一覧をcreatedAt降順で返すこと
+
+#### remove
+
+- [x] 本人がSightingを削除できること
+- [x] 他者が削除しようとすると ForbiddenException
+- [x] 存在しないSightingを削除しようとすると NotFoundException
+
+---
+
 ### AuthService (`src/auth/auth.service.spec.ts`)
 
 （既存テスト・詳細省略）

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -82,6 +82,18 @@ apps/api/src/
 │           ├── オーナーが削除できる
 │           ├── オーナー以外は ForbiddenException を伝播する
 │           └── 存在しない投稿は HttpException を伝播する
+├── sightings/
+│   └── sighting.service.spec.ts
+│       ├── create
+│       │   ├── 有効なデータでSightingを作成できること
+│       │   ├── 投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException
+│       │   └── 存在しないPostにSightingを作成しようとすると NotFoundException
+│       ├── findByPost
+│       │   └── postIdに紐づくSighting一覧をcreatedAt降順で返すこと
+│       └── remove
+│           ├── 本人がSightingを削除できること
+│           ├── 他者が削除しようとすると ForbiddenException
+│           └── 存在しないSightingを削除しようとすると NotFoundException
 └── users/
     └── user.service.spec.ts
         └── UserService（既存）


### PR DESCRIPTION
## Summary

- `POST /sightings` — Sighting作成（ログイン必須、投稿者本人は403）
- `GET /sightings?postId=` — Post別一覧取得（ゲスト可）
- `DELETE /sightings/:id` — Sighting削除（本人のみ、他者は403）

## テスト確認結果

- 97テスト全通過
- カバレッジ: Stmts 98.21% / Branch 85.09% / Funcs 86.95% / Lines 98.07%（全項目80%超）
- 型エラーなし

## Test plan

- [x] 有効なデータでSightingを作成できること
- [x] 投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException
- [x] 存在しないPostにSightingを作成しようとすると NotFoundException
- [x] postIdに紐づくSighting一覧をcreatedAt降順で返すこと
- [x] 本人がSightingを削除できること
- [x] 他者が削除しようとすると ForbiddenException
- [x] 存在しないSightingを削除しようとすると NotFoundException

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)