### PR TITLE
fix: issue#26 E2Eタイムアウトの原因を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
         working-directory: apps/api
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test
-          HMAC_SECRET: ${{ secrets.HMAC_SECRET }}
-          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
+          HMAC_SECRET: ${{ secrets.HMAC_SECRET || 'ci-hmac-secret' }}
+          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY || '0123456789abcdef0123456789abcdef' }}
 
       - name: Web unit tests
         run: npm test -- --run
@@ -125,8 +125,8 @@ jobs:
           DATABASE_URL: postgresql://test:test@localhost:5432/test
           NODE_ENV: test
           JWT_SECRET: ci-test-secret
-          HMAC_SECRET: ${{ secrets.HMAC_SECRET }}
-          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
+          HMAC_SECRET: ${{ secrets.HMAC_SECRET || 'ci-hmac-secret' }}
+          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY || '0123456789abcdef0123456789abcdef' }}
 
       - name: Wait for API
         run: npx wait-on -t 60000 http://localhost:3000/api-json || (cat /tmp/api.log && exit 1)

--- a/apps/web/tests/playwright/e2e.spec.ts
+++ b/apps/web/tests/playwright/e2e.spec.ts
@@ -15,18 +15,39 @@ test("basic E2E flow: register → login → create post → view posts", async 
   await page.fill('input[placeholder="email"]', email);
   await page.fill('input[placeholder="password"]', password);
   await page.fill('input[placeholder="name"]', "E2E User");
+  const registerResponsePromise = page.waitForResponse(
+    (res) =>
+      res.url().includes("/api/users/register") &&
+      res.request().method() === "POST"
+  );
   await page.click('button:has-text("Register")');
 
+  const registerResponse = await registerResponsePromise;
+  expect(
+    registerResponse.ok(),
+    `register failed: ${registerResponse.status()} ${registerResponse.statusText()}`
+  ).toBeTruthy();
+
   // Wait for redirect to login (Register component navigates on success)
-  await page.waitForURL(`${baseUrl}/login`);
+  await expect(page).toHaveURL(`${baseUrl}/login`, { timeout: 15000 });
 
   // 2. Login
   await page.fill('input[placeholder="email"]', email);
   await page.fill('input[placeholder="password"]', password);
+  const loginResponsePromise = page.waitForResponse(
+    (res) =>
+      res.url().includes("/api/auth/login") && res.request().method() === "POST"
+  );
   await page.click('button:has-text("Login")');
 
+  const loginResponse = await loginResponsePromise;
+  expect(
+    loginResponse.ok(),
+    `login failed: ${loginResponse.status()} ${loginResponse.statusText()}`
+  ).toBeTruthy();
+
   // Should navigate to posts page
-  await page.waitForURL(`${baseUrl}/`);
+  await expect(page).toHaveURL(`${baseUrl}/`, { timeout: 15000 });
   await expect(page.locator("nav")).toContainText("Logout");
 
   // 3. Create post (use link click to preserve in-memory auth token)


### PR DESCRIPTION
## 概要
- E2Eで登録/ログインAPIの成功を先に検証し、URL待機タイムアウトを早期失敗化
- CIのAPI起動時に HMAC_SECRET と ENCRYPTION_KEY の既定値を与え、Secrets未設定でも登録APIが500にならないよう修正

## 確認
- pre-commit で API typecheck / Web typecheck / API Jest 151件 passed
- ローカルの完全E2E再実行は既存プロセス競合のため未完了