### PR TITLE
feat: Issue #25 管理者ロール（RBAC）の実装

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -35,7 +35,11 @@ export class AuthController {
         "認証情報が正しくありません",
         HttpStatus.UNAUTHORIZED
       );
-    const payload: JwtPayload = { sub: user.id, email: user.email };
+    const payload: JwtPayload = {
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+    };
     const accessToken = this.jwt.sign(payload);
     const refresh = await this.auth.createRefreshToken(user.id);
     this.setRefreshCookie(res, refresh);
@@ -53,7 +57,11 @@ export class AuthController {
     const rot = await this.auth.rotateRefreshToken(token);
     if (!rot)
       return res.status(401).json({ error: "無効なリフレッシュトークンです" });
-    const payload: JwtPayload = { sub: rot.userId, email: rot.email };
+    const payload: JwtPayload = {
+      sub: rot.userId,
+      email: rot.email,
+      role: rot.role,
+    };
     const accessToken = this.jwt.sign(payload);
     this.setRefreshCookie(res, rot.newToken);
     return res.status(200).json({ accessToken });

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -32,18 +32,29 @@ describe("AuthService", () => {
 
   // ─── validateUser ────────────────────────────────────────────
   describe("validateUser", () => {
-    it("正しいパスワードで id と email を返す", async () => {
+    it("正しいパスワードで id と email と role を返す", async () => {
       const hashed = await bcrypt.hash("password123", 10);
-      mockUsersService.findByEmail.mockResolvedValue(makeUser({ password: hashed }));
+      mockUsersService.findByEmail.mockResolvedValue(
+        makeUser({ password: hashed, role: "user" })
+      );
 
-      const result = await service.validateUser("test@example.com", "password123");
+      const result = await service.validateUser(
+        "test@example.com",
+        "password123"
+      );
 
-      expect(result).toEqual({ id: "user1", email: "test@example.com" });
+      expect(result).toEqual({
+        id: "user1",
+        email: "test@example.com",
+        role: "user",
+      });
     });
 
     it("パスワード不一致は null を返す", async () => {
       const hashed = await bcrypt.hash("correct", 10);
-      mockUsersService.findByEmail.mockResolvedValue(makeUser({ password: hashed }));
+      mockUsersService.findByEmail.mockResolvedValue(
+        makeUser({ password: hashed })
+      );
 
       const result = await service.validateUser("test@example.com", "wrong");
 
@@ -100,7 +111,9 @@ describe("AuthService", () => {
       expect(result!.userId).toBe("user1");
       expect(result!.email).toBe("test@example.com");
       expect(result!.newToken).toHaveLength(96);
-      expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({ where: { token: "old" } });
+      expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({
+        where: { token: "old" },
+      });
     });
 
     it("存在しないトークンは null を返す", async () => {
@@ -120,7 +133,9 @@ describe("AuthService", () => {
 
       await service.revokeRefreshToken("sometoken");
 
-      expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({ where: { token: "sometoken" } });
+      expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({
+        where: { token: "sometoken" },
+      });
     });
 
     it("存在しないトークンでもエラーを投げない", async () => {
@@ -133,7 +148,11 @@ describe("AuthService", () => {
   // ─── findRefreshToken ────────────────────────────────────────
   describe("findRefreshToken", () => {
     it("トークンレコードを返す", async () => {
-      const rec = { token: "t", userId: "user1", expiresAt: new Date(Date.now() + 60 * 60 * 1000) };
+      const rec = {
+        token: "t",
+        userId: "user1",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      };
       mockPrisma.refreshToken.findUnique.mockResolvedValue(rec);
 
       const result = await service.findRefreshToken("t");
@@ -150,7 +169,11 @@ describe("AuthService", () => {
     });
 
     it("期限切れトークンは null を返す", async () => {
-      const expired = { token: "t", userId: "user1", expiresAt: new Date(Date.now() - 1000) };
+      const expired = {
+        token: "t",
+        userId: "user1",
+        expiresAt: new Date(Date.now() - 1000),
+      };
       mockPrisma.refreshToken.findUnique.mockResolvedValue(expired);
 
       const result = await service.findRefreshToken("t");

--- a/apps/api/src/auth/interfaces/jwt-payload.interface.ts
+++ b/apps/api/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,4 +1,7 @@
+import { Role } from "@prisma/client";
+
 export interface JwtPayload {
   sub: string;
   email: string;
+  role: Role;
 }

--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -15,6 +15,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   validate(payload: JwtPayload) {
-    return { id: payload.sub, email: payload.email };
+    return { id: payload.sub, email: payload.email, role: payload.role };
   }
 }

--- a/apps/api/src/auth/roles.decorator.ts
+++ b/apps/api/src/auth/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from "@nestjs/common";
+import { Role } from "@prisma/client";
+
+export const ROLES_KEY = "roles";
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/auth/roles.guard.spec.ts
+++ b/apps/api/src/auth/roles.guard.spec.ts
@@ -1,0 +1,47 @@
+import { RolesGuard } from "./roles.guard";
+import { Reflector } from "@nestjs/core";
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+
+function makeContext(role: string | undefined): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user: role ? { id: "u1", role } : undefined }),
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  } as unknown as ExecutionContext;
+}
+
+describe("RolesGuard", () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it("@Roles デコレータがない場合は通す", () => {
+    jest.spyOn(reflector, "getAllAndOverride").mockReturnValue(undefined);
+    expect(guard.canActivate(makeContext("user"))).toBe(true);
+  });
+
+  it("ロールが一致する場合は通す", () => {
+    jest.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+    expect(guard.canActivate(makeContext("admin"))).toBe(true);
+  });
+
+  it("ロールが一致しない場合は ForbiddenException をスローする", () => {
+    jest.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+    expect(() => guard.canActivate(makeContext("user"))).toThrow(
+      ForbiddenException
+    );
+  });
+
+  it("ユーザーが未設定の場合は ForbiddenException をスローする", () => {
+    jest.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+    expect(() => guard.canActivate(makeContext(undefined))).toThrow(
+      ForbiddenException
+    );
+  });
+});

--- a/apps/api/src/auth/roles.guard.ts
+++ b/apps/api/src/auth/roles.guard.ts
@@ -1,0 +1,28 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Role } from "@prisma/client";
+import { ROLES_KEY } from "./roles.decorator";
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const required = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!required) return true;
+
+    const { user } = context.switchToHttp().getRequest();
+    if (!user || !required.includes(user.role)) {
+      throw new ForbiddenException("この操作には管理者権限が必要です");
+    }
+    return true;
+  }
+}

--- a/apps/api/src/posts/post.controller.spec.ts
+++ b/apps/api/src/posts/post.controller.spec.ts
@@ -413,7 +413,11 @@ describe("PostsController", () => {
 
       const result = await controller.remove(req, "post1");
 
-      expect(mockPostsService.remove).toHaveBeenCalledWith("post1", "user1");
+      expect(mockPostsService.remove).toHaveBeenCalledWith(
+        "post1",
+        "user1",
+        false
+      );
       expect(result).toEqual(post);
     });
 

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -130,7 +130,8 @@ export class PostsController {
   })
   async remove(@Req() req: any, @Param("id") id: string) {
     const userId = req.user?.id ?? req.user?.userId;
-    return this.posts.remove(id, userId);
+    const isAdmin = req.user?.role === "admin";
+    return this.posts.remove(id, userId, isAdmin);
   }
 
   @HttpPost(":id/images")

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -778,6 +778,18 @@ describe("PostsService", () => {
       );
     });
 
+    it("管理者は他人の投稿を削除できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.post.delete.mockResolvedValue(existingPost);
+
+      const result = await service.remove("post1", "admin-user", true);
+
+      expect(mockPrisma.post.delete).toHaveBeenCalledWith({
+        where: { id: "post1" },
+      });
+      expect(result).toEqual(existingPost);
+    });
+
     it("画像処理でSharpエラーが発生した場合 BadRequestException をスローする", async () => {
       const sharpMock = jest.requireMock("sharp") as jest.Mock;
       sharpMock.mockImplementation(() => {

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -361,7 +361,7 @@ export class PostsService {
     return { favorited: true };
   }
 
-  async remove(id: string, userId: string) {
+  async remove(id: string, userId: string, isAdmin = false) {
     const post = await this.prisma.post.findUnique({
       where: { id },
       include: { images: true },
@@ -369,7 +369,7 @@ export class PostsService {
     if (!post) {
       throw new HttpException("投稿が見つかりません", HttpStatus.NOT_FOUND);
     }
-    if (post.userId !== userId) {
+    if (post.userId !== userId && !isAdmin) {
       throw new ForbiddenException("投稿のオーナーではありません");
     }
 

--- a/apps/api/src/sightings/sighting.controller.spec.ts
+++ b/apps/api/src/sightings/sighting.controller.spec.ts
@@ -59,7 +59,11 @@ describe("SightingsController", () => {
 
       const result = await controller.remove(req as any, "s-1");
 
-      expect(mockSightingsService.remove).toHaveBeenCalledWith("user-1", "s-1");
+      expect(mockSightingsService.remove).toHaveBeenCalledWith(
+        "user-1",
+        "s-1",
+        false
+      );
       expect(result).toEqual({ id: "s-1" });
     });
 

--- a/apps/api/src/sightings/sighting.controller.ts
+++ b/apps/api/src/sightings/sighting.controller.ts
@@ -48,7 +48,8 @@ export class SightingsController {
   @ApiResponse({ status: 204 })
   remove(@Request() req: any, @Param("id") id: string) {
     const userId = req.user?.id ?? req.user?.userId;
-    return this.sightingsService.remove(userId, id);
+    const isAdmin = req.user?.role === "admin";
+    return this.sightingsService.remove(userId, id, isAdmin);
   }
 
   @Post(":id/favorite")

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -138,6 +138,19 @@ describe("SightingsService", () => {
         NotFoundException
       );
     });
+
+    it("管理者は他者のSightingを削除できること", async () => {
+      mockPrisma.sighting.findUnique.mockResolvedValue({
+        id: "s-1",
+        userId: "user-1",
+      });
+
+      await service.remove("admin-user", "s-1", true);
+
+      expect(mockPrisma.sighting.delete).toHaveBeenCalledWith({
+        where: { id: "s-1" },
+      });
+    });
   });
 
   // ─── toggleFavorite ─────────────────────────────────────────

--- a/apps/api/src/sightings/sighting.service.ts
+++ b/apps/api/src/sightings/sighting.service.ts
@@ -69,10 +69,10 @@ export class SightingsService {
     return { favorited: true };
   }
 
-  async remove(userId: string, id: string) {
+  async remove(userId: string, id: string, isAdmin = false) {
     const sighting = await this.prisma.sighting.findUnique({ where: { id } });
     if (!sighting) throw new NotFoundException("目撃情報が見つかりません");
-    if (sighting.userId !== userId)
+    if (sighting.userId !== userId && !isAdmin)
       throw new ForbiddenException("削除できるのは本人のみです");
 
     await this.prisma.sighting.delete({ where: { id } });

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -1,7 +1,8 @@
 import "express";
+import { Role } from "@prisma/client";
 
 declare module "express" {
   interface Request {
-    user?: { id: string; email?: string };
+    user?: { id: string; email?: string; role?: Role };
   }
 }

--- a/apps/api/src/users/user.controller.ts
+++ b/apps/api/src/users/user.controller.ts
@@ -1,27 +1,59 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
-  Post,
+  HttpCode,
   HttpException,
   HttpStatus,
+  Param,
+  Post,
+  UseGuards,
 } from "@nestjs/common";
-import { ApiTags, ApiResponse } from "@nestjs/swagger";
-import { UsersService } from "./user.service";
-import { UserResponseDto } from "./dto/user-response.dto";
+import { ApiBearerAuth, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { Role } from "@prisma/client";
+import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { Roles } from "../auth/roles.decorator";
+import { RolesGuard } from "../auth/roles.guard";
 import { RegisterDto } from "./dto/register.dto";
+import { UserResponseDto } from "./dto/user-response.dto";
+import { UsersService } from "./user.service";
 
 @ApiTags("users")
 @Controller("users")
 export class UsersController {
   constructor(private users: UsersService) {}
 
-  // TanStack Start との対比用エンドポイント
-  // TanStack Start: モーダルから await getUsers() を呼ぶだけで完結
-  // NestJS:  ① このルート定義 ② service.findAll() ③ フロントの useQuery の3段階が必要
   @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.admin)
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, type: [UserResponseDto] })
+  @ApiResponse({ status: 403, description: "管理者のみ" })
   async findAll() {
     return this.users.findAll();
+  }
+
+  @Delete(":id")
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.admin)
+  @ApiBearerAuth()
+  @HttpCode(200)
+  @ApiResponse({ status: 200, description: "ユーザー削除成功" })
+  @ApiResponse({ status: 403, description: "管理者のみ" })
+  @ApiResponse({ status: 404, description: "ユーザーが見つかりません" })
+  async remove(@Param("id") id: string) {
+    try {
+      return await this.users.deleteUser(id);
+    } catch (e: any) {
+      if (e?.code === "P2025") {
+        throw new HttpException(
+          { error: "ユーザーが見つかりません" },
+          HttpStatus.NOT_FOUND
+        );
+      }
+      throw e;
+    }
   }
 
   @Post("register")

--- a/apps/api/src/users/user.service.spec.ts
+++ b/apps/api/src/users/user.service.spec.ts
@@ -6,6 +6,7 @@ const mockPrisma = {
     create: jest.fn(),
     findUnique: jest.fn(),
     findMany: jest.fn(),
+    delete: jest.fn(),
   },
 };
 
@@ -152,6 +153,28 @@ describe("UsersService", () => {
         },
       });
       expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  // ─── deleteUser ───────────────────────────────────────────────
+  describe("deleteUser", () => {
+    it("指定IDのユーザーを削除する", async () => {
+      const deleted = { id: "u1", nickname: "Alice" };
+      mockPrisma.user.delete.mockResolvedValue(deleted);
+
+      const result = await service.deleteUser("u1");
+
+      expect(mockPrisma.user.delete).toHaveBeenCalledWith({
+        where: { id: "u1" },
+      });
+      expect(result).toEqual(deleted);
+    });
+
+    it("存在しないIDは Prisma エラーを再スローする", async () => {
+      const err = Object.assign(new Error("Not found"), { code: "P2025" });
+      mockPrisma.user.delete.mockRejectedValue(err);
+
+      await expect(service.deleteUser("no-such")).rejects.toThrow("Not found");
     });
   });
 });

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -60,6 +60,7 @@
 - [x] 画像ファイルも削除する
 - [x] オーナー以外は ForbiddenException
 - [x] 存在しない投稿は HttpException (404)
+- [x] 管理者は他人の投稿を削除できる
 
 ---
 
@@ -155,6 +156,7 @@
 - [x] 本人がSightingを削除できること
 - [x] 他者が削除しようとすると ForbiddenException
 - [x] 存在しないSightingを削除しようとすると NotFoundException
+- [x] 管理者は他者のSightingを削除できること
 
 #### toggleFavorite
 
@@ -253,13 +255,31 @@
 
 ---
 
+### RolesGuard (`src/auth/roles.guard.spec.ts`)
+
+- [x] @Roles デコレータがない場合は通す
+- [x] ロールが一致する場合は通す
+- [x] ロールが一致しない場合は ForbiddenException をスローする
+- [x] ユーザーが未設定の場合は ForbiddenException をスローする
+
+---
+
 ### AuthService (`src/auth/auth.service.spec.ts`)
 
-（既存テスト・詳細省略）
+#### validateUser
+
+- [x] 正しいパスワードで id と email と role を返す
+
+（その他既存テスト省略）
 
 ### UserService (`src/users/user.service.spec.ts`)
 
-（既存テスト・詳細省略）
+#### deleteUser
+
+- [x] 指定IDのユーザーを削除する
+- [x] 存在しないIDは Prisma エラーを再スローする
+
+（その他既存テスト省略）
 
 ---
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -3,8 +3,14 @@
 ```
 apps/api/src/
 ├── auth/
-│   └── auth.service.spec.ts
-│       └── AuthService（既存）
+│   ├── auth.service.spec.ts
+│   │   └── AuthService（既存 + validateUser で role を返すことを検証）
+│   └── roles.guard.spec.ts
+│       └── RolesGuard
+│           ├── @Roles デコレータがない場合は通す
+│           ├── ロールが一致する場合は通す
+│           ├── ロールが一致しない場合は ForbiddenException をスローする
+│           └── ユーザーが未設定の場合は ForbiddenException をスローする
 ├── posts/
 │   ├── post.service.spec.ts
 │   │   ├── findAll
@@ -45,7 +51,8 @@ apps/api/src/
 │   │       ├── オーナーが削除できる
 │   │       ├── 画像ファイルも削除する
 │   │       ├── オーナー以外は ForbiddenException
-│   │       └── 存在しない投稿は HttpException (404)
+│   │       ├── 存在しない投稿は HttpException (404)
+│   │       └── 管理者は他人の投稿を削除できる
 │   │   └── toggleFavorite
 │   │       ├── お気に入りしていない状態でtoggleFavoriteを呼ぶと { favorited: true } を返す
 │   │       ├── 既にお気に入り済みの状態でtoggleFavoriteを呼ぶと { favorited: false } を返す
@@ -150,7 +157,8 @@ apps/api/src/
 │   │   ├── remove
 │   │   │   ├── 本人がSightingを削除できること
 │   │   │   ├── 他者が削除しようとすると ForbiddenException
-│   │   │   └── 存在しないSightingを削除しようとすると NotFoundException
+│   │   │   ├── 存在しないSightingを削除しようとすると NotFoundException
+│   │   │   └── 管理者は他者のSightingを削除できること
 │   │   └── toggleFavorite
 │   │       ├── お気に入りしていない状態でtoggleFavoriteを呼ぶと { favorited: true } を返す
 │   │       ├── 既にお気に入り済みの状態でtoggleFavoriteを呼ぶと { favorited: false } を返す
@@ -164,7 +172,11 @@ apps/api/src/
 │           └── NotFoundException を伝播する
 └── users/
     └── user.service.spec.ts
-        └── UserService（既存）
+        └── UserService
+            ├── （既存テスト省略）
+            └── deleteUser
+                ├── 指定IDのユーザーを削除する
+                └── 存在しないIDは Prisma エラーを再スローする
 
 apps/api/test/
 └── app.e2e.ts


### PR DESCRIPTION
## Summary

- `RolesGuard` + `@Roles()` デコレータを新規作成
- `JwtPayload` / `JwtStrategy` / `AuthController` に `role` を追加し、JWT にロール情報を埋め込む
- `GET /users` を `admin` ロール限定に変更（`JwtAuthGuard` + `RolesGuard`）
- `DELETE /posts/:id`, `DELETE /sightings/:id` を管理者も実行可能に変更（`isAdmin` フラグを追加）
- `DELETE /users/:id` を管理者専用エンドポイントとして新規追加
- `express.d.ts` の `Request.user` 型に `role` を追加

## 依存ブランチ

`feat/issue26/email-encryption`（`Role` enum・`role` フィールドをスキーマに追加したブランチ）

## Test plan

- [x] `RolesGuard` のユニットテスト 4件追加（`src/auth/roles.guard.spec.ts`）
- [x] `PostsService.remove` に管理者削除テスト追加
- [x] `SightingsService.remove` に管理者削除テスト追加
- [x] `UsersService.deleteUser` のユニットテスト 2件追加
- [x] `AuthService.validateUser` のテストを `role` 含む期待値に更新
- [x] 既存テスト更新（`remove` の引数に `isAdmin` が追加されたため）
- [x] 全テスト通過: 159 passed / 12 suites
- [x] 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)