### PR TITLE
fix: issue#26 register 500 を解消する role migration を追加

### DIFF
--- a/apps/api/prisma/migrations/20260420182000_add_user_role/migration.sql
+++ b/apps/api/prisma/migrations/20260420182000_add_user_role/migration.sql
@@ -1,0 +1,9 @@
+DO $$
+BEGIN
+  CREATE TYPE "Role" AS ENUM ('user', 'admin');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "User"
+ADD COLUMN IF NOT EXISTS "role" "Role" NOT NULL DEFAULT 'user';


### PR DESCRIPTION
## 問題
main の E2E で register が 500 になる

## 原因
Prisma schema には User.role が存在する一方、migration 履歴に role 列追加が無く、fresh DB では User.role が存在しない。
そのため register 時の INSERT が role 列を参照して失敗する。

## 変更
- User.role enum/column を冪等に追加する migration を追加
  - apps/api/prisma/migrations/20260420182000_add_user_role/migration.sql

## 確認
- pre-commit: typecheck(api/web) と api test(160) pass