### PR TITLE
feat: issue#10 Conversation + Message API（WebSocket リアルタイム）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/
 .playwright-mcp/
 .claude/
 CLAUDE.md
+apps/web/test-results/

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -56,7 +56,9 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.19",
+    "@nestjs/platform-socket.io": "^11.1.19",
     "@nestjs/swagger": "^7.4.2",
+    "@nestjs/websockets": "^11.1.19",
     "@prisma/client": "6.19.0",
     "bcrypt": "^4.0.1",
     "class-transformer": "^0.5.1",
@@ -68,6 +70,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "sharp": "^0.34.5",
+    "socket.io": "^4.8.3",
     "swagger-ui-express": "^4.1.6",
     "uuid": "^13.0.0"
   },

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { PostsModule } from "./posts/post.module";
 import { AuthModule } from "./auth/auth.module";
 import { MapModule } from "./map/map.module";
 import { SightingsModule } from "./sightings/sighting.module";
+import { ConversationsModule } from "./conversations/conversation.module";
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { SightingsModule } from "./sightings/sighting.module";
     AuthModule,
     MapModule,
     SightingsModule,
+    ConversationsModule,
   ],
   providers: [PrismaService],
 })

--- a/apps/api/src/conversations/conversation.controller.spec.ts
+++ b/apps/api/src/conversations/conversation.controller.spec.ts
@@ -1,0 +1,79 @@
+import { ConversationsController } from "./conversation.controller";
+
+const mockService = {
+  create: jest.fn(),
+  findAllForUser: jest.fn(),
+  createMessage: jest.fn(),
+  findMessages: jest.fn(),
+  markAsRead: jest.fn(),
+};
+
+const mockGateway = {
+  broadcastMessage: jest.fn(),
+};
+
+const req = { user: { userId: "user-1" } };
+
+describe("ConversationsController", () => {
+  let controller: ConversationsController;
+
+  beforeEach(() => {
+    controller = new ConversationsController(
+      mockService as never,
+      mockGateway as never
+    );
+    jest.clearAllMocks();
+  });
+
+  // ─── createMessage ──────────────────────────────────────────
+  describe("createMessage", () => {
+    it("メッセージ作成後にbroadcastMessageを呼び出すこと", async () => {
+      const message = {
+        id: "msg-1",
+        conversationId: "conv-1",
+        senderId: "user-1",
+        body: "hello",
+        createdAt: new Date(),
+        readAt: null,
+      };
+      mockService.createMessage.mockResolvedValue(message);
+
+      const result = await controller.createMessage(req, "conv-1", {
+        body: "hello",
+      });
+
+      expect(mockService.createMessage).toHaveBeenCalledWith(
+        "user-1",
+        "conv-1",
+        { body: "hello" }
+      );
+      expect(mockGateway.broadcastMessage).toHaveBeenCalledWith(
+        "conv-1",
+        message
+      );
+      expect(result).toBe(message);
+    });
+
+    it("サービスが例外を投げた場合はbroadcastMessageを呼ばないこと", async () => {
+      mockService.createMessage.mockRejectedValue(new Error("forbidden"));
+
+      await expect(
+        controller.createMessage(req, "conv-1", { body: "hello" })
+      ).rejects.toThrow("forbidden");
+
+      expect(mockGateway.broadcastMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── markAsRead ─────────────────────────────────────────────
+  describe("markAsRead", () => {
+    it("既読更新結果を返すこと", async () => {
+      mockService.markAsRead.mockResolvedValue({ count: 2 });
+
+      const result = await controller.markAsRead(req, "conv-1");
+
+      expect(mockService.markAsRead).toHaveBeenCalledWith("user-1", "conv-1");
+      expect(result).toEqual({ count: 2 });
+    });
+  });
+});

--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { CreateConversationDto } from "./dto/create-conversation.dto";
+import { CreateMessageDto } from "./dto/create-message.dto";
+import { ConversationsService } from "./conversation.service";
+import { ConversationsGateway } from "./conversations.gateway";
+
+@ApiTags("conversations")
+@Controller("conversations")
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class ConversationsController {
+  constructor(
+    private readonly conversationsService: ConversationsService,
+    private readonly conversationsGateway: ConversationsGateway
+  ) {}
+
+  @Post()
+  @ApiOperation({ summary: "会話を作成する" })
+  create(
+    @Request() req: { user: { userId: string } },
+    @Body() dto: CreateConversationDto
+  ) {
+    return this.conversationsService.create(req.user.userId, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: "自分が参加する会話一覧を取得する" })
+  findAll(@Request() req: { user: { userId: string } }) {
+    return this.conversationsService.findAllForUser(req.user.userId);
+  }
+
+  @Post(":id/messages")
+  @ApiOperation({ summary: "メッセージを送信する" })
+  async createMessage(
+    @Request() req: { user: { userId: string } },
+    @Param("id") id: string,
+    @Body() dto: CreateMessageDto
+  ) {
+    const message = await this.conversationsService.createMessage(
+      req.user.userId,
+      id,
+      dto
+    );
+    this.conversationsGateway.broadcastMessage(id, message);
+    return message;
+  }
+
+  @Get(":id/messages")
+  @ApiOperation({ summary: "メッセージ一覧を取得する" })
+  findMessages(
+    @Request() req: { user: { userId: string } },
+    @Param("id") id: string
+  ) {
+    return this.conversationsService.findMessages(req.user.userId, id);
+  }
+}

--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -2,7 +2,9 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
   Param,
+  Patch,
   Post,
   Request,
   UseGuards,
@@ -25,6 +27,7 @@ export class ConversationsController {
   ) {}
 
   @Post()
+  @HttpCode(201)
   @ApiOperation({ summary: "会話を作成する" })
   create(
     @Request() req: { user: { userId: string } },
@@ -62,5 +65,15 @@ export class ConversationsController {
     @Param("id") id: string
   ) {
     return this.conversationsService.findMessages(req.user.userId, id);
+  }
+
+  @Patch(":id/messages/read")
+  @HttpCode(200)
+  @ApiOperation({ summary: "会話内の未読メッセージを既読にする" })
+  markAsRead(
+    @Request() req: { user: { userId: string } },
+    @Param("id") id: string
+  ) {
+    return this.conversationsService.markAsRead(req.user.userId, id);
   }
 }

--- a/apps/api/src/conversations/conversation.module.ts
+++ b/apps/api/src/conversations/conversation.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../prisma.service";
+import { ConversationsController } from "./conversation.controller";
+import { ConversationsService } from "./conversation.service";
+import { ConversationsGateway } from "./conversations.gateway";
+
+@Module({
+  controllers: [ConversationsController],
+  providers: [ConversationsService, ConversationsGateway, PrismaService],
+})
+export class ConversationsModule {}

--- a/apps/api/src/conversations/conversation.module.ts
+++ b/apps/api/src/conversations/conversation.module.ts
@@ -1,10 +1,20 @@
 import { Module } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { JwtModule } from "@nestjs/jwt";
 import { PrismaService } from "../prisma.service";
 import { ConversationsController } from "./conversation.controller";
 import { ConversationsService } from "./conversation.service";
 import { ConversationsGateway } from "./conversations.gateway";
 
 @Module({
+  imports: [
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.getOrThrow<string>("JWT_SECRET"),
+      }),
+    }),
+  ],
   controllers: [ConversationsController],
   providers: [ConversationsService, ConversationsGateway, PrismaService],
 })

--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -1,0 +1,238 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from "@nestjs/common";
+import { ConversationsService } from "./conversation.service";
+
+const mockPrisma = {
+  post: { findUnique: jest.fn() },
+  sighting: { findUnique: jest.fn() },
+  conversation: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+  },
+  message: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    updateMany: jest.fn(),
+  },
+};
+
+describe("ConversationsService", () => {
+  let service: ConversationsService;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    service = new ConversationsService(mockPrisma as any);
+    jest.clearAllMocks();
+  });
+
+  // ─── create ────────────────────────────────────────────────
+  describe("create", () => {
+    const dto = { postId: "post-1", sightingId: "sighting-1" };
+
+    it("有効なデータで会話を作成できること", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post-1",
+        userId: "owner-1",
+      });
+      mockPrisma.sighting.findUnique.mockResolvedValue({
+        id: "sighting-1",
+        userId: "sighter-1",
+      });
+      mockPrisma.conversation.findUnique.mockResolvedValue(null);
+      mockPrisma.conversation.create.mockResolvedValue({
+        id: "conv-1",
+        postId: "post-1",
+        sightingId: "sighting-1",
+        ownerId: "owner-1",
+        sighterId: "sighter-1",
+      });
+
+      const result = await service.create("owner-1", dto);
+
+      expect(mockPrisma.conversation.create).toHaveBeenCalledWith({
+        data: {
+          postId: "post-1",
+          sightingId: "sighting-1",
+          ownerId: "owner-1",
+          sighterId: "sighter-1",
+        },
+      });
+      expect(result).toMatchObject({ id: "conv-1" });
+    });
+
+    it("同一postId+sightingIdの会話はConflictException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post-1",
+        userId: "owner-1",
+      });
+      mockPrisma.sighting.findUnique.mockResolvedValue({
+        id: "sighting-1",
+        userId: "sighter-1",
+      });
+      mockPrisma.conversation.findUnique.mockResolvedValue({ id: "conv-1" });
+
+      await expect(service.create("owner-1", dto)).rejects.toThrow(
+        ConflictException
+      );
+    });
+
+    it("存在しないpostIdはNotFoundException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(null);
+
+      await expect(service.create("owner-1", dto)).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("存在しないsightingIdはNotFoundException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post-1",
+        userId: "owner-1",
+      });
+      mockPrisma.sighting.findUnique.mockResolvedValue(null);
+
+      await expect(service.create("owner-1", dto)).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("会話参加者以外（無関係なユーザー）はForbiddenException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post-1",
+        userId: "owner-1",
+      });
+      mockPrisma.sighting.findUnique.mockResolvedValue({
+        id: "sighting-1",
+        userId: "sighter-1",
+      });
+
+      await expect(service.create("stranger", dto)).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+  });
+
+  // ─── findAllForUser ─────────────────────────────────────────
+  describe("findAllForUser", () => {
+    it("自分がownerまたはsighterとして参加する会話一覧を返すこと", async () => {
+      const conversations = [
+        { id: "conv-1", ownerId: "user-1", sighterId: "sighter-1" },
+        { id: "conv-2", ownerId: "owner-2", sighterId: "user-1" },
+      ];
+      mockPrisma.conversation.findMany.mockResolvedValue(conversations);
+
+      const result = await service.findAllForUser("user-1");
+
+      expect(mockPrisma.conversation.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ ownerId: "user-1" }, { sighterId: "user-1" }],
+        },
+        orderBy: { createdAt: "desc" },
+      });
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // ─── createMessage ──────────────────────────────────────────
+  describe("createMessage", () => {
+    const conversation = {
+      id: "conv-1",
+      ownerId: "user-1",
+      sighterId: "sighter-1",
+    };
+
+    it("会話参加者がメッセージを送信できること", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
+      mockPrisma.message.create.mockResolvedValue({
+        id: "msg-1",
+        conversationId: "conv-1",
+        senderId: "user-1",
+        body: "こんにちは",
+        readAt: null,
+      });
+
+      const result = await service.createMessage("user-1", "conv-1", {
+        body: "こんにちは",
+      });
+
+      expect(mockPrisma.message.create).toHaveBeenCalledWith({
+        data: {
+          conversationId: "conv-1",
+          senderId: "user-1",
+          body: "こんにちは",
+        },
+      });
+      expect(result).toMatchObject({ id: "msg-1" });
+    });
+
+    it("bodyが1000文字超過はBadRequestException", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
+
+      await expect(
+        service.createMessage("user-1", "conv-1", { body: "a".repeat(1001) })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("会話参加者以外のメッセージ送信はForbiddenException", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
+
+      await expect(
+        service.createMessage("stranger", "conv-1", { body: "test" })
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("存在しない会話へのメッセージはNotFoundException", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.createMessage("user-1", "conv-999", { body: "test" })
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── findMessages ───────────────────────────────────────────
+  describe("findMessages", () => {
+    const conversation = {
+      id: "conv-1",
+      ownerId: "user-1",
+      sighterId: "sighter-1",
+    };
+
+    it("会話参加者がメッセージ一覧を取得できること", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
+      mockPrisma.message.findMany.mockResolvedValue([
+        { id: "msg-1", body: "hello" },
+        { id: "msg-2", body: "world" },
+      ]);
+
+      const result = await service.findMessages("user-1", "conv-1");
+
+      expect(mockPrisma.message.findMany).toHaveBeenCalledWith({
+        where: { conversationId: "conv-1" },
+        orderBy: { createdAt: "asc" },
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it("会話参加者以外のメッセージ一覧取得はForbiddenException", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
+
+      await expect(service.findMessages("stranger", "conv-1")).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("存在しない会話のメッセージ一覧はNotFoundException", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(null);
+
+      await expect(service.findMessages("user-1", "conv-999")).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+});

--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -240,4 +240,46 @@ describe("ConversationsService", () => {
       );
     });
   });
+
+  // ─── markAsRead ─────────────────────────────────────────────
+  describe("markAsRead", () => {
+    const conversation = {
+      id: "conv-1",
+      ownerId: "user-1",
+      sighterId: "sighter-1",
+    };
+
+    it("相手が送ったunreadメッセージをすべて既読にすること", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
+      mockPrisma.message.updateMany.mockResolvedValue({ count: 3 });
+
+      const result = await service.markAsRead("user-1", "conv-1");
+
+      expect(mockPrisma.message.updateMany).toHaveBeenCalledWith({
+        where: {
+          conversationId: "conv-1",
+          senderId: { not: "user-1" },
+          readAt: null,
+        },
+        data: { readAt: expect.any(Date) },
+      });
+      expect(result).toEqual({ count: 3 });
+    });
+
+    it("会話参加者以外はForbiddenException", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
+
+      await expect(service.markAsRead("stranger", "conv-1")).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("存在しない会話はNotFoundException", async () => {
+      mockPrisma.conversation.findUnique.mockResolvedValue(null);
+
+      await expect(service.markAsRead("user-1", "conv-999")).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
 });

--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   NotFoundException,
 } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 import { ConversationsService } from "./conversation.service";
 
 const mockPrisma = {
@@ -43,7 +44,6 @@ describe("ConversationsService", () => {
         id: "sighting-1",
         userId: "sighter-1",
       });
-      mockPrisma.conversation.findUnique.mockResolvedValue(null);
       mockPrisma.conversation.create.mockResolvedValue({
         id: "conv-1",
         postId: "post-1",
@@ -74,7 +74,12 @@ describe("ConversationsService", () => {
         id: "sighting-1",
         userId: "sighter-1",
       });
-      mockPrisma.conversation.findUnique.mockResolvedValue({ id: "conv-1" });
+      mockPrisma.conversation.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: "P2002",
+          clientVersion: "0.0.0",
+        })
+      );
 
       await expect(service.create("owner-1", dto)).rejects.toThrow(
         ConflictException

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 import { PrismaService } from "../prisma.service";
 import { CreateConversationDto } from "./dto/create-conversation.dto";
 import { CreateMessageDto } from "./dto/create-message.dto";
@@ -30,22 +31,24 @@ export class ConversationsService {
       );
     }
 
-    const existing = await this.prisma.conversation.findUnique({
-      where: {
-        postId_sightingId: { postId: dto.postId, sightingId: dto.sightingId },
-      },
-    });
-    if (existing)
-      throw new ConflictException("この組み合わせの会話はすでに存在します");
-
-    return this.prisma.conversation.create({
-      data: {
-        postId: dto.postId,
-        sightingId: dto.sightingId,
-        ownerId: post.userId,
-        sighterId: sighting.userId,
-      },
-    });
+    try {
+      return await this.prisma.conversation.create({
+        data: {
+          postId: dto.postId,
+          sightingId: dto.sightingId,
+          ownerId: post.userId,
+          sighterId: sighting.userId,
+        },
+      });
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === "P2002"
+      ) {
+        throw new ConflictException("この組み合わせの会話はすでに存在します");
+      }
+      throw e;
+    }
   }
 
   async findAllForUser(userId: string) {

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -1,0 +1,106 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { PrismaService } from "../prisma.service";
+import { CreateConversationDto } from "./dto/create-conversation.dto";
+import { CreateMessageDto } from "./dto/create-message.dto";
+
+@Injectable()
+export class ConversationsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(userId: string, dto: CreateConversationDto) {
+    const post = await this.prisma.post.findUnique({
+      where: { id: dto.postId },
+    });
+    if (!post) throw new NotFoundException("Post not found");
+
+    const sighting = await this.prisma.sighting.findUnique({
+      where: { id: dto.sightingId },
+    });
+    if (!sighting) throw new NotFoundException("Sighting not found");
+
+    if (post.userId !== userId && sighting.userId !== userId) {
+      throw new ForbiddenException(
+        "会話を開始できるのは投稿者または目撃者のみです"
+      );
+    }
+
+    const existing = await this.prisma.conversation.findUnique({
+      where: {
+        postId_sightingId: { postId: dto.postId, sightingId: dto.sightingId },
+      },
+    });
+    if (existing)
+      throw new ConflictException("この組み合わせの会話はすでに存在します");
+
+    return this.prisma.conversation.create({
+      data: {
+        postId: dto.postId,
+        sightingId: dto.sightingId,
+        ownerId: post.userId,
+        sighterId: sighting.userId,
+      },
+    });
+  }
+
+  async findAllForUser(userId: string) {
+    return this.prisma.conversation.findMany({
+      where: {
+        OR: [{ ownerId: userId }, { sighterId: userId }],
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async createMessage(
+    userId: string,
+    conversationId: string,
+    dto: CreateMessageDto
+  ) {
+    if (dto.body.length > 1000) {
+      throw new BadRequestException(
+        "メッセージは1000文字以内で入力してください"
+      );
+    }
+
+    const conversation = await this.prisma.conversation.findUnique({
+      where: { id: conversationId },
+    });
+    if (!conversation) throw new NotFoundException("Conversation not found");
+
+    if (conversation.ownerId !== userId && conversation.sighterId !== userId) {
+      throw new ForbiddenException(
+        "この会話にメッセージを送る権限がありません"
+      );
+    }
+
+    return this.prisma.message.create({
+      data: {
+        conversationId,
+        senderId: userId,
+        body: dto.body,
+      },
+    });
+  }
+
+  async findMessages(userId: string, conversationId: string) {
+    const conversation = await this.prisma.conversation.findUnique({
+      where: { id: conversationId },
+    });
+    if (!conversation) throw new NotFoundException("Conversation not found");
+
+    if (conversation.ownerId !== userId && conversation.sighterId !== userId) {
+      throw new ForbiddenException("この会話を閲覧する権限がありません");
+    }
+
+    return this.prisma.message.findMany({
+      where: { conversationId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+}

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -106,4 +106,24 @@ export class ConversationsService {
       orderBy: { createdAt: "asc" },
     });
   }
+
+  async markAsRead(userId: string, conversationId: string) {
+    const conversation = await this.prisma.conversation.findUnique({
+      where: { id: conversationId },
+    });
+    if (!conversation) throw new NotFoundException("Conversation not found");
+
+    if (conversation.ownerId !== userId && conversation.sighterId !== userId) {
+      throw new ForbiddenException("この会話を閲覧する権限がありません");
+    }
+
+    return this.prisma.message.updateMany({
+      where: {
+        conversationId,
+        senderId: { not: userId },
+        readAt: null,
+      },
+      data: { readAt: new Date() },
+    });
+  }
 }

--- a/apps/api/src/conversations/conversations.gateway.spec.ts
+++ b/apps/api/src/conversations/conversations.gateway.spec.ts
@@ -1,0 +1,92 @@
+import { JwtService } from "@nestjs/jwt";
+import { ConversationsGateway } from "./conversations.gateway";
+import { Socket } from "socket.io";
+
+function makeSocket(token?: string, authToken?: string): jest.Mocked<Socket> {
+  return {
+    handshake: {
+      auth: authToken !== undefined ? { token: authToken } : {},
+      headers: token !== undefined ? { authorization: token } : {},
+    },
+    data: {},
+    disconnect: jest.fn(),
+    join: jest.fn(),
+    leave: jest.fn(),
+  } as unknown as jest.Mocked<Socket>;
+}
+
+describe("ConversationsGateway", () => {
+  let gateway: ConversationsGateway;
+  let jwtService: jest.Mocked<JwtService>;
+
+  beforeEach(() => {
+    jwtService = { verify: jest.fn() } as unknown as jest.Mocked<JwtService>;
+    gateway = new ConversationsGateway(jwtService);
+  });
+
+  // ─── handleConnection ──────────────────────────────────────
+  describe("handleConnection", () => {
+    it("トークンなしで接続した場合は切断される", () => {
+      const client = makeSocket();
+      gateway.handleConnection(client);
+      expect(client.disconnect).toHaveBeenCalled();
+    });
+
+    it("無効なトークンで接続した場合は切断される", () => {
+      jwtService.verify.mockImplementation(() => {
+        throw new Error("invalid token");
+      });
+      const client = makeSocket(undefined, "invalid.token");
+      gateway.handleConnection(client);
+      expect(client.disconnect).toHaveBeenCalled();
+    });
+
+    it("有効なトークンで接続した場合はsocket.data.userIdが設定される", () => {
+      jwtService.verify.mockReturnValue({ sub: "user-1", email: "a@b.com" });
+      const client = makeSocket(undefined, "valid.token");
+      gateway.handleConnection(client);
+      expect(client.disconnect).not.toHaveBeenCalled();
+      expect(client.data.userId).toBe("user-1");
+    });
+
+    it("Authorizationヘッダー（Bearer形式）でも認証できる", () => {
+      jwtService.verify.mockReturnValue({ sub: "user-2", email: "b@c.com" });
+      const client = makeSocket("Bearer valid.token");
+      gateway.handleConnection(client);
+      expect(client.disconnect).not.toHaveBeenCalled();
+      expect(client.data.userId).toBe("user-2");
+    });
+  });
+
+  // ─── broadcastMessage ──────────────────────────────────────
+  describe("broadcastMessage", () => {
+    it("最小化されたペイロードのみemitする", () => {
+      const emitMock = jest.fn();
+      const toMock = jest.fn().mockReturnValue({ emit: emitMock });
+      gateway.server = { to: toMock } as never;
+
+      const message = {
+        id: "msg-1",
+        conversationId: "conv-1",
+        senderId: "user-1",
+        body: "hello",
+        createdAt: new Date("2026-01-01"),
+        readAt: new Date("2026-01-02"),
+      } as import("@prisma/client").Message;
+
+      gateway.broadcastMessage("conv-1", message);
+
+      expect(toMock).toHaveBeenCalledWith("conversation:conv-1");
+      expect(emitMock).toHaveBeenCalledWith("newMessage", {
+        id: "msg-1",
+        conversationId: "conv-1",
+        senderId: "user-1",
+        body: "hello",
+        createdAt: message.createdAt,
+      });
+      // readAt は含まれないこと
+      const emitted = emitMock.mock.calls[0][1] as Record<string, unknown>;
+      expect(emitted).not.toHaveProperty("readAt");
+    });
+  });
+});

--- a/apps/api/src/conversations/conversations.gateway.ts
+++ b/apps/api/src/conversations/conversations.gateway.ts
@@ -1,0 +1,36 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  MessageBody,
+  ConnectedSocket,
+} from "@nestjs/websockets";
+import { Server, Socket } from "socket.io";
+
+@WebSocketGateway({ cors: true, namespace: "/conversations" })
+export class ConversationsGateway {
+  @WebSocketServer()
+  server: Server;
+
+  @SubscribeMessage("joinConversation")
+  handleJoin(
+    @MessageBody() conversationId: string,
+    @ConnectedSocket() client: Socket
+  ) {
+    client.join(`conversation:${conversationId}`);
+  }
+
+  @SubscribeMessage("leaveConversation")
+  handleLeave(
+    @MessageBody() conversationId: string,
+    @ConnectedSocket() client: Socket
+  ) {
+    client.leave(`conversation:${conversationId}`);
+  }
+
+  broadcastMessage(conversationId: string, message: unknown) {
+    this.server
+      .to(`conversation:${conversationId}`)
+      .emit("newMessage", message);
+  }
+}

--- a/apps/api/src/conversations/conversations.gateway.ts
+++ b/apps/api/src/conversations/conversations.gateway.ts
@@ -9,6 +9,7 @@ import {
 import { Server, Socket } from "socket.io";
 import { JwtService } from "@nestjs/jwt";
 import { Message } from "@prisma/client";
+import { JwtPayload } from "../auth/interfaces/jwt-payload.interface";
 
 @WebSocketGateway({
   cors: { origin: process.env.WEB_ORIGIN || "http://localhost:5173" },
@@ -32,7 +33,8 @@ export class ConversationsGateway implements OnGatewayConnection {
 
     try {
       const token = raw.startsWith("Bearer ") ? raw.slice(7) : raw;
-      this.jwtService.verify(token);
+      const payload = this.jwtService.verify<JwtPayload>(token);
+      client.data.userId = payload.sub;
     } catch {
       client.disconnect();
     }
@@ -55,8 +57,9 @@ export class ConversationsGateway implements OnGatewayConnection {
   }
 
   broadcastMessage(conversationId: string, message: Message) {
+    const { id, senderId, body, createdAt } = message;
     this.server
       .to(`conversation:${conversationId}`)
-      .emit("newMessage", message);
+      .emit("newMessage", { id, conversationId, senderId, body, createdAt });
   }
 }

--- a/apps/api/src/conversations/conversations.gateway.ts
+++ b/apps/api/src/conversations/conversations.gateway.ts
@@ -4,13 +4,39 @@ import {
   SubscribeMessage,
   MessageBody,
   ConnectedSocket,
+  OnGatewayConnection,
 } from "@nestjs/websockets";
 import { Server, Socket } from "socket.io";
+import { JwtService } from "@nestjs/jwt";
+import { Message } from "@prisma/client";
 
-@WebSocketGateway({ cors: true, namespace: "/conversations" })
-export class ConversationsGateway {
+@WebSocketGateway({
+  cors: { origin: process.env.WEB_ORIGIN || "http://localhost:5173" },
+  namespace: "/conversations",
+})
+export class ConversationsGateway implements OnGatewayConnection {
   @WebSocketServer()
   server: Server;
+
+  constructor(private jwtService: JwtService) {}
+
+  handleConnection(client: Socket) {
+    const raw =
+      client.handshake.auth?.token ??
+      (client.handshake.headers?.authorization as string | undefined);
+
+    if (!raw) {
+      client.disconnect();
+      return;
+    }
+
+    try {
+      const token = raw.startsWith("Bearer ") ? raw.slice(7) : raw;
+      this.jwtService.verify(token);
+    } catch {
+      client.disconnect();
+    }
+  }
 
   @SubscribeMessage("joinConversation")
   handleJoin(
@@ -28,7 +54,7 @@ export class ConversationsGateway {
     client.leave(`conversation:${conversationId}`);
   }
 
-  broadcastMessage(conversationId: string, message: unknown) {
+  broadcastMessage(conversationId: string, message: Message) {
     this.server
       .to(`conversation:${conversationId}`)
       .emit("newMessage", message);

--- a/apps/api/src/conversations/dto/create-conversation.dto.ts
+++ b/apps/api/src/conversations/dto/create-conversation.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString } from "class-validator";
+
+export class CreateConversationDto {
+  @ApiProperty()
+  @IsString()
+  postId: string;
+
+  @ApiProperty()
+  @IsString()
+  sightingId: string;
+}

--- a/apps/api/src/conversations/dto/create-message.dto.ts
+++ b/apps/api/src/conversations/dto/create-message.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, MaxLength } from "class-validator";
+
+export class CreateMessageDto {
+  @ApiProperty({ maxLength: 1000 })
+  @IsString()
+  @MaxLength(1000)
+  body: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,9 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.19",
+        "@nestjs/platform-socket.io": "^11.1.19",
         "@nestjs/swagger": "^7.4.2",
+        "@nestjs/websockets": "^11.1.19",
         "@prisma/client": "6.19.0",
         "bcrypt": "^4.0.1",
         "class-transformer": "^0.5.1",
@@ -49,6 +51,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "sharp": "^0.34.5",
+        "socket.io": "^4.8.3",
         "swagger-ui-express": "^4.1.6",
         "uuid": "^13.0.0"
       },
@@ -7141,6 +7144,48 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.19.tgz",
+      "integrity": "sha512-gu1nPIEaP5Qjjg/Cl8wXyvwGpdZGzgbtK4KcH65YRAA+GTKUkIHb4BNpLJ27Ymq/wqLJKNEbCjajfzD0BEjMGA==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.3",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.19.tgz",
+      "integrity": "sha512-2qo8jtIwwwgkqAI1BtnJ02EaFLrRkKA39eYXS8IhZCHilhBHCWdjnJ5cLcFq4oF+s+KZ7LcLGD/3stxJy8ijzg==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-socket.io": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -7461,6 +7506,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -7616,6 +7667,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -7716,6 +7776,15 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -8270,6 +8339,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -8775,6 +8853,58 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/entities": {
@@ -10477,6 +10607,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -11310,6 +11449,69 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -12102,6 +12304,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -416,6 +416,89 @@
         "tags": ["sightings"],
         "security": [{ "bearer": [] }]
       }
+    },
+    "/api/conversations": {
+      "post": {
+        "operationId": "ConversationsController_create",
+        "summary": "会話を作成する",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateConversationDto" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "ConversationsController_findAll",
+        "summary": "自分が参加する会話一覧を取得する",
+        "parameters": [],
+        "responses": { "200": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/conversations/{id}/messages": {
+      "post": {
+        "operationId": "ConversationsController_createMessage",
+        "summary": "メッセージを送信する",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateMessageDto" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "ConversationsController_findMessages",
+        "summary": "メッセージ一覧を取得する",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/conversations/{id}/messages/read": {
+      "patch": {
+        "operationId": "ConversationsController_markAsRead",
+        "summary": "会話内の未読メッセージを既読にする",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      }
     }
   },
   "info": {
@@ -635,6 +718,19 @@
           "comment": { "type": "string" }
         },
         "required": ["postId", "lat", "lng", "sightedAt"]
+      },
+      "CreateConversationDto": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "string" },
+          "sightingId": { "type": "string" }
+        },
+        "required": ["postId", "sightingId"]
+      },
+      "CreateMessageDto": {
+        "type": "object",
+        "properties": { "body": { "type": "string", "maxLength": 1000 } },
+        "required": ["body"]
       }
     }
   }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -43,6 +43,16 @@ export type PostsControllerCreateBody = {
   title?: string;
 };
 
+export interface CreateMessageDto {
+  /** @maxLength 1000 */
+  body: string;
+}
+
+export interface CreateConversationDto {
+  postId: string;
+  sightingId: string;
+}
+
 export interface CreateSightingDto {
   address?: string;
   comment?: string;
@@ -401,6 +411,68 @@ export const sightingsControllerRemove = <TData = AxiosResponse<void>>(
   return axios.delete(`/api/sightings/${id}`, options);
 };
 
+/**
+ * @summary 会話を作成する
+ */
+export const conversationsControllerCreate = <TData = AxiosResponse<void>>(
+  createConversationDto: CreateConversationDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/conversations`, createConversationDto, options);
+};
+
+/**
+ * @summary 自分が参加する会話一覧を取得する
+ */
+export const conversationsControllerFindAll = <TData = AxiosResponse<void>>(
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/conversations`, options);
+};
+
+/**
+ * @summary メッセージを送信する
+ */
+export const conversationsControllerCreateMessage = <
+  TData = AxiosResponse<void>,
+>(
+  id: string,
+  createMessageDto: CreateMessageDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(
+    `/api/conversations/${id}/messages`,
+    createMessageDto,
+    options
+  );
+};
+
+/**
+ * @summary メッセージ一覧を取得する
+ */
+export const conversationsControllerFindMessages = <
+  TData = AxiosResponse<void>,
+>(
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/conversations/${id}/messages`, options);
+};
+
+/**
+ * @summary 会話内の未読メッセージを既読にする
+ */
+export const conversationsControllerMarkAsRead = <TData = AxiosResponse<void>>(
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.patch(
+    `/api/conversations/${id}/messages/read`,
+    undefined,
+    options
+  );
+};
+
 export type UsersControllerFindAllResult = AxiosResponse<void>;
 export type UsersControllerRegisterResult = AxiosResponse<UserResponseDto>;
 export type PostsControllerCreateResult = AxiosResponse<PostResponseDto>;
@@ -418,3 +490,8 @@ export type MapControllerGetMarkersResult = AxiosResponse<MapMarkerDto[]>;
 export type SightingsControllerCreateResult = AxiosResponse<void>;
 export type SightingsControllerFindByPostResult = AxiosResponse<void>;
 export type SightingsControllerRemoveResult = AxiosResponse<void>;
+export type ConversationsControllerCreateResult = AxiosResponse<void>;
+export type ConversationsControllerFindAllResult = AxiosResponse<void>;
+export type ConversationsControllerCreateMessageResult = AxiosResponse<void>;
+export type ConversationsControllerFindMessagesResult = AxiosResponse<void>;
+export type ConversationsControllerMarkAsReadResult = AxiosResponse<void>;

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -165,6 +165,40 @@
 - [x] 会話参加者以外のメッセージ一覧取得はForbiddenException
 - [x] 存在しない会話のメッセージ一覧はNotFoundException
 
+#### markAsRead
+
+- [x] 相手が送ったunreadメッセージをすべて既読にすること
+- [x] 会話参加者以外はForbiddenException
+- [x] 存在しない会話はNotFoundException
+
+---
+
+### ConversationsGateway (`src/conversations/conversations.gateway.spec.ts`)
+
+#### handleConnection
+
+- [x] トークンなしで接続した場合は切断される
+- [x] 無効なトークンで接続した場合は切断される
+- [x] 有効なトークンで接続した場合はsocket.data.userIdが設定される
+- [x] Authorizationヘッダー（Bearer形式）でも認証できる
+
+#### broadcastMessage
+
+- [x] 最小化されたペイロードのみemitする（readAtを含まない）
+
+---
+
+### ConversationsController (`src/conversations/conversation.controller.spec.ts`)
+
+#### createMessage
+
+- [x] メッセージ作成後にbroadcastMessageを呼び出すこと
+- [x] サービスが例外を投げた場合はbroadcastMessageを呼ばないこと
+
+#### markAsRead
+
+- [x] 既読更新結果を返すこと
+
 ---
 
 ### MapService (`src/map/map.service.spec.ts`)

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -138,6 +138,35 @@
 
 ---
 
+### ConversationsService (`src/conversations/conversation.service.spec.ts`)
+
+#### create
+
+- [x] 有効なデータで会話を作成できること
+- [x] 同一postId+sightingIdの会話はConflictException
+- [x] 存在しないpostIdはNotFoundException
+- [x] 存在しないsightingIdはNotFoundException
+- [x] 会話参加者以外（無関係なユーザー）はForbiddenException
+
+#### findAllForUser
+
+- [x] 自分がownerまたはsighterとして参加する会話一覧を返すこと
+
+#### createMessage
+
+- [x] 会話参加者がメッセージを送信できること
+- [x] bodyが1000文字超過はBadRequestException
+- [x] 会話参加者以外のメッセージ送信はForbiddenException
+- [x] 存在しない会話へのメッセージはNotFoundException
+
+#### findMessages
+
+- [x] 会話参加者がメッセージ一覧を取得できること
+- [x] 会話参加者以外のメッセージ一覧取得はForbiddenException
+- [x] 存在しない会話のメッセージ一覧はNotFoundException
+
+---
+
 ### MapService (`src/map/map.service.spec.ts`)
 
 #### getMarkers

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -92,6 +92,25 @@ apps/api/src/
 │           ├── bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
 │           ├── bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
 │           └── フィルタなしで全マーカー（Post+Sighting）が返ること
+├── conversations/
+│   └── conversation.service.spec.ts
+│       ├── create
+│       │   ├── 有効なデータで会話を作成できること
+│       │   ├── 同一postId+sightingIdの会話はConflictException
+│       │   ├── 存在しないpostIdはNotFoundException
+│       │   ├── 存在しないsightingIdはNotFoundException
+│       │   └── 会話参加者以外（無関係なユーザー）はForbiddenException
+│       ├── findAllForUser
+│       │   └── 自分がownerまたはsighterとして参加する会話一覧を返すこと
+│       ├── createMessage
+│       │   ├── 会話参加者がメッセージを送信できること
+│       │   ├── bodyが1000文字超過はBadRequestException
+│       │   ├── 会話参加者以外のメッセージ送信はForbiddenException
+│       │   └── 存在しない会話へのメッセージはNotFoundException
+│       └── findMessages
+│           ├── 会話参加者がメッセージ一覧を取得できること
+│           ├── 会話参加者以外のメッセージ一覧取得はForbiddenException
+│           └── 存在しない会話のメッセージ一覧はNotFoundException
 ├── sightings/
 │   └── sighting.service.spec.ts
 │       ├── create

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -93,24 +93,42 @@ apps/api/src/
 │           ├── bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
 │           └── フィルタなしで全マーカー（Post+Sighting）が返ること
 ├── conversations/
-│   └── conversation.service.spec.ts
-│       ├── create
-│       │   ├── 有効なデータで会話を作成できること
-│       │   ├── 同一postId+sightingIdの会話はConflictException
-│       │   ├── 存在しないpostIdはNotFoundException
-│       │   ├── 存在しないsightingIdはNotFoundException
-│       │   └── 会話参加者以外（無関係なユーザー）はForbiddenException
-│       ├── findAllForUser
-│       │   └── 自分がownerまたはsighterとして参加する会話一覧を返すこと
+│   ├── conversation.service.spec.ts
+│   │   ├── create
+│   │   │   ├── 有効なデータで会話を作成できること
+│   │   │   ├── 同一postId+sightingIdの会話はConflictException
+│   │   │   ├── 存在しないpostIdはNotFoundException
+│   │   │   ├── 存在しないsightingIdはNotFoundException
+│   │   │   └── 会話参加者以外（無関係なユーザー）はForbiddenException
+│   │   ├── findAllForUser
+│   │   │   └── 自分がownerまたはsighterとして参加する会話一覧を返すこと
+│   │   ├── createMessage
+│   │   │   ├── 会話参加者がメッセージを送信できること
+│   │   │   ├── bodyが1000文字超過はBadRequestException
+│   │   │   ├── 会話参加者以外のメッセージ送信はForbiddenException
+│   │   │   └── 存在しない会話へのメッセージはNotFoundException
+│   │   ├── findMessages
+│   │   │   ├── 会話参加者がメッセージ一覧を取得できること
+│   │   │   ├── 会話参加者以外のメッセージ一覧取得はForbiddenException
+│   │   │   └── 存在しない会話のメッセージ一覧はNotFoundException
+│   │   └── markAsRead
+│   │       ├── 相手が送ったunreadメッセージをすべて既読にすること
+│   │       ├── 会話参加者以外はForbiddenException
+│   │       └── 存在しない会話はNotFoundException
+│   ├── conversations.gateway.spec.ts
+│   │   ├── handleConnection
+│   │   │   ├── トークンなしで接続した場合は切断される
+│   │   │   ├── 無効なトークンで接続した場合は切断される
+│   │   │   ├── 有効なトークンで接続した場合はsocket.data.userIdが設定される
+│   │   │   └── Authorizationヘッダー（Bearer形式）でも認証できる
+│   │   └── broadcastMessage
+│   │       └── 最小化されたペイロードのみemitする（readAtを含まない）
+│   └── conversation.controller.spec.ts
 │       ├── createMessage
-│       │   ├── 会話参加者がメッセージを送信できること
-│       │   ├── bodyが1000文字超過はBadRequestException
-│       │   ├── 会話参加者以外のメッセージ送信はForbiddenException
-│       │   └── 存在しない会話へのメッセージはNotFoundException
-│       └── findMessages
-│           ├── 会話参加者がメッセージ一覧を取得できること
-│           ├── 会話参加者以外のメッセージ一覧取得はForbiddenException
-│           └── 存在しない会話のメッセージ一覧はNotFoundException
+│       │   ├── メッセージ作成後にbroadcastMessageを呼び出すこと
+│       │   └── サービスが例外を投げた場合はbroadcastMessageを呼ばないこと
+│       └── markAsRead
+│           └── 既読更新結果を返すこと
 ├── sightings/
 │   └── sighting.service.spec.ts
 │       ├── create


### PR DESCRIPTION
## Summary

- `POST /api/conversations` — 会話作成（postId + sightingId）。投稿者または目撃者のみ開始可能、重複は 409
- `GET /api/conversations` — 自分が参加する会話一覧（owner/sighter どちらも対象）
- `POST /api/conversations/:id/messages` — メッセージ送信（body 最大1000文字）。送信後に Socket.IO で `conversation:{id}` ルームへリアルタイム配信
- `GET /api/conversations/:id/messages` — メッセージ一覧（参加者のみ）
- WebSocket Gateway: クライアントは `joinConversation` / `leaveConversation` イベントでルーム参加・離脱し、新着メッセージを `newMessage` イベントで受信

## Test plan

- [x] `ConversationsService` 全メソッドのユニットテスト 13件追加（happy path・ConflictException・NotFoundException・ForbiddenException・BadRequestException）
- [x] 全117テスト通過
- [x] 型チェック（`typecheck:api`）通過
- [x] カバレッジ全閾値（80%）クリア（`conversation.service.ts` は 100%）

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)