### PR TITLE
feat: 地図マーカーAPI更新（Post + Sighting 統合）

### DIFF
--- a/apps/api/src/map/dto/get-markers-query.dto.ts
+++ b/apps/api/src/map/dto/get-markers-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsEnum, IsNumber, IsOptional } from "class-validator";
+import { IsIn, IsNumber, IsOptional } from "class-validator";
 
 export class GetMarkersQueryDto {
   @ApiPropertyOptional()
@@ -29,6 +29,6 @@ export class GetMarkersQueryDto {
 
   @ApiPropertyOptional({ enum: ["lost", "resolved"] })
   @IsOptional()
-  @IsEnum(["lost", "resolved"])
+  @IsIn(["lost", "resolved"])
   status?: "lost" | "resolved";
 }

--- a/apps/api/src/map/dto/get-markers-query.dto.ts
+++ b/apps/api/src/map/dto/get-markers-query.dto.ts
@@ -1,0 +1,34 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsEnum, IsNumber, IsOptional } from "class-validator";
+
+export class GetMarkersQueryDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  minLat?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  maxLat?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  minLng?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  maxLng?: number;
+
+  @ApiPropertyOptional({ enum: ["lost", "resolved"] })
+  @IsOptional()
+  @IsEnum(["lost", "resolved"])
+  status?: "lost" | "resolved";
+}

--- a/apps/api/src/map/dto/marker-response.dto.ts
+++ b/apps/api/src/map/dto/marker-response.dto.ts
@@ -8,7 +8,7 @@ export class MapMarkerDto {
   @ApiProperty({ required: false }) postId?: string;
   @ApiProperty() lat: number;
   @ApiProperty() lng: number;
-  @ApiProperty({ enum: ["lost", "resolved"] }) status: string;
+  @ApiProperty({ enum: ["lost", "resolved"] }) status: "lost" | "resolved";
 }
 
 /** @deprecated 後方互換のためのエイリアス */

--- a/apps/api/src/map/dto/marker-response.dto.ts
+++ b/apps/api/src/map/dto/marker-response.dto.ts
@@ -1,9 +1,15 @@
 import { ApiProperty } from "@nestjs/swagger";
 
-export class MarkerDto {
+export type MarkerType = "post" | "sighting";
+
+export class MapMarkerDto {
+  @ApiProperty({ enum: ["post", "sighting"] }) type: MarkerType;
+  @ApiProperty() id: string;
+  @ApiProperty({ required: false }) postId?: string;
   @ApiProperty() lat: number;
   @ApiProperty() lng: number;
-  @ApiProperty() title: string;
-  @ApiProperty() description: string;
-  @ApiProperty({ required: false }) imageUrl?: string;
+  @ApiProperty({ enum: ["lost", "resolved"] }) status: string;
 }
+
+/** @deprecated 後方互換のためのエイリアス */
+export class MarkerDto extends MapMarkerDto {}

--- a/apps/api/src/map/map.controller.ts
+++ b/apps/api/src/map/map.controller.ts
@@ -1,19 +1,17 @@
-import { Controller, Get, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth, ApiResponse, ApiTags } from "@nestjs/swagger";
-import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { Controller, Get, Query } from "@nestjs/common";
+import { ApiResponse, ApiTags } from "@nestjs/swagger";
+import { GetMarkersQueryDto } from "./dto/get-markers-query.dto";
+import { MapMarkerDto } from "./dto/marker-response.dto";
 import { MapService } from "./map.service";
-import { MarkerDto } from "./dto/marker-response.dto";
 
 @ApiTags("map")
-@ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller("map")
 export class MapController {
   constructor(private readonly mapService: MapService) {}
 
   @Get("markers")
-  @ApiResponse({ status: 200, type: MarkerDto, isArray: true })
-  getMarkers(): MarkerDto[] {
-    return this.mapService.getMarkers();
+  @ApiResponse({ status: 200, type: MapMarkerDto, isArray: true })
+  getMarkers(@Query() query: GetMarkersQueryDto): Promise<MapMarkerDto[]> {
+    return this.mapService.getMarkers(query);
   }
 }

--- a/apps/api/src/map/map.module.ts
+++ b/apps/api/src/map/map.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
+import { PrismaService } from "../prisma.service";
 import { MapController } from "./map.controller";
 import { MapService } from "./map.service";
 
 @Module({
   controllers: [MapController],
-  providers: [MapService],
+  providers: [MapService, PrismaService],
 })
 export class MapModule {}

--- a/apps/api/src/map/map.service.spec.ts
+++ b/apps/api/src/map/map.service.spec.ts
@@ -1,0 +1,150 @@
+import { MapService } from "./map.service";
+
+const mockPrisma = {
+  post: {
+    findMany: jest.fn(),
+  },
+  sighting: {
+    findMany: jest.fn(),
+  },
+};
+
+describe("MapService", () => {
+  let service: MapService;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service = new MapService(mockPrisma as any);
+    jest.clearAllMocks();
+  });
+
+  describe("getMarkers", () => {
+    it("bbox内のPostマーカーが type='post' で返ること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([
+        { id: "post-1", status: "lost", location: { lat: 35.9, lng: 139.6 } },
+      ]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      const result = await service.getMarkers({
+        minLat: 35.0,
+        maxLat: 36.0,
+        minLng: 139.0,
+        maxLng: 140.0,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: "post",
+        id: "post-1",
+        lat: 35.9,
+        lng: 139.6,
+        status: "lost",
+      });
+    });
+
+    it("bbox内のSightingマーカーが type='sighting' で返ること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([
+        {
+          id: "s-1",
+          postId: "post-1",
+          lat: 35.85,
+          lng: 139.55,
+          post: { status: "lost" },
+        },
+      ]);
+
+      const result = await service.getMarkers({
+        minLat: 35.0,
+        maxLat: 36.0,
+        minLng: 139.0,
+        maxLng: 140.0,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: "sighting",
+        id: "s-1",
+        postId: "post-1",
+        lat: 35.85,
+        lng: 139.55,
+        status: "lost",
+      });
+    });
+    it("statusフィルタ指定時にPostクエリのwhereにstatusが含まれること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      await service.getMarkers({ status: "lost" });
+
+      const postCall = mockPrisma.post.findMany.mock.calls[0][0];
+      expect(postCall.where.status).toBe("lost");
+    });
+
+    it("statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      await service.getMarkers({ status: "resolved" });
+
+      const sightingCall = mockPrisma.sighting.findMany.mock.calls[0][0];
+      expect(sightingCall.where.post).toEqual({ status: "resolved" });
+    });
+
+    it("bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      await service.getMarkers({
+        minLat: 35.0,
+        maxLat: 36.0,
+        minLng: 139.0,
+        maxLng: 140.0,
+      });
+
+      const postCall = mockPrisma.post.findMany.mock.calls[0][0];
+      expect(postCall.where.location).toMatchObject({
+        lat: { gte: 35.0, lte: 36.0 },
+        lng: { gte: 139.0, lte: 140.0 },
+      });
+    });
+
+    it("bboxクエリ条件がSightingのlat/lngフィルタとして渡ること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      await service.getMarkers({
+        minLat: 35.0,
+        maxLat: 36.0,
+        minLng: 139.0,
+        maxLng: 140.0,
+      });
+
+      const sightingCall = mockPrisma.sighting.findMany.mock.calls[0][0];
+      expect(sightingCall.where.lat).toMatchObject({ gte: 35.0, lte: 36.0 });
+      expect(sightingCall.where.lng).toMatchObject({ gte: 139.0, lte: 140.0 });
+    });
+
+    it("フィルタなしで全マーカー（Post+Sighting）が返ること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([
+        { id: "post-1", status: "lost", location: { lat: 35.9, lng: 139.6 } },
+      ]);
+      mockPrisma.sighting.findMany.mockResolvedValue([
+        {
+          id: "s-1",
+          postId: "post-1",
+          lat: 35.85,
+          lng: 139.55,
+          post: { status: "lost" },
+        },
+      ]);
+
+      const result = await service.getMarkers({});
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.type)).toEqual(
+        expect.arrayContaining(["post", "sighting"])
+      );
+    });
+  });
+});

--- a/apps/api/src/map/map.service.ts
+++ b/apps/api/src/map/map.service.ts
@@ -1,18 +1,89 @@
 import { Injectable } from "@nestjs/common";
-import { MarkerDto } from "./dto/marker-response.dto";
+import { PrismaService } from "../prisma.service";
+import { GetMarkersQueryDto } from "./dto/get-markers-query.dto";
+import { MapMarkerDto } from "./dto/marker-response.dto";
 
 @Injectable()
 export class MapService {
-  getMarkers(): MarkerDto[] {
-    return [
-      {
-        lat: 35.9062,
-        lng: 139.6236,
-        title: "大宮駅",
-        description:
-          "埼玉県さいたま市大宮区にあるJR東日本・東武鉄道の主要駅。新幹線（東北・上越・北陸）が停車し、埼玉県最大の交通拠点。",
-        imageUrl: "/omiya-station.jpg",
+  constructor(private prisma: PrismaService) {}
+
+  async getMarkers(query: GetMarkersQueryDto): Promise<MapMarkerDto[]> {
+    const { minLat, maxLat, minLng, maxLng, status } = query;
+
+    const bboxFilter = (latField: string, lngField: string) => {
+      const filter: Record<string, unknown> = {};
+      if (minLat !== undefined)
+        filter[latField] = {
+          ...((filter[latField] as object) ?? {}),
+          gte: minLat,
+        };
+      if (maxLat !== undefined)
+        filter[latField] = {
+          ...((filter[latField] as object) ?? {}),
+          lte: maxLat,
+        };
+      if (minLng !== undefined)
+        filter[lngField] = {
+          ...((filter[lngField] as object) ?? {}),
+          gte: minLng,
+        };
+      if (maxLng !== undefined)
+        filter[lngField] = {
+          ...((filter[lngField] as object) ?? {}),
+          lte: maxLng,
+        };
+      return filter;
+    };
+
+    const postWhere: Record<string, unknown> = {
+      location: { isNot: null, ...bboxFilter("lat", "lng") },
+    };
+    if (status) postWhere.status = status;
+
+    const posts = await this.prisma.post.findMany({
+      where: postWhere,
+      select: {
+        id: true,
+        status: true,
+        location: { select: { lat: true, lng: true } },
       },
-    ];
+    });
+
+    const sightingWhere: Record<string, unknown> = {
+      ...bboxFilter("lat", "lng"),
+    };
+    if (status) sightingWhere.post = { status };
+
+    const sightings = await this.prisma.sighting.findMany({
+      where: sightingWhere,
+      select: {
+        id: true,
+        postId: true,
+        lat: true,
+        lng: true,
+        post: { select: { status: true } },
+      },
+    });
+
+    const postMarkers: MapMarkerDto[] = posts
+      .filter((p) => p.location)
+      .map((p) => ({
+        type: "post",
+        id: p.id,
+        lat: p.location!.lat,
+        lng: p.location!.lng,
+        status: p.status,
+      }));
+
+    const sightingMarkers: MapMarkerDto[] = sightings.map((s) => ({
+      type: "sighting",
+      id: s.id,
+      postId: s.postId,
+      lat: s.lat,
+      lng: s.lng,
+      status: s.post.status,
+    }));
+
+    return [...postMarkers, ...sightingMarkers];
   }
 }

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -2,25 +2,35 @@ import { useEffect, useState } from "react";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
-import type { MarkerDto } from "../../../../packages/api-client/src/index";
+import type { MapMarkerDto } from "../../../../packages/api-client/src/index";
 import { useApiClient } from "../api/orvalClient";
 
-delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)._getIconUrl;
+delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)
+  ._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
-  iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  iconRetinaUrl:
+    "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
   shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
 });
 
 const DEFAULT_CENTER: [number, number] = [35.9062, 139.6236];
 
+const STATUS_LABEL: Record<string, string> = {
+  lost: "迷子",
+  resolved: "解決済み",
+};
+
 export default function Map() {
   const api = useApiClient();
-  const [markers, setMarkers] = useState<MarkerDto[]>([]);
+  const [markers, setMarkers] = useState<MapMarkerDto[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    api.getMapMarkers().then(setMarkers).catch(() => setError("マーカーデータの取得に失敗しました"));
+    api
+      .getMapMarkers()
+      .then(setMarkers)
+      .catch(() => setError("マーカーデータの取得に失敗しました"));
   }, [api]);
 
   if (error) return <p style={{ padding: 16, color: "red" }}>{error}</p>;
@@ -43,19 +53,12 @@ export default function Map() {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         {markers.map((m) => (
-          <Marker key={`${m.lat}-${m.lng}`} position={[m.lat, m.lng]}>
-            <Popup minWidth={220}>
-              <div style={{ textAlign: "center" }}>
-                <strong style={{ fontSize: "1.1em" }}>{m.title}</strong>
-                {m.imageUrl && (
-                  <img
-                    src={m.imageUrl}
-                    alt={m.title}
-                    style={{ display: "block", width: "100%", margin: "8px 0", borderRadius: 4 }}
-                  />
-                )}
-                <p style={{ margin: 0, fontSize: "0.85em", textAlign: "left", lineHeight: 1.5 }}>
-                  {m.description}
+          <Marker key={`${m.type}-${m.id}`} position={[m.lat, m.lng]}>
+            <Popup minWidth={180}>
+              <div>
+                <strong>{m.type === "post" ? "迷子投稿" : "目撃情報"}</strong>
+                <p style={{ margin: "4px 0 0", fontSize: "0.85em" }}>
+                  ステータス: {STATUS_LABEL[m.status] ?? m.status}
                 </p>
               </div>
             </Popup>

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -1,1 +1,641 @@
-{"openapi":"3.0.0","paths":{"/api/users/register":{"post":{"operationId":"UsersController_register","parameters":[],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/RegisterDto"}}}},"responses":{"201":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserResponseDto"}}}}},"tags":["users"]}},"/api/posts":{"post":{"operationId":"PostsController_create","parameters":[],"requestBody":{"required":true,"content":{"multipart/form-data":{"schema":{"type":"object","properties":{"title":{"type":"string"},"content":{"type":"string"},"image":{"type":"string","format":"binary"}}}}}},"responses":{"201":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}}},"tags":["posts"],"security":[{"bearer":[]}]},"get":{"operationId":"PostsController_list","parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostListResponseDto"}}}}},"tags":["posts"],"security":[{"bearer":[]}]}},"/api/posts/{id}":{"get":{"operationId":"PostsController_get","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}}},"tags":["posts"],"security":[{"bearer":[]}]},"put":{"operationId":"PostsController_update","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"requestBody":{"required":true,"content":{"multipart/form-data":{"schema":{"type":"object","properties":{"title":{"type":"string"},"content":{"type":"string"},"image":{"type":"string","format":"binary"}}}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}},"403":{"description":"Forbidden: not the post owner"}},"tags":["posts"],"security":[{"bearer":[]}]},"delete":{"operationId":"PostsController_remove","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}},"403":{"description":"Forbidden: not the post owner"}},"tags":["posts"],"security":[{"bearer":[]}]}},"/api/auth/login":{"post":{"operationId":"AuthController_login","parameters":[],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/LoginDto"}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AccessTokenResponseDto"}}}}},"tags":["auth"]}},"/api/auth/refresh":{"post":{"operationId":"AuthController_refresh","parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AccessTokenResponseDto"}}}}},"tags":["auth"]}},"/api/auth/logout":{"post":{"operationId":"AuthController_logout","parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/LogoutResponseDto"}}}}},"tags":["auth"]}}},"info":{"title":"API","description":"API description","version":"1.0","contact":{}},"tags":[],"servers":[],"components":{"securitySchemes":{"bearer":{"scheme":"bearer","bearerFormat":"JWT","type":"http"}},"schemas":{"RegisterDto":{"type":"object","properties":{"email":{"type":"string","example":"user@example.com"},"password":{"type":"string","example":"password123","minLength":8},"name":{"type":"string","example":"Alice"}},"required":["email","password"]},"UserResponseDto":{"type":"object","properties":{"id":{"type":"string"},"email":{"type":"string"},"name":{"type":"string","nullable":true},"createdAt":{"format":"date-time","type":"string"}},"required":["id","email","createdAt"]},"PostResponseDto":{"type":"object","properties":{"id":{"type":"string"},"title":{"type":"string"},"content":{"type":"string"},"image":{"type":"string","nullable":true},"authorId":{"type":"string"},"createdAt":{"format":"date-time","type":"string"}},"required":["id","title","content","authorId","createdAt"]},"PostListResponseDto":{"type":"object","properties":{"items":{"type":"array","items":{"$ref":"#/components/schemas/PostResponseDto"}},"total":{"type":"number"}},"required":["items","total"]},"LoginDto":{"type":"object","properties":{"email":{"type":"string","example":"user@example.com"},"password":{"type":"string","example":"password123","minLength":8}},"required":["email","password"]},"AccessTokenResponseDto":{"type":"object","properties":{"accessToken":{"type":"string"}},"required":["accessToken"]},"LogoutResponseDto":{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}}}}
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/users": {
+      "get": {
+        "operationId": "UsersController_findAll",
+        "parameters": [],
+        "responses": { "200": { "description": "" } },
+        "tags": ["users"]
+      }
+    },
+    "/api/users/register": {
+      "post": {
+        "operationId": "UsersController_register",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RegisterDto" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["users"]
+      }
+    },
+    "/api/posts": {
+      "post": {
+        "operationId": "PostsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string" },
+                  "description": { "type": "string" },
+                  "lostDate": { "type": "string" },
+                  "petDetail": {
+                    "type": "string",
+                    "description": "JSON string"
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "JSON string"
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": { "type": "string", "format": "binary" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "PostsController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostListResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/posts/{id}": {
+      "get": {
+        "operationId": "PostsController_get",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      },
+      "patch": {
+        "operationId": "PostsController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdatePostDto" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          },
+          "403": { "description": "Forbidden: not the post owner" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      },
+      "delete": {
+        "operationId": "PostsController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          },
+          "403": { "description": "Forbidden: not the post owner" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/posts/{id}/images": {
+      "post": {
+        "operationId": "PostsController_addImages",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "images": {
+                    "type": "array",
+                    "items": { "type": "string", "format": "binary" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddImagesResponseDto"
+                }
+              }
+            }
+          },
+          "400": { "description": "画像枚数上限超過" },
+          "403": { "description": "Forbidden: not the post owner" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/posts/{id}/images/{imageId}": {
+      "delete": {
+        "operationId": "PostsController_removeImage",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "imageId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ImageResponseDto" }
+              }
+            }
+          },
+          "403": { "description": "Forbidden: not the post owner" },
+          "404": { "description": "Image not found" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "operationId": "AuthController_login",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/LoginDto" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessTokenResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "operationId": "AuthController_refresh",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessTokenResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "operationId": "AuthController_logout",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LogoutResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/map/markers": {
+      "get": {
+        "operationId": "MapController_getMarkers",
+        "parameters": [
+          {
+            "name": "minLat",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "maxLat",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "minLng",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "maxLng",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "schema": { "enum": ["lost", "resolved"], "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/MapMarkerDto" }
+                }
+              }
+            }
+          }
+        },
+        "tags": ["map"]
+      }
+    },
+    "/api/sightings": {
+      "post": {
+        "operationId": "SightingsController_create",
+        "summary": "目撃情報を作成する",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateSightingDto" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "" } },
+        "tags": ["sightings"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "SightingsController_findByPost",
+        "summary": "postId別の目撃情報一覧を取得する",
+        "parameters": [
+          {
+            "name": "postId",
+            "required": true,
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "" } },
+        "tags": ["sightings"]
+      }
+    },
+    "/api/sightings/{id}": {
+      "delete": {
+        "operationId": "SightingsController_remove",
+        "summary": "目撃情報を削除する（本人のみ）",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "204": { "description": "" } },
+        "tags": ["sightings"],
+        "security": [{ "bearer": [] }]
+      }
+    }
+  },
+  "info": {
+    "title": "API",
+    "description": "API description",
+    "version": "1.0",
+    "contact": {}
+  },
+  "tags": [],
+  "servers": [],
+  "components": {
+    "securitySchemes": {
+      "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" }
+    },
+    "schemas": {
+      "RegisterDto": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string", "example": "user@example.com" },
+          "password": {
+            "type": "string",
+            "example": "password123",
+            "minLength": 8
+          },
+          "name": { "type": "string", "example": "Alice" }
+        },
+        "required": ["email", "password"]
+      },
+      "UserResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "email": { "type": "string" },
+          "nickname": { "type": "string" },
+          "createdAt": { "format": "date-time", "type": "string" }
+        },
+        "required": ["id", "email", "nickname", "createdAt"]
+      },
+      "PetDetailResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "color": { "type": "string" },
+          "age": { "type": "string" },
+          "features": { "type": "string" },
+          "gender": { "type": "string", "nullable": true },
+          "breed": { "type": "string", "nullable": true },
+          "size": { "type": "string", "nullable": true },
+          "collar": { "type": "string", "nullable": true },
+          "microchip": { "type": "boolean", "nullable": true },
+          "neutered": { "type": "boolean", "nullable": true }
+        },
+        "required": ["id", "name", "color", "age", "features"]
+      },
+      "LocationResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "prefecture": { "type": "string" },
+          "city": { "type": "string" },
+          "address": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" }
+        },
+        "required": ["id", "prefecture", "city", "address", "lat", "lng"]
+      },
+      "ImageResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "url": { "type": "string" },
+          "createdAt": { "format": "date-time", "type": "string" }
+        },
+        "required": ["id", "url", "createdAt"]
+      },
+      "PostResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string", "nullable": true },
+          "description": { "type": "string" },
+          "userId": { "type": "string" },
+          "status": { "type": "string" },
+          "lostDate": { "format": "date-time", "type": "string" },
+          "resolvedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "petDetail": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/PetDetailResponseDto" }]
+          },
+          "location": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/LocationResponseDto" }]
+          },
+          "images": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ImageResponseDto" }
+          },
+          "createdAt": { "format": "date-time", "type": "string" },
+          "updatedAt": { "format": "date-time", "type": "string" }
+        },
+        "required": [
+          "id",
+          "description",
+          "userId",
+          "status",
+          "lostDate",
+          "images",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "PostListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/PostResponseDto" }
+          },
+          "total": { "type": "number" }
+        },
+        "required": ["items", "total"]
+      },
+      "UpdatePetDetailDto": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "color": { "type": "string" },
+          "age": { "type": "string" },
+          "features": { "type": "string" },
+          "gender": { "type": "string", "enum": ["male", "female", "unknown"] },
+          "breed": { "type": "string" },
+          "size": { "type": "string" },
+          "collar": { "type": "string" },
+          "microchip": { "type": "boolean" },
+          "neutered": { "type": "boolean" }
+        }
+      },
+      "UpdateLocationDto": {
+        "type": "object",
+        "properties": {
+          "prefecture": { "type": "string", "enum": ["saitama"] },
+          "city": { "type": "string" },
+          "address": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" }
+        }
+      },
+      "UpdatePostDto": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "lostDate": { "type": "string", "example": "2024-01-01" },
+          "status": { "type": "string", "enum": ["lost", "resolved"] },
+          "petDetail": { "$ref": "#/components/schemas/UpdatePetDetailDto" },
+          "location": { "$ref": "#/components/schemas/UpdateLocationDto" }
+        }
+      },
+      "AddImagesResponseDto": {
+        "type": "object",
+        "properties": {
+          "remainingSlots": { "type": "number" },
+          "images": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ImageResponseDto" }
+          }
+        },
+        "required": ["remainingSlots", "images"]
+      },
+      "LoginDto": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string", "example": "user@example.com" },
+          "password": {
+            "type": "string",
+            "example": "password123",
+            "minLength": 8
+          }
+        },
+        "required": ["email", "password"]
+      },
+      "AccessTokenResponseDto": {
+        "type": "object",
+        "properties": { "accessToken": { "type": "string" } },
+        "required": ["accessToken"]
+      },
+      "LogoutResponseDto": {
+        "type": "object",
+        "properties": { "ok": { "type": "boolean" } },
+        "required": ["ok"]
+      },
+      "MapMarkerDto": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "enum": ["post", "sighting"] },
+          "id": { "type": "string" },
+          "postId": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" },
+          "status": { "type": "string", "enum": ["lost", "resolved"] }
+        },
+        "required": ["type", "id", "lat", "lng", "status"]
+      },
+      "CreateSightingDto": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" },
+          "address": { "type": "string" },
+          "sightedAt": { "type": "string" },
+          "comment": { "type": "string" }
+        },
+        "required": ["postId", "lat", "lng", "sightedAt"]
+      }
+    }
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -7,16 +7,77 @@
  */
 import axios from "axios";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
-export type PostsControllerUpdateBody = {
-  description?: string;
-  title?: string;
+export type SightingsControllerFindByPostParams = {
+  postId: string;
+};
+
+export type MapControllerGetMarkersStatus =
+  (typeof MapControllerGetMarkersStatus)[keyof typeof MapControllerGetMarkersStatus];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MapControllerGetMarkersStatus = {
+  lost: "lost",
+  resolved: "resolved",
+} as const;
+
+export type MapControllerGetMarkersParams = {
+  minLat?: number;
+  maxLat?: number;
+  minLng?: number;
+  maxLng?: number;
+  status?: MapControllerGetMarkersStatus;
+};
+
+export type PostsControllerAddImagesBody = {
+  images?: Blob[];
 };
 
 export type PostsControllerCreateBody = {
   description?: string;
+  images?: Blob[];
+  /** JSON string */
+  location?: string;
   lostDate?: string;
+  /** JSON string */
+  petDetail?: string;
   title?: string;
 };
+
+export interface CreateSightingDto {
+  address?: string;
+  comment?: string;
+  lat: number;
+  lng: number;
+  postId: string;
+  sightedAt: string;
+}
+
+export type MapMarkerDtoType =
+  (typeof MapMarkerDtoType)[keyof typeof MapMarkerDtoType];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MapMarkerDtoType = {
+  post: "post",
+  sighting: "sighting",
+} as const;
+
+export type MapMarkerDtoStatus =
+  (typeof MapMarkerDtoStatus)[keyof typeof MapMarkerDtoStatus];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MapMarkerDtoStatus = {
+  lost: "lost",
+  resolved: "resolved",
+} as const;
+
+export interface MapMarkerDto {
+  id: string;
+  lat: number;
+  lng: number;
+  postId?: string;
+  status: MapMarkerDtoStatus;
+  type: MapMarkerDtoType;
+}
 
 export interface LogoutResponseDto {
   ok: boolean;
@@ -32,14 +93,66 @@ export interface LoginDto {
   password: string;
 }
 
-export interface PostResponseDto {
-  createdAt: string;
-  description: string;
-  id: string;
-  lostDate: string;
-  /** @nullable */
-  title?: string | null;
-  userId: string;
+export interface AddImagesResponseDto {
+  images: ImageResponseDto[];
+  remainingSlots: number;
+}
+
+export type UpdatePostDtoStatus =
+  (typeof UpdatePostDtoStatus)[keyof typeof UpdatePostDtoStatus];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdatePostDtoStatus = {
+  lost: "lost",
+  resolved: "resolved",
+} as const;
+
+export interface UpdatePostDto {
+  description?: string;
+  location?: UpdateLocationDto;
+  lostDate?: string;
+  petDetail?: UpdatePetDetailDto;
+  status?: UpdatePostDtoStatus;
+  title?: string;
+}
+
+export type UpdateLocationDtoPrefecture =
+  (typeof UpdateLocationDtoPrefecture)[keyof typeof UpdateLocationDtoPrefecture];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdateLocationDtoPrefecture = {
+  saitama: "saitama",
+} as const;
+
+export interface UpdateLocationDto {
+  address?: string;
+  city?: string;
+  lat?: number;
+  lng?: number;
+  prefecture?: UpdateLocationDtoPrefecture;
+}
+
+export type UpdatePetDetailDtoGender =
+  (typeof UpdatePetDetailDtoGender)[keyof typeof UpdatePetDetailDtoGender];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdatePetDetailDtoGender = {
+  male: "male",
+  female: "female",
+  unknown: "unknown",
+} as const;
+
+export interface UpdatePetDetailDto {
+  age?: string;
+  breed?: string;
+  collar?: string;
+  color?: string;
+  features?: string;
+  gender?: UpdatePetDetailDtoGender;
+  microchip?: boolean;
+  name?: string;
+  neutered?: boolean;
+  size?: string;
 }
 
 export interface PostListResponseDto {
@@ -47,12 +160,75 @@ export interface PostListResponseDto {
   total: number;
 }
 
+/**
+ * @nullable
+ */
+export type PostResponseDtoPetDetail = PetDetailResponseDto | null;
+
+/**
+ * @nullable
+ */
+export type PostResponseDtoLocation = LocationResponseDto | null;
+
+export interface ImageResponseDto {
+  createdAt: string;
+  id: string;
+  url: string;
+}
+
+export interface PostResponseDto {
+  createdAt: string;
+  description: string;
+  id: string;
+  images: ImageResponseDto[];
+  /** @nullable */
+  location?: PostResponseDtoLocation;
+  lostDate: string;
+  /** @nullable */
+  petDetail?: PostResponseDtoPetDetail;
+  /** @nullable */
+  resolvedAt?: string | null;
+  status: string;
+  /** @nullable */
+  title?: string | null;
+  updatedAt: string;
+  userId: string;
+}
+
+export interface LocationResponseDto {
+  address: string;
+  city: string;
+  id: string;
+  lat: number;
+  lng: number;
+  prefecture: string;
+}
+
+export interface PetDetailResponseDto {
+  age: string;
+  /** @nullable */
+  breed?: string | null;
+  /** @nullable */
+  collar?: string | null;
+  color: string;
+  features: string;
+  /** @nullable */
+  gender?: string | null;
+  id: string;
+  /** @nullable */
+  microchip?: boolean | null;
+  name: string;
+  /** @nullable */
+  neutered?: boolean | null;
+  /** @nullable */
+  size?: string | null;
+}
+
 export interface UserResponseDto {
   createdAt: string;
   email: string;
   id: string;
-  /** @nullable */
-  name?: string | null;
+  nickname: string;
 }
 
 export interface RegisterDto {
@@ -61,6 +237,12 @@ export interface RegisterDto {
   /** @minLength 8 */
   password: string;
 }
+
+export const usersControllerFindAll = <TData = AxiosResponse<void>>(
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/users`, options);
+};
 
 export const usersControllerRegister = <TData = AxiosResponse<UserResponseDto>>(
   registerDto: RegisterDto,
@@ -83,6 +265,17 @@ export const postsControllerCreate = <TData = AxiosResponse<PostResponseDto>>(
   if (postsControllerCreateBody.lostDate !== undefined) {
     formData.append("lostDate", postsControllerCreateBody.lostDate);
   }
+  if (postsControllerCreateBody.petDetail !== undefined) {
+    formData.append("petDetail", postsControllerCreateBody.petDetail);
+  }
+  if (postsControllerCreateBody.location !== undefined) {
+    formData.append("location", postsControllerCreateBody.location);
+  }
+  if (postsControllerCreateBody.images !== undefined) {
+    postsControllerCreateBody.images.forEach((value) =>
+      formData.append("images", value)
+    );
+  }
 
   return axios.post(`/api/posts`, formData, options);
 };
@@ -102,18 +295,10 @@ export const postsControllerGet = <TData = AxiosResponse<PostResponseDto>>(
 
 export const postsControllerUpdate = <TData = AxiosResponse<PostResponseDto>>(
   id: string,
-  postsControllerUpdateBody: PostsControllerUpdateBody,
+  updatePostDto: UpdatePostDto,
   options?: AxiosRequestConfig
 ): Promise<TData> => {
-  const formData = new FormData();
-  if (postsControllerUpdateBody.title !== undefined) {
-    formData.append("title", postsControllerUpdateBody.title);
-  }
-  if (postsControllerUpdateBody.description !== undefined) {
-    formData.append("description", postsControllerUpdateBody.description);
-  }
-
-  return axios.put(`/api/posts/${id}`, formData, options);
+  return axios.patch(`/api/posts/${id}`, updatePostDto, options);
 };
 
 export const postsControllerRemove = <TData = AxiosResponse<PostResponseDto>>(
@@ -121,6 +306,33 @@ export const postsControllerRemove = <TData = AxiosResponse<PostResponseDto>>(
   options?: AxiosRequestConfig
 ): Promise<TData> => {
   return axios.delete(`/api/posts/${id}`, options);
+};
+
+export const postsControllerAddImages = <
+  TData = AxiosResponse<AddImagesResponseDto>,
+>(
+  id: string,
+  postsControllerAddImagesBody: PostsControllerAddImagesBody,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  const formData = new FormData();
+  if (postsControllerAddImagesBody.images !== undefined) {
+    postsControllerAddImagesBody.images.forEach((value) =>
+      formData.append("images", value)
+    );
+  }
+
+  return axios.post(`/api/posts/${id}/images`, formData, options);
+};
+
+export const postsControllerRemoveImage = <
+  TData = AxiosResponse<ImageResponseDto>,
+>(
+  id: string,
+  imageId: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.delete(`/api/posts/${id}/images/${imageId}`, options);
 };
 
 export const authControllerLogin = <
@@ -146,28 +358,63 @@ export const authControllerLogout = <TData = AxiosResponse<LogoutResponseDto>>(
   return axios.post(`/api/auth/logout`, undefined, options);
 };
 
+export const mapControllerGetMarkers = <TData = AxiosResponse<MapMarkerDto[]>>(
+  params?: MapControllerGetMarkersParams,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/map/markers`, {
+    ...options,
+    params: { ...params, ...options?.params },
+  });
+};
+
+/**
+ * @summary 目撃情報を作成する
+ */
+export const sightingsControllerCreate = <TData = AxiosResponse<void>>(
+  createSightingDto: CreateSightingDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/sightings`, createSightingDto, options);
+};
+
+/**
+ * @summary postId別の目撃情報一覧を取得する
+ */
+export const sightingsControllerFindByPost = <TData = AxiosResponse<void>>(
+  params: SightingsControllerFindByPostParams,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/sightings`, {
+    ...options,
+    params: { ...params, ...options?.params },
+  });
+};
+
+/**
+ * @summary 目撃情報を削除する（本人のみ）
+ */
+export const sightingsControllerRemove = <TData = AxiosResponse<void>>(
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.delete(`/api/sightings/${id}`, options);
+};
+
+export type UsersControllerFindAllResult = AxiosResponse<void>;
 export type UsersControllerRegisterResult = AxiosResponse<UserResponseDto>;
 export type PostsControllerCreateResult = AxiosResponse<PostResponseDto>;
 export type PostsControllerListResult = AxiosResponse<PostListResponseDto>;
 export type PostsControllerGetResult = AxiosResponse<PostResponseDto>;
 export type PostsControllerUpdateResult = AxiosResponse<PostResponseDto>;
 export type PostsControllerRemoveResult = AxiosResponse<PostResponseDto>;
+export type PostsControllerAddImagesResult =
+  AxiosResponse<AddImagesResponseDto>;
+export type PostsControllerRemoveImageResult = AxiosResponse<ImageResponseDto>;
 export type AuthControllerLoginResult = AxiosResponse<AccessTokenResponseDto>;
 export type AuthControllerRefreshResult = AxiosResponse<AccessTokenResponseDto>;
-
-export interface MarkerDto {
-  lat: number;
-  lng: number;
-  title: string;
-  description: string;
-  imageUrl?: string;
-}
-
-export const mapControllerGetMarkers = <TData = AxiosResponse<MarkerDto[]>>(
-  options?: AxiosRequestConfig
-): Promise<TData> => {
-  return axios.get(`/api/map/markers`, options);
-};
-
-export type MapControllerGetMarkersResult = AxiosResponse<MarkerDto[]>;
 export type AuthControllerLogoutResult = AxiosResponse<LogoutResponseDto>;
+export type MapControllerGetMarkersResult = AxiosResponse<MapMarkerDto[]>;
+export type SightingsControllerCreateResult = AxiosResponse<void>;
+export type SightingsControllerFindByPostResult = AxiosResponse<void>;
+export type SightingsControllerRemoveResult = AxiosResponse<void>;

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -138,6 +138,20 @@
 
 ---
 
+### MapService (`src/map/map.service.spec.ts`)
+
+#### getMarkers
+
+- [x] bbox内のPostマーカーが type='post' で返ること
+- [x] bbox内のSightingマーカーが type='sighting' で返ること
+- [x] statusフィルタ指定時にPostクエリのwhereにstatusが含まれること
+- [x] statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
+- [x] bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
+- [x] bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
+- [x] フィルタなしで全マーカー（Post+Sighting）が返ること
+
+---
+
 ### AuthService (`src/auth/auth.service.spec.ts`)
 
 （既存テスト・詳細省略）

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -82,6 +82,16 @@ apps/api/src/
 │           ├── オーナーが削除できる
 │           ├── オーナー以外は ForbiddenException を伝播する
 │           └── 存在しない投稿は HttpException を伝播する
+├── map/
+│   └── map.service.spec.ts
+│       └── getMarkers
+│           ├── bbox内のPostマーカーが type='post' で返ること
+│           ├── bbox内のSightingマーカーが type='sighting' で返ること
+│           ├── statusフィルタ指定時にPostクエリのwhereにstatusが含まれること
+│           ├── statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
+│           ├── bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
+│           ├── bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
+│           └── フィルタなしで全マーカー（Post+Sighting）が返ること
 ├── sightings/
 │   └── sighting.service.spec.ts
 │       ├── create


### PR DESCRIPTION
## Summary

- `GET /map/markers?minLat&maxLat&minLng&maxLng&status` で Post と Sighting の両マーカーを1本のエンドポイントで返す
- `type: 'post' | 'sighting'` フィールドでマーカー種別を区別
- bboxフィルタ（minLat/maxLat/minLng/maxLng）・statusフィルタ対応
- 認証ガードを除去（ゲスト可）
- PrismaService を MapModule に追加し DB から取得

## Test plan

- [x] bbox内のPostマーカーが type='post' で返ること
- [x] bbox内のSightingマーカーが type='sighting' で返ること
- [x] statusフィルタ指定時にPostクエリのwhereにstatusが含まれること
- [x] statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
- [x] bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
- [x] bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
- [x] フィルタなしで全マーカー（Post+Sighting）が返ること
- [x] 全テスト 104件 GREEN（既存テスト含む）

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)