### PR TITLE
fix: map markers の500修正と Schemathesis v4オプション統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
         run: |
           schemathesis run \
             http://localhost:3000/api-json \
-            --base-url http://localhost:3000 \
+            --url http://localhost:3000 \
             --checks not_a_server_error \
             --max-examples 25 \
             --continue-on-failure

--- a/README.md
+++ b/README.md
@@ -51,8 +51,20 @@ npm run test:ci
 
 Schemathesis は重いため、通常は nightly または手動実行を推奨します。
 
+注意:
+
+- Schemathesis v4 の CLI は `--url` を使用します（`--base-url` は使用不可）。
+- コマンドを更新する際は `README.md` と `.github/workflows/ci.yml` の両方を同時に更新してください。
+
 ```bash
 # 例: ローカルで Schemathesis を直接実行
-python -m pip install schemathesis
-schemathesis run http://localhost:3000/api-json --base-url http://localhost:3000 --checks not_a_server_error
+# Debian/Ubuntu で pip が無い場合
+sudo apt install -y python3-pip
+
+python3 -m pip install schemathesis
+schemathesis run http://localhost:3000/api-json --url http://localhost:3000 --checks not_a_server_error --max-examples 25 --continue-on-failure
+
+# 認証が必要なAPIも検証したい場合（JWTを付与）
+ACCESS_TOKEN="<JWT_ACCESS_TOKEN>"
+schemathesis run http://localhost:3000/api-json --url http://localhost:3000 --checks not_a_server_error --max-examples 25 --continue-on-failure -H "Authorization: Bearer ${ACCESS_TOKEN}"
 ```

--- a/apps/api/src/map/map.service.spec.ts
+++ b/apps/api/src/map/map.service.spec.ts
@@ -104,8 +104,10 @@ describe("MapService", () => {
 
       const postCall = mockPrisma.post.findMany.mock.calls[0][0];
       expect(postCall.where.location).toMatchObject({
-        lat: { gte: 35.0, lte: 36.0 },
-        lng: { gte: 139.0, lte: 140.0 },
+        is: {
+          lat: { gte: 35.0, lte: 36.0 },
+          lng: { gte: 139.0, lte: 140.0 },
+        },
       });
     });
 
@@ -123,6 +125,30 @@ describe("MapService", () => {
       const sightingCall = mockPrisma.sighting.findMany.mock.calls[0][0];
       expect(sightingCall.where.lat).toMatchObject({ gte: 35.0, lte: 36.0 });
       expect(sightingCall.where.lng).toMatchObject({ gte: 139.0, lte: 140.0 });
+    });
+
+    it("bboxクエリが文字列でも数値フィルタとして渡ること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      await service.getMarkers({
+        minLat: "0",
+        maxLat: "0",
+        minLng: "0",
+        maxLng: "0",
+      } as never);
+
+      const postCall = mockPrisma.post.findMany.mock.calls[0][0];
+      const sightingCall = mockPrisma.sighting.findMany.mock.calls[0][0];
+
+      expect(postCall.where.location).toMatchObject({
+        is: {
+          lat: { gte: 0, lte: 0 },
+          lng: { gte: 0, lte: 0 },
+        },
+      });
+      expect(sightingCall.where.lat).toMatchObject({ gte: 0, lte: 0 });
+      expect(sightingCall.where.lng).toMatchObject({ gte: 0, lte: 0 });
     });
 
     it("フィルタなしで全マーカー（Post+Sighting）が返ること", async () => {

--- a/apps/api/src/map/map.service.spec.ts
+++ b/apps/api/src/map/map.service.spec.ts
@@ -151,6 +151,31 @@ describe("MapService", () => {
       expect(sightingCall.where.lng).toMatchObject({ gte: 0, lte: 0 });
     });
 
+    it("空白文字列と非有限数はbboxフィルタに含めないこと", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      await service.getMarkers({
+        minLat: "   ",
+        maxLat: Number.NaN,
+        minLng: Number.POSITIVE_INFINITY,
+        maxLng: "  140.5  ",
+      } as never);
+
+      const postCall = mockPrisma.post.findMany.mock.calls[0][0];
+      const sightingCall = mockPrisma.sighting.findMany.mock.calls[0][0];
+
+      expect(postCall.where.location).toMatchObject({
+        is: {
+          lng: { lte: 140.5 },
+        },
+      });
+      expect(sightingCall.where).toMatchObject({
+        lng: { lte: 140.5 },
+      });
+      expect(sightingCall.where.lat).toBeUndefined();
+    });
+
     it("フィルタなしで全マーカー（Post+Sighting）が返ること", async () => {
       mockPrisma.post.findMany.mockResolvedValue([
         { id: "post-1", status: "lost", location: { lat: 35.9, lng: 139.6 } },

--- a/apps/api/src/map/map.service.ts
+++ b/apps/api/src/map/map.service.ts
@@ -9,9 +9,12 @@ export class MapService {
 
   private toOptionalNumber(value: unknown): number | undefined {
     if (value === undefined || value === null || value === "") return undefined;
-    if (typeof value === "number") return value;
+    if (typeof value === "number")
+      return Number.isFinite(value) ? value : undefined;
     if (typeof value === "string") {
-      const parsed = Number(value);
+      const trimmed = value.trim();
+      if (trimmed === "") return undefined;
+      const parsed = Number(trimmed);
       return Number.isFinite(parsed) ? parsed : undefined;
     }
     return undefined;

--- a/apps/api/src/map/map.service.ts
+++ b/apps/api/src/map/map.service.ts
@@ -7,8 +7,22 @@ import { MapMarkerDto } from "./dto/marker-response.dto";
 export class MapService {
   constructor(private prisma: PrismaService) {}
 
+  private toOptionalNumber(value: unknown): number | undefined {
+    if (value === undefined || value === null || value === "") return undefined;
+    if (typeof value === "number") return value;
+    if (typeof value === "string") {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+  }
+
   async getMarkers(query: GetMarkersQueryDto): Promise<MapMarkerDto[]> {
-    const { minLat, maxLat, minLng, maxLng, status } = query;
+    const { status } = query;
+    const minLat = this.toOptionalNumber(query.minLat);
+    const maxLat = this.toOptionalNumber(query.maxLat);
+    const minLng = this.toOptionalNumber(query.minLng);
+    const maxLng = this.toOptionalNumber(query.maxLng);
 
     const bboxFilter = (latField: string, lngField: string) => {
       const filter: Record<string, unknown> = {};
@@ -35,8 +49,13 @@ export class MapService {
       return filter;
     };
 
+    const locationFilter = bboxFilter("lat", "lng");
+    const hasLocationRangeFilter = Object.keys(locationFilter).length > 0;
+
     const postWhere: Record<string, unknown> = {
-      location: { isNot: null, ...bboxFilter("lat", "lng") },
+      location: hasLocationRangeFilter
+        ? { is: locationFilter }
+        : { isNot: null },
     };
     if (status) postWhere.status = status;
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -251,6 +251,7 @@
 - [x] statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
 - [x] bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
 - [x] bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
+- [x] bboxクエリが文字列でも数値フィルタとして渡ること
 - [x] フィルタなしで全マーカー（Post+Sighting）が返ること
 
 ---

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -252,6 +252,7 @@
 - [x] bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
 - [x] bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
 - [x] bboxクエリが文字列でも数値フィルタとして渡ること
+- [x] 空白文字列と非有限数はbboxフィルタに含めないこと
 - [x] フィルタなしで全マーカー（Post+Sighting）が返ること
 
 ---

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -109,6 +109,7 @@ apps/api/src/
 │           ├── bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
 │           ├── bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
 │           ├── bboxクエリが文字列でも数値フィルタとして渡ること
+│           ├── 空白文字列と非有限数はbboxフィルタに含めないこと
 │           └── フィルタなしで全マーカー（Post+Sighting）が返ること
 ├── conversations/
 │   ├── conversation.service.spec.ts

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -108,6 +108,7 @@ apps/api/src/
 │           ├── statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
 │           ├── bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
 │           ├── bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
+│           ├── bboxクエリが文字列でも数値フィルタとして渡ること
 │           └── フィルタなしで全マーカー（Post+Sighting）が返ること
 ├── conversations/
 │   ├── conversation.service.spec.ts


### PR DESCRIPTION
## 概要
- `GET /api/map/markers` で bbox クエリが文字列として渡るケースを数値に正規化
- Prisma の relation filter を `location.is` / `location.isNot` の正しい形に修正し、500 を解消
- Schemathesis v4 の CLI 仕様に合わせて `--base-url` を `--url` へ統一
- README に認証付き実行例と運用注意（README/CI 同期更新）を追記

## 変更ファイル
- `.github/workflows/ci.yml`
- `README.md`
- `apps/api/src/map/map.service.ts`
- `apps/api/src/map/map.service.spec.ts`
- `tests/TESTS.md`
- `tests/TESTS_TREE.md`

## 確認結果
- `cd apps/api && npx jest src/map/map.service.spec.ts --runInBand` : pass (8/8)
- `curl 'http://localhost:3000/api/map/markers?minLat=0&maxLat=0&minLng=0&maxLng=0'` : 200（修正前は500）
- `~/.local/bin/schemathesis run http://localhost:3000/api-json --url http://localhost:3000 --checks not_a_server_error --max-examples 10 --continue-on-failure` : failures 0（warnings のみ）
- pre-commit で API/Web typecheck + API jest 全件 pass（12 suites, 161 tests）

## 補足
- 認証が必要な API はトークン未指定時に Schemathesis で 401 警告が出るため、README に `-H 'Authorization: Bearer ...'` 例を追加済みです。
