### PR TITLE
fix: issue#39 Sighting.postId nullable 対応

### DIFF
--- a/apps/api/prisma/migrations/20260421045728_make_sighting_post_id_nullable/migration.sql
+++ b/apps/api/prisma/migrations/20260421045728_make_sighting_post_id_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Sighting" ALTER COLUMN "postId" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -106,8 +106,8 @@ model Image {
 
 model Sighting {
   id        String           @id @default(cuid())
-  post      Post             @relation(fields: [postId], references: [id], onDelete: Cascade)
-  postId    String
+  post      Post?            @relation(fields: [postId], references: [id], onDelete: Cascade)
+  postId    String?
   user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId    String
   lat       Float

--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -42,6 +42,7 @@ describe("ConversationsService", () => {
       });
       mockPrisma.sighting.findUnique.mockResolvedValue({
         id: "sighting-1",
+        postId: "post-1",
         userId: "sighter-1",
       });
       mockPrisma.conversation.create.mockResolvedValue({
@@ -72,6 +73,7 @@ describe("ConversationsService", () => {
       });
       mockPrisma.sighting.findUnique.mockResolvedValue({
         id: "sighting-1",
+        postId: "post-1",
         userId: "sighter-1",
       });
       mockPrisma.conversation.create.mockRejectedValue(
@@ -113,11 +115,28 @@ describe("ConversationsService", () => {
       });
       mockPrisma.sighting.findUnique.mockResolvedValue({
         id: "sighting-1",
+        postId: "post-1",
         userId: "sighter-1",
       });
 
       await expect(service.create("stranger", dto)).rejects.toThrow(
         ForbiddenException
+      );
+    });
+
+    it("standalone Sighting は NotFoundException で会話を作成できないこと", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post-1",
+        userId: "owner-1",
+      });
+      mockPrisma.sighting.findUnique.mockResolvedValue({
+        id: "sighting-1",
+        postId: null,
+        userId: "sighter-1",
+      });
+
+      await expect(service.create("owner-1", dto)).rejects.toThrow(
+        NotFoundException
       );
     });
   });

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -24,6 +24,9 @@ export class ConversationsService {
       where: { id: dto.sightingId },
     });
     if (!sighting) throw new NotFoundException("目撃情報が見つかりません");
+    if (sighting.postId == null || sighting.postId !== dto.postId) {
+      throw new NotFoundException("目撃情報が見つかりません");
+    }
 
     if (post.userId !== userId && sighting.userId !== userId) {
       throw new ForbiddenException(

--- a/apps/api/src/map/dto/marker-response.dto.ts
+++ b/apps/api/src/map/dto/marker-response.dto.ts
@@ -8,7 +8,8 @@ export class MapMarkerDto {
   @ApiProperty({ required: false }) postId?: string;
   @ApiProperty() lat: number;
   @ApiProperty() lng: number;
-  @ApiProperty({ enum: ["lost", "resolved"] }) status: "lost" | "resolved";
+  @ApiProperty({ enum: ["lost", "resolved"], default: "lost" })
+  status: "lost" | "resolved";
 }
 
 /** @deprecated 後方互換のためのエイリアス */

--- a/apps/api/src/map/map.service.spec.ts
+++ b/apps/api/src/map/map.service.spec.ts
@@ -71,6 +71,31 @@ describe("MapService", () => {
         status: "lost",
       });
     });
+
+    it("standalone Sighting は statusなしで lost として返ること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.sighting.findMany.mockResolvedValue([
+        {
+          id: "s-standalone",
+          postId: null,
+          lat: 35.8,
+          lng: 139.52,
+          post: null,
+        },
+      ]);
+
+      const result = await service.getMarkers({});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: "sighting",
+        id: "s-standalone",
+        postId: undefined,
+        lat: 35.8,
+        lng: 139.52,
+        status: "lost",
+      });
+    });
     it("statusフィルタ指定時にPostクエリのwhereにstatusが含まれること", async () => {
       mockPrisma.post.findMany.mockResolvedValue([]);
       mockPrisma.sighting.findMany.mockResolvedValue([]);

--- a/apps/api/src/map/map.service.ts
+++ b/apps/api/src/map/map.service.ts
@@ -100,10 +100,10 @@ export class MapService {
     const sightingMarkers: MapMarkerDto[] = sightings.map((s) => ({
       type: "sighting",
       id: s.id,
-      postId: s.postId,
+      postId: s.postId ?? undefined,
       lat: s.lat,
       lng: s.lng,
-      status: s.post.status,
+      status: s.post?.status ?? "lost",
     }));
 
     return [...postMarkers, ...sightingMarkers];

--- a/apps/api/src/sightings/dto/create-sighting.dto.spec.ts
+++ b/apps/api/src/sightings/dto/create-sighting.dto.spec.ts
@@ -1,0 +1,15 @@
+import { validate } from "class-validator";
+import { CreateSightingDto } from "./create-sighting.dto";
+
+describe("CreateSightingDto", () => {
+  it("postId がなくてもバリデーションエラーにならないこと", async () => {
+    const dto = new CreateSightingDto();
+    dto.lat = 35.9;
+    dto.lng = 139.6;
+    dto.sightedAt = "2026-04-19T10:00:00.000Z";
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/apps/api/src/sightings/dto/create-sighting.dto.spec.ts
+++ b/apps/api/src/sightings/dto/create-sighting.dto.spec.ts
@@ -12,4 +12,16 @@ describe("CreateSightingDto", () => {
 
     expect(errors).toHaveLength(0);
   });
+
+  it("postId が空文字のときはバリデーションエラーになること", async () => {
+    const dto = new CreateSightingDto();
+    dto.postId = "";
+    dto.lat = 35.9;
+    dto.lng = 139.6;
+    dto.sightedAt = "2026-04-19T10:00:00.000Z";
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === "postId")).toBe(true);
+  });
 });

--- a/apps/api/src/sightings/dto/create-sighting.dto.ts
+++ b/apps/api/src/sightings/dto/create-sighting.dto.ts
@@ -1,10 +1,17 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsDateString, IsNumber, IsOptional, IsString } from "class-validator";
+import {
+  IsDateString,
+  IsNumber,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from "class-validator";
 
 export class CreateSightingDto {
   @ApiProperty({ required: false })
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   postId?: string;
   @ApiProperty() @IsNumber() lat: number;
   @ApiProperty() @IsNumber() lng: number;

--- a/apps/api/src/sightings/dto/create-sighting.dto.ts
+++ b/apps/api/src/sightings/dto/create-sighting.dto.ts
@@ -2,7 +2,10 @@ import { ApiProperty } from "@nestjs/swagger";
 import { IsDateString, IsNumber, IsOptional, IsString } from "class-validator";
 
 export class CreateSightingDto {
-  @ApiProperty() @IsString() postId: string;
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  postId?: string;
   @ApiProperty() @IsNumber() lat: number;
   @ApiProperty() @IsNumber() lng: number;
   @ApiProperty({ required: false }) @IsOptional() @IsString() address?: string;

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -66,6 +66,39 @@ describe("SightingsService", () => {
       expect(result).toMatchObject({ id: "s-1" });
     });
 
+    it("postId がない時は Post チェックをスキップして Sighting を作成できること", async () => {
+      const dtoWithoutPostId = {
+        lat: 35.9,
+        lng: 139.6,
+        sightedAt: "2026-04-19T10:00:00.000Z",
+      };
+      mockPrisma.sighting.create.mockResolvedValue({
+        id: "s-standalone",
+        postId: null,
+        userId: "other-user",
+        ...dtoWithoutPostId,
+      });
+
+      const result = await service.create(
+        "other-user",
+        dtoWithoutPostId as never
+      );
+
+      expect(mockPrisma.post.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.sighting.create).toHaveBeenCalledWith({
+        data: {
+          postId: null,
+          userId: "other-user",
+          lat: 35.9,
+          lng: 139.6,
+          address: undefined,
+          sightedAt: new Date("2026-04-19T10:00:00.000Z"),
+          comment: undefined,
+        },
+      });
+      expect(result).toMatchObject({ id: "s-standalone", postId: null });
+    });
+
     it("投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException", async () => {
       mockPrisma.post.findUnique.mockResolvedValue({
         id: "post-1",

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -99,6 +99,25 @@ describe("SightingsService", () => {
       expect(result).toMatchObject({ id: "s-standalone", postId: null });
     });
 
+    it("postId が空文字の時は Post チェックを行って NotFoundException になること", async () => {
+      const dtoWithEmptyPostId = {
+        postId: "",
+        lat: 35.9,
+        lng: 139.6,
+        sightedAt: "2026-04-19T10:00:00.000Z",
+      };
+
+      mockPrisma.post.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create("other-user", dtoWithEmptyPostId as never)
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockPrisma.post.findUnique).toHaveBeenCalledWith({
+        where: { id: "" },
+      });
+    });
+
     it("投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException", async () => {
       mockPrisma.post.findUnique.mockResolvedValue({
         id: "post-1",

--- a/apps/api/src/sightings/sighting.service.ts
+++ b/apps/api/src/sightings/sighting.service.ts
@@ -14,7 +14,7 @@ export class SightingsService {
   constructor(private prisma: PrismaService) {}
 
   async create(userId: string, dto: CreateSightingDto) {
-    if (dto.postId) {
+    if (dto.postId != null) {
       const post = await this.prisma.post.findUnique({
         where: { id: dto.postId },
       });

--- a/apps/api/src/sightings/sighting.service.ts
+++ b/apps/api/src/sightings/sighting.service.ts
@@ -14,16 +14,18 @@ export class SightingsService {
   constructor(private prisma: PrismaService) {}
 
   async create(userId: string, dto: CreateSightingDto) {
-    const post = await this.prisma.post.findUnique({
-      where: { id: dto.postId },
-    });
-    if (!post) throw new NotFoundException("投稿が見つかりません");
-    if (post.userId === userId)
-      throw new ForbiddenException("投稿者本人はSightingを作成できません");
+    if (dto.postId) {
+      const post = await this.prisma.post.findUnique({
+        where: { id: dto.postId },
+      });
+      if (!post) throw new NotFoundException("投稿が見つかりません");
+      if (post.userId === userId)
+        throw new ForbiddenException("投稿者本人はSightingを作成できません");
+    }
 
     return this.prisma.sighting.create({
       data: {
-        postId: dto.postId,
+        postId: dto.postId ?? null,
         userId,
         lat: dto.lat,
         lng: dto.lng,

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -1,1 +1,846 @@
-{"openapi":"3.0.0","paths":{"/api/users":{"get":{"operationId":"UsersController_findAll","parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/UserResponseDto"}}}}},"401":{"description":"認証が必要です"},"403":{"description":"管理者のみ"}},"tags":["users"],"security":[{"bearer":[]}]}},"/api/users/{id}":{"delete":{"operationId":"UsersController_remove","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":"ユーザー削除成功"},"401":{"description":"認証が必要です"},"403":{"description":"管理者のみ"},"404":{"description":"ユーザーが見つかりません"}},"tags":["users"],"security":[{"bearer":[]}]}},"/api/users/register":{"post":{"operationId":"UsersController_register","parameters":[],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/RegisterDto"}}}},"responses":{"201":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserResponseDto"}}}}},"tags":["users"]}},"/api/posts":{"post":{"operationId":"PostsController_create","parameters":[],"requestBody":{"required":true,"content":{"multipart/form-data":{"schema":{"type":"object","properties":{"postType":{"type":"string","enum":["cat"],"default":"cat"},"title":{"type":"string"},"description":{"type":"string"},"lostDate":{"type":"string"},"petDetail":{"type":"string","description":"JSON string"},"location":{"type":"string","description":"JSON string"},"images":{"type":"array","items":{"type":"string","format":"binary"}}}}}}},"responses":{"201":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}}},"tags":["posts"],"security":[{"bearer":[]}]},"get":{"operationId":"PostsController_list","parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostListResponseDto"}}}}},"tags":["posts"],"security":[{"bearer":[]}]}},"/api/posts/{id}":{"get":{"operationId":"PostsController_get","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}}},"tags":["posts"],"security":[{"bearer":[]}]},"patch":{"operationId":"PostsController_update","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/UpdatePostDto"}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}},"403":{"description":"Forbidden: not the post owner"}},"tags":["posts"],"security":[{"bearer":[]}]},"delete":{"operationId":"PostsController_remove","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PostResponseDto"}}}},"403":{"description":"Forbidden: not the post owner or admin"}},"tags":["posts"],"security":[{"bearer":[]}]}},"/api/posts/{id}/images":{"post":{"operationId":"PostsController_addImages","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"requestBody":{"required":true,"content":{"multipart/form-data":{"schema":{"type":"object","properties":{"images":{"type":"array","items":{"type":"string","format":"binary"}}}}}}},"responses":{"201":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AddImagesResponseDto"}}}},"400":{"description":"画像枚数上限超過"},"403":{"description":"Forbidden: not the post owner"}},"tags":["posts"],"security":[{"bearer":[]}]}},"/api/posts/{id}/images/{imageId}":{"delete":{"operationId":"PostsController_removeImage","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}},{"name":"imageId","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ImageResponseDto"}}}},"403":{"description":"Forbidden: not the post owner or admin"},"404":{"description":"Image not found"}},"tags":["posts"],"security":[{"bearer":[]}]}},"/api/posts/{id}/favorite":{"post":{"operationId":"PostsController_toggleFavorite","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"201":{"description":"","content":{"application/json":{"schema":{"properties":{"favorited":{"type":"boolean"}}}}}},"400":{"description":"お気に入り上限超過"},"403":{"description":"自分の投稿はお気に入り不可"},"404":{"description":"Post not found"}},"tags":["posts"],"security":[{"bearer":[]}]}},"/api/auth/login":{"post":{"operationId":"AuthController_login","parameters":[],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/LoginDto"}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AccessTokenResponseDto"}}}}},"tags":["auth"]}},"/api/auth/refresh":{"post":{"operationId":"AuthController_refresh","parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AccessTokenResponseDto"}}}}},"tags":["auth"]}},"/api/auth/logout":{"post":{"operationId":"AuthController_logout","parameters":[],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/LogoutResponseDto"}}}}},"tags":["auth"]}},"/api/map/markers":{"get":{"operationId":"MapController_getMarkers","parameters":[{"name":"minLat","required":false,"in":"query","schema":{"type":"number"}},{"name":"maxLat","required":false,"in":"query","schema":{"type":"number"}},{"name":"minLng","required":false,"in":"query","schema":{"type":"number"}},{"name":"maxLng","required":false,"in":"query","schema":{"type":"number"}},{"name":"status","required":false,"in":"query","schema":{"enum":["lost","resolved"],"type":"string"}}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/MapMarkerDto"}}}}}},"tags":["map"]}},"/api/sightings":{"post":{"operationId":"SightingsController_create","summary":"目撃情報を作成する","parameters":[],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CreateSightingDto"}}}},"responses":{"201":{"description":""}},"tags":["sightings"],"security":[{"bearer":[]}]},"get":{"operationId":"SightingsController_findByPost","summary":"postId別の目撃情報一覧を取得する","parameters":[{"name":"postId","required":true,"in":"query","schema":{"type":"string"}}],"responses":{"200":{"description":""}},"tags":["sightings"]}},"/api/sightings/{id}":{"delete":{"operationId":"SightingsController_remove","summary":"目撃情報を削除する（本人または管理者）","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"204":{"description":""}},"tags":["sightings"],"security":[{"bearer":[]}]}},"/api/sightings/{id}/favorite":{"post":{"operationId":"SightingsController_toggleFavorite","summary":"目撃情報のお気に入りをトグルする","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"201":{"description":"","content":{"application/json":{"schema":{"properties":{"favorited":{"type":"boolean"}}}}}},"400":{"description":"お気に入り上限超過"},"404":{"description":"Sighting not found"}},"tags":["sightings"],"security":[{"bearer":[]}]}},"/api/conversations":{"post":{"operationId":"ConversationsController_create","summary":"会話を作成する","parameters":[],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CreateConversationDto"}}}},"responses":{"201":{"description":""}},"tags":["conversations"],"security":[{"bearer":[]}]},"get":{"operationId":"ConversationsController_findAll","summary":"自分が参加する会話一覧を取得する","parameters":[],"responses":{"200":{"description":""}},"tags":["conversations"],"security":[{"bearer":[]}]}},"/api/conversations/{id}/messages":{"post":{"operationId":"ConversationsController_createMessage","summary":"メッセージを送信する","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CreateMessageDto"}}}},"responses":{"201":{"description":""}},"tags":["conversations"],"security":[{"bearer":[]}]},"get":{"operationId":"ConversationsController_findMessages","summary":"メッセージ一覧を取得する","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":""}},"tags":["conversations"],"security":[{"bearer":[]}]}},"/api/conversations/{id}/messages/read":{"patch":{"operationId":"ConversationsController_markAsRead","summary":"会話内の未読メッセージを既読にする","parameters":[{"name":"id","required":true,"in":"path","schema":{"type":"string"}}],"responses":{"200":{"description":""}},"tags":["conversations"],"security":[{"bearer":[]}]}}},"info":{"title":"API","description":"API description","version":"1.0","contact":{}},"tags":[],"servers":[],"components":{"securitySchemes":{"bearer":{"scheme":"bearer","bearerFormat":"JWT","type":"http"}},"schemas":{"UserResponseDto":{"type":"object","properties":{"id":{"type":"string"},"email":{"type":"string"},"nickname":{"type":"string"},"createdAt":{"format":"date-time","type":"string"}},"required":["id","email","nickname","createdAt"]},"RegisterDto":{"type":"object","properties":{"email":{"type":"string","example":"user@example.com"},"password":{"type":"string","example":"password123","minLength":8},"name":{"type":"string","example":"Alice"},"nickname":{"type":"string","example":"Alice"}},"required":["email","password"]},"PetDetailResponseDto":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"color":{"type":"string"},"age":{"type":"string"},"features":{"type":"string"},"gender":{"type":"string","nullable":true},"breed":{"type":"string","nullable":true},"size":{"type":"string","nullable":true},"collar":{"type":"string","nullable":true},"microchip":{"type":"boolean","nullable":true},"neutered":{"type":"boolean","nullable":true}},"required":["id","name","color","age","features"]},"LocationResponseDto":{"type":"object","properties":{"id":{"type":"string"},"prefecture":{"type":"string"},"city":{"type":"string"},"address":{"type":"string"},"lat":{"type":"number"},"lng":{"type":"number"}},"required":["id","prefecture","city","address","lat","lng"]},"ImageResponseDto":{"type":"object","properties":{"id":{"type":"string"},"postId":{"type":"string"},"url":{"type":"string"},"createdAt":{"format":"date-time","type":"string"}},"required":["id","postId","url","createdAt"]},"PostResponseDto":{"type":"object","properties":{"id":{"type":"string"},"postType":{"type":"string","enum":["cat"]},"title":{"type":"string","nullable":true},"description":{"type":"string"},"userId":{"type":"string"},"status":{"type":"string"},"lostDate":{"format":"date-time","type":"string"},"resolvedAt":{"format":"date-time","type":"string","nullable":true},"petDetail":{"nullable":true,"allOf":[{"$ref":"#/components/schemas/PetDetailResponseDto"}]},"location":{"nullable":true,"allOf":[{"$ref":"#/components/schemas/LocationResponseDto"}]},"images":{"type":"array","items":{"$ref":"#/components/schemas/ImageResponseDto"}},"createdAt":{"format":"date-time","type":"string"},"updatedAt":{"format":"date-time","type":"string"}},"required":["id","postType","description","userId","status","lostDate","images","createdAt","updatedAt"]},"PostListResponseDto":{"type":"object","properties":{"items":{"type":"array","items":{"$ref":"#/components/schemas/PostResponseDto"}},"total":{"type":"number"}},"required":["items","total"]},"UpdatePetDetailDto":{"type":"object","properties":{"name":{"type":"string"},"color":{"type":"string"},"age":{"type":"string"},"features":{"type":"string"},"gender":{"type":"string","enum":["male","female","unknown"]},"breed":{"type":"string"},"size":{"type":"string"},"collar":{"type":"string"},"microchip":{"type":"boolean"},"neutered":{"type":"boolean"}}},"UpdateLocationDto":{"type":"object","properties":{"prefecture":{"type":"string","enum":["saitama"]},"city":{"type":"string"},"address":{"type":"string"},"lat":{"type":"number"},"lng":{"type":"number"}}},"UpdatePostDto":{"type":"object","properties":{"title":{"type":"string"},"description":{"type":"string"},"lostDate":{"type":"string","example":"2024-01-01"},"status":{"type":"string","enum":["lost","resolved"]},"petDetail":{"$ref":"#/components/schemas/UpdatePetDetailDto"},"location":{"$ref":"#/components/schemas/UpdateLocationDto"}}},"AddImagesResponseDto":{"type":"object","properties":{"remainingSlots":{"type":"number"},"images":{"type":"array","items":{"$ref":"#/components/schemas/ImageResponseDto"}}},"required":["remainingSlots","images"]},"LoginDto":{"type":"object","properties":{"email":{"type":"string","example":"user@example.com"},"password":{"type":"string","example":"password123","minLength":8}},"required":["email","password"]},"AccessTokenResponseDto":{"type":"object","properties":{"accessToken":{"type":"string"}},"required":["accessToken"]},"LogoutResponseDto":{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]},"MapMarkerDto":{"type":"object","properties":{"type":{"type":"string","enum":["post","sighting"]},"id":{"type":"string"},"postId":{"type":"string"},"lat":{"type":"number"},"lng":{"type":"number"},"status":{"type":"string","enum":["lost","resolved"]}},"required":["type","id","lat","lng","status"]},"CreateSightingDto":{"type":"object","properties":{"postId":{"type":"string"},"lat":{"type":"number"},"lng":{"type":"number"},"address":{"type":"string"},"sightedAt":{"type":"string"},"comment":{"type":"string"}},"required":["postId","lat","lng","sightedAt"]},"CreateConversationDto":{"type":"object","properties":{"postId":{"type":"string"},"sightingId":{"type":"string"}},"required":["postId","sightingId"]},"CreateMessageDto":{"type":"object","properties":{"body":{"type":"string","maxLength":1000}},"required":["body"]}}}}
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/users": {
+      "get": {
+        "operationId": "UsersController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/UserResponseDto" }
+                }
+              }
+            }
+          },
+          "401": { "description": "認証が必要です" },
+          "403": { "description": "管理者のみ" }
+        },
+        "tags": ["users"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/users/{id}": {
+      "delete": {
+        "operationId": "UsersController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "ユーザー削除成功" },
+          "401": { "description": "認証が必要です" },
+          "403": { "description": "管理者のみ" },
+          "404": { "description": "ユーザーが見つかりません" }
+        },
+        "tags": ["users"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/users/register": {
+      "post": {
+        "operationId": "UsersController_register",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RegisterDto" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["users"]
+      }
+    },
+    "/api/posts": {
+      "post": {
+        "operationId": "PostsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "postType": {
+                    "type": "string",
+                    "enum": ["cat"],
+                    "default": "cat"
+                  },
+                  "title": { "type": "string" },
+                  "description": { "type": "string" },
+                  "lostDate": { "type": "string" },
+                  "petDetail": {
+                    "type": "string",
+                    "description": "JSON string"
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "JSON string"
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": { "type": "string", "format": "binary" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "PostsController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostListResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/posts/{id}": {
+      "get": {
+        "operationId": "PostsController_get",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      },
+      "patch": {
+        "operationId": "PostsController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdatePostDto" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          },
+          "403": { "description": "Forbidden: not the post owner" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      },
+      "delete": {
+        "operationId": "PostsController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+              }
+            }
+          },
+          "403": { "description": "Forbidden: not the post owner or admin" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/posts/{id}/images": {
+      "post": {
+        "operationId": "PostsController_addImages",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "images": {
+                    "type": "array",
+                    "items": { "type": "string", "format": "binary" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddImagesResponseDto"
+                }
+              }
+            }
+          },
+          "400": { "description": "画像枚数上限超過" },
+          "403": { "description": "Forbidden: not the post owner" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/posts/{id}/images/{imageId}": {
+      "delete": {
+        "operationId": "PostsController_removeImage",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "imageId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ImageResponseDto" }
+              }
+            }
+          },
+          "403": { "description": "Forbidden: not the post owner or admin" },
+          "404": { "description": "Image not found" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/posts/{id}/favorite": {
+      "post": {
+        "operationId": "PostsController_toggleFavorite",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": { "favorited": { "type": "boolean" } }
+                }
+              }
+            }
+          },
+          "400": { "description": "お気に入り上限超過" },
+          "403": { "description": "自分の投稿はお気に入り不可" },
+          "404": { "description": "Post not found" }
+        },
+        "tags": ["posts"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "operationId": "AuthController_login",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/LoginDto" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessTokenResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "operationId": "AuthController_refresh",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessTokenResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "operationId": "AuthController_logout",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LogoutResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/map/markers": {
+      "get": {
+        "operationId": "MapController_getMarkers",
+        "parameters": [
+          {
+            "name": "minLat",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "maxLat",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "minLng",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "maxLng",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "schema": { "enum": ["lost", "resolved"], "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/MapMarkerDto" }
+                }
+              }
+            }
+          }
+        },
+        "tags": ["map"]
+      }
+    },
+    "/api/sightings": {
+      "post": {
+        "operationId": "SightingsController_create",
+        "summary": "目撃情報を作成する",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateSightingDto" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "" } },
+        "tags": ["sightings"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "SightingsController_findByPost",
+        "summary": "postId別の目撃情報一覧を取得する",
+        "parameters": [
+          {
+            "name": "postId",
+            "required": true,
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "" } },
+        "tags": ["sightings"]
+      }
+    },
+    "/api/sightings/{id}": {
+      "delete": {
+        "operationId": "SightingsController_remove",
+        "summary": "目撃情報を削除する（本人または管理者）",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "204": { "description": "" } },
+        "tags": ["sightings"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/sightings/{id}/favorite": {
+      "post": {
+        "operationId": "SightingsController_toggleFavorite",
+        "summary": "目撃情報のお気に入りをトグルする",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": { "favorited": { "type": "boolean" } }
+                }
+              }
+            }
+          },
+          "400": { "description": "お気に入り上限超過" },
+          "404": { "description": "Sighting not found" }
+        },
+        "tags": ["sightings"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/conversations": {
+      "post": {
+        "operationId": "ConversationsController_create",
+        "summary": "会話を作成する",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateConversationDto" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "ConversationsController_findAll",
+        "summary": "自分が参加する会話一覧を取得する",
+        "parameters": [],
+        "responses": { "200": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/conversations/{id}/messages": {
+      "post": {
+        "operationId": "ConversationsController_createMessage",
+        "summary": "メッセージを送信する",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateMessageDto" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      },
+      "get": {
+        "operationId": "ConversationsController_findMessages",
+        "summary": "メッセージ一覧を取得する",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      }
+    },
+    "/api/conversations/{id}/messages/read": {
+      "patch": {
+        "operationId": "ConversationsController_markAsRead",
+        "summary": "会話内の未読メッセージを既読にする",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "" } },
+        "tags": ["conversations"],
+        "security": [{ "bearer": [] }]
+      }
+    }
+  },
+  "info": {
+    "title": "API",
+    "description": "API description",
+    "version": "1.0",
+    "contact": {}
+  },
+  "tags": [],
+  "servers": [],
+  "components": {
+    "securitySchemes": {
+      "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" }
+    },
+    "schemas": {
+      "UserResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "email": { "type": "string" },
+          "nickname": { "type": "string" },
+          "createdAt": { "format": "date-time", "type": "string" }
+        },
+        "required": ["id", "email", "nickname", "createdAt"]
+      },
+      "RegisterDto": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string", "example": "user@example.com" },
+          "password": {
+            "type": "string",
+            "example": "password123",
+            "minLength": 8
+          },
+          "name": { "type": "string", "example": "Alice" },
+          "nickname": { "type": "string", "example": "Alice" }
+        },
+        "required": ["email", "password"]
+      },
+      "PetDetailResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "color": { "type": "string" },
+          "age": { "type": "string" },
+          "features": { "type": "string" },
+          "gender": { "type": "string", "nullable": true },
+          "breed": { "type": "string", "nullable": true },
+          "size": { "type": "string", "nullable": true },
+          "collar": { "type": "string", "nullable": true },
+          "microchip": { "type": "boolean", "nullable": true },
+          "neutered": { "type": "boolean", "nullable": true }
+        },
+        "required": ["id", "name", "color", "age", "features"]
+      },
+      "LocationResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "prefecture": { "type": "string" },
+          "city": { "type": "string" },
+          "address": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" }
+        },
+        "required": ["id", "prefecture", "city", "address", "lat", "lng"]
+      },
+      "ImageResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "postId": { "type": "string" },
+          "url": { "type": "string" },
+          "createdAt": { "format": "date-time", "type": "string" }
+        },
+        "required": ["id", "postId", "url", "createdAt"]
+      },
+      "PostResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "postType": { "type": "string", "enum": ["cat"] },
+          "title": { "type": "string", "nullable": true },
+          "description": { "type": "string" },
+          "userId": { "type": "string" },
+          "status": { "type": "string" },
+          "lostDate": { "format": "date-time", "type": "string" },
+          "resolvedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "petDetail": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/PetDetailResponseDto" }]
+          },
+          "location": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/LocationResponseDto" }]
+          },
+          "images": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ImageResponseDto" }
+          },
+          "createdAt": { "format": "date-time", "type": "string" },
+          "updatedAt": { "format": "date-time", "type": "string" }
+        },
+        "required": [
+          "id",
+          "postType",
+          "description",
+          "userId",
+          "status",
+          "lostDate",
+          "images",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "PostListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/PostResponseDto" }
+          },
+          "total": { "type": "number" }
+        },
+        "required": ["items", "total"]
+      },
+      "UpdatePetDetailDto": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "color": { "type": "string" },
+          "age": { "type": "string" },
+          "features": { "type": "string" },
+          "gender": { "type": "string", "enum": ["male", "female", "unknown"] },
+          "breed": { "type": "string" },
+          "size": { "type": "string" },
+          "collar": { "type": "string" },
+          "microchip": { "type": "boolean" },
+          "neutered": { "type": "boolean" }
+        }
+      },
+      "UpdateLocationDto": {
+        "type": "object",
+        "properties": {
+          "prefecture": { "type": "string", "enum": ["saitama"] },
+          "city": { "type": "string" },
+          "address": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" }
+        }
+      },
+      "UpdatePostDto": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "lostDate": { "type": "string", "example": "2024-01-01" },
+          "status": { "type": "string", "enum": ["lost", "resolved"] },
+          "petDetail": { "$ref": "#/components/schemas/UpdatePetDetailDto" },
+          "location": { "$ref": "#/components/schemas/UpdateLocationDto" }
+        }
+      },
+      "AddImagesResponseDto": {
+        "type": "object",
+        "properties": {
+          "remainingSlots": { "type": "number" },
+          "images": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ImageResponseDto" }
+          }
+        },
+        "required": ["remainingSlots", "images"]
+      },
+      "LoginDto": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string", "example": "user@example.com" },
+          "password": {
+            "type": "string",
+            "example": "password123",
+            "minLength": 8
+          }
+        },
+        "required": ["email", "password"]
+      },
+      "AccessTokenResponseDto": {
+        "type": "object",
+        "properties": { "accessToken": { "type": "string" } },
+        "required": ["accessToken"]
+      },
+      "LogoutResponseDto": {
+        "type": "object",
+        "properties": { "ok": { "type": "boolean" } },
+        "required": ["ok"]
+      },
+      "MapMarkerDto": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "enum": ["post", "sighting"] },
+          "id": { "type": "string" },
+          "postId": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" },
+          "status": {
+            "type": "string",
+            "enum": ["lost", "resolved"],
+            "default": "lost"
+          }
+        },
+        "required": ["type", "id", "lat", "lng", "status"]
+      },
+      "CreateSightingDto": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "string" },
+          "lat": { "type": "number" },
+          "lng": { "type": "number" },
+          "address": { "type": "string" },
+          "sightedAt": { "type": "string" },
+          "comment": { "type": "string" }
+        },
+        "required": ["lat", "lng", "sightedAt"]
+      },
+      "CreateConversationDto": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "string" },
+          "sightingId": { "type": "string" }
+        },
+        "required": ["postId", "sightingId"]
+      },
+      "CreateMessageDto": {
+        "type": "object",
+        "properties": { "body": { "type": "string", "maxLength": 1000 } },
+        "required": ["body"]
+      }
+    }
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -5,34 +5,31 @@
  * API description
  * OpenAPI spec version: 1.0
  */
-import axios from 'axios'
-import type {
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios'
+import axios from "axios";
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
 export type SightingsControllerToggleFavorite201 = {
   favorited?: boolean;
 };
 
 export type SightingsControllerFindByPostParams = {
-postId: string;
+  postId: string;
 };
 
-export type MapControllerGetMarkersStatus = typeof MapControllerGetMarkersStatus[keyof typeof MapControllerGetMarkersStatus];
-
+export type MapControllerGetMarkersStatus =
+  (typeof MapControllerGetMarkersStatus)[keyof typeof MapControllerGetMarkersStatus];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const MapControllerGetMarkersStatus = {
-  lost: 'lost',
-  resolved: 'resolved',
+  lost: "lost",
+  resolved: "resolved",
 } as const;
 
 export type MapControllerGetMarkersParams = {
-minLat?: number;
-maxLat?: number;
-minLng?: number;
-maxLng?: number;
-status?: MapControllerGetMarkersStatus;
+  minLat?: number;
+  maxLat?: number;
+  minLng?: number;
+  maxLng?: number;
+  status?: MapControllerGetMarkersStatus;
 };
 
 export type PostsControllerToggleFavorite201 = {
@@ -43,12 +40,12 @@ export type PostsControllerAddImagesBody = {
   images?: Blob[];
 };
 
-export type PostsControllerCreateBodyPostType = typeof PostsControllerCreateBodyPostType[keyof typeof PostsControllerCreateBodyPostType];
-
+export type PostsControllerCreateBodyPostType =
+  (typeof PostsControllerCreateBodyPostType)[keyof typeof PostsControllerCreateBodyPostType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const PostsControllerCreateBodyPostType = {
-  cat: 'cat',
+  cat: "cat",
 } as const;
 
 export type PostsControllerCreateBody = {
@@ -78,26 +75,26 @@ export interface CreateSightingDto {
   comment?: string;
   lat: number;
   lng: number;
-  postId: string;
+  postId?: string;
   sightedAt: string;
 }
 
-export type MapMarkerDtoType = typeof MapMarkerDtoType[keyof typeof MapMarkerDtoType];
-
+export type MapMarkerDtoType =
+  (typeof MapMarkerDtoType)[keyof typeof MapMarkerDtoType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const MapMarkerDtoType = {
-  post: 'post',
-  sighting: 'sighting',
+  post: "post",
+  sighting: "sighting",
 } as const;
 
-export type MapMarkerDtoStatus = typeof MapMarkerDtoStatus[keyof typeof MapMarkerDtoStatus];
-
+export type MapMarkerDtoStatus =
+  (typeof MapMarkerDtoStatus)[keyof typeof MapMarkerDtoStatus];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const MapMarkerDtoStatus = {
-  lost: 'lost',
-  resolved: 'resolved',
+  lost: "lost",
+  resolved: "resolved",
 } as const;
 
 export interface MapMarkerDto {
@@ -128,13 +125,13 @@ export interface AddImagesResponseDto {
   remainingSlots: number;
 }
 
-export type UpdatePostDtoStatus = typeof UpdatePostDtoStatus[keyof typeof UpdatePostDtoStatus];
-
+export type UpdatePostDtoStatus =
+  (typeof UpdatePostDtoStatus)[keyof typeof UpdatePostDtoStatus];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const UpdatePostDtoStatus = {
-  lost: 'lost',
-  resolved: 'resolved',
+  lost: "lost",
+  resolved: "resolved",
 } as const;
 
 export interface UpdatePostDto {
@@ -146,12 +143,12 @@ export interface UpdatePostDto {
   title?: string;
 }
 
-export type UpdateLocationDtoPrefecture = typeof UpdateLocationDtoPrefecture[keyof typeof UpdateLocationDtoPrefecture];
-
+export type UpdateLocationDtoPrefecture =
+  (typeof UpdateLocationDtoPrefecture)[keyof typeof UpdateLocationDtoPrefecture];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const UpdateLocationDtoPrefecture = {
-  saitama: 'saitama',
+  saitama: "saitama",
 } as const;
 
 export interface UpdateLocationDto {
@@ -162,14 +159,14 @@ export interface UpdateLocationDto {
   prefecture?: UpdateLocationDtoPrefecture;
 }
 
-export type UpdatePetDetailDtoGender = typeof UpdatePetDetailDtoGender[keyof typeof UpdatePetDetailDtoGender];
-
+export type UpdatePetDetailDtoGender =
+  (typeof UpdatePetDetailDtoGender)[keyof typeof UpdatePetDetailDtoGender];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const UpdatePetDetailDtoGender = {
-  male: 'male',
-  female: 'female',
-  unknown: 'unknown',
+  male: "male",
+  female: "female",
+  unknown: "unknown",
 } as const;
 
 export interface UpdatePetDetailDto {
@@ -185,12 +182,12 @@ export interface UpdatePetDetailDto {
   size?: string;
 }
 
-export type PostResponseDtoPostType = typeof PostResponseDtoPostType[keyof typeof PostResponseDtoPostType];
-
+export type PostResponseDtoPostType =
+  (typeof PostResponseDtoPostType)[keyof typeof PostResponseDtoPostType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const PostResponseDtoPostType = {
-  cat: 'cat',
+  cat: "cat",
 } as const;
 
 /**
@@ -279,292 +276,288 @@ export interface UserResponseDto {
   nickname: string;
 }
 
-
-
-
-
-  export const usersControllerFindAll = <TData = AxiosResponse<UserResponseDto[]>>(
-     options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/users`,options
-    );
-  }
+export const usersControllerFindAll = <
+  TData = AxiosResponse<UserResponseDto[]>,
+>(
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/users`, options);
+};
 
 export const usersControllerRemove = <TData = AxiosResponse<void>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.delete(
-      `/api/users/${id}`,options
-    );
-  }
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.delete(`/api/users/${id}`, options);
+};
 
 export const usersControllerRegister = <TData = AxiosResponse<UserResponseDto>>(
-    registerDto: RegisterDto, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/users/register`,
-      registerDto,options
-    );
-  }
+  registerDto: RegisterDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/users/register`, registerDto, options);
+};
 
 export const postsControllerCreate = <TData = AxiosResponse<PostResponseDto>>(
-    postsControllerCreateBody: PostsControllerCreateBody, options?: AxiosRequestConfig
- ): Promise<TData> => {const formData = new FormData();
-if(postsControllerCreateBody.postType !== undefined) {
- formData.append('postType', postsControllerCreateBody.postType)
- }
-if(postsControllerCreateBody.title !== undefined) {
- formData.append('title', postsControllerCreateBody.title)
- }
-if(postsControllerCreateBody.description !== undefined) {
- formData.append('description', postsControllerCreateBody.description)
- }
-if(postsControllerCreateBody.lostDate !== undefined) {
- formData.append('lostDate', postsControllerCreateBody.lostDate)
- }
-if(postsControllerCreateBody.petDetail !== undefined) {
- formData.append('petDetail', postsControllerCreateBody.petDetail)
- }
-if(postsControllerCreateBody.location !== undefined) {
- formData.append('location', postsControllerCreateBody.location)
- }
-if(postsControllerCreateBody.images !== undefined) {
- postsControllerCreateBody.images.forEach(value => formData.append('images', value));
- }
-
-    return axios.post(
-      `/api/posts`,
-      formData,options
+  postsControllerCreateBody: PostsControllerCreateBody,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  const formData = new FormData();
+  if (postsControllerCreateBody.postType !== undefined) {
+    formData.append("postType", postsControllerCreateBody.postType);
+  }
+  if (postsControllerCreateBody.title !== undefined) {
+    formData.append("title", postsControllerCreateBody.title);
+  }
+  if (postsControllerCreateBody.description !== undefined) {
+    formData.append("description", postsControllerCreateBody.description);
+  }
+  if (postsControllerCreateBody.lostDate !== undefined) {
+    formData.append("lostDate", postsControllerCreateBody.lostDate);
+  }
+  if (postsControllerCreateBody.petDetail !== undefined) {
+    formData.append("petDetail", postsControllerCreateBody.petDetail);
+  }
+  if (postsControllerCreateBody.location !== undefined) {
+    formData.append("location", postsControllerCreateBody.location);
+  }
+  if (postsControllerCreateBody.images !== undefined) {
+    postsControllerCreateBody.images.forEach((value) =>
+      formData.append("images", value)
     );
   }
+
+  return axios.post(`/api/posts`, formData, options);
+};
 
 export const postsControllerList = <TData = AxiosResponse<PostListResponseDto>>(
-     options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/posts`,options
-    );
-  }
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/posts`, options);
+};
 
 export const postsControllerGet = <TData = AxiosResponse<PostResponseDto>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/posts/${id}`,options
-    );
-  }
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/posts/${id}`, options);
+};
 
 export const postsControllerUpdate = <TData = AxiosResponse<PostResponseDto>>(
-    id: string,
-    updatePostDto: UpdatePostDto, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.patch(
-      `/api/posts/${id}`,
-      updatePostDto,options
-    );
-  }
+  id: string,
+  updatePostDto: UpdatePostDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.patch(`/api/posts/${id}`, updatePostDto, options);
+};
 
 export const postsControllerRemove = <TData = AxiosResponse<PostResponseDto>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.delete(
-      `/api/posts/${id}`,options
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.delete(`/api/posts/${id}`, options);
+};
+
+export const postsControllerAddImages = <
+  TData = AxiosResponse<AddImagesResponseDto>,
+>(
+  id: string,
+  postsControllerAddImagesBody: PostsControllerAddImagesBody,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  const formData = new FormData();
+  if (postsControllerAddImagesBody.images !== undefined) {
+    postsControllerAddImagesBody.images.forEach((value) =>
+      formData.append("images", value)
     );
   }
 
-export const postsControllerAddImages = <TData = AxiosResponse<AddImagesResponseDto>>(
-    id: string,
-    postsControllerAddImagesBody: PostsControllerAddImagesBody, options?: AxiosRequestConfig
- ): Promise<TData> => {const formData = new FormData();
-if(postsControllerAddImagesBody.images !== undefined) {
- postsControllerAddImagesBody.images.forEach(value => formData.append('images', value));
- }
+  return axios.post(`/api/posts/${id}/images`, formData, options);
+};
 
-    return axios.post(
-      `/api/posts/${id}/images`,
-      formData,options
-    );
-  }
+export const postsControllerRemoveImage = <
+  TData = AxiosResponse<ImageResponseDto>,
+>(
+  id: string,
+  imageId: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.delete(`/api/posts/${id}/images/${imageId}`, options);
+};
 
-export const postsControllerRemoveImage = <TData = AxiosResponse<ImageResponseDto>>(
-    id: string,
-    imageId: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.delete(
-      `/api/posts/${id}/images/${imageId}`,options
-    );
-  }
+export const postsControllerToggleFavorite = <
+  TData = AxiosResponse<PostsControllerToggleFavorite201>,
+>(
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/posts/${id}/favorite`, undefined, options);
+};
 
-export const postsControllerToggleFavorite = <TData = AxiosResponse<PostsControllerToggleFavorite201>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/posts/${id}/favorite`,undefined,options
-    );
-  }
+export const authControllerLogin = <
+  TData = AxiosResponse<AccessTokenResponseDto>,
+>(
+  loginDto: LoginDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/auth/login`, loginDto, options);
+};
 
-export const authControllerLogin = <TData = AxiosResponse<AccessTokenResponseDto>>(
-    loginDto: LoginDto, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/auth/login`,
-      loginDto,options
-    );
-  }
-
-export const authControllerRefresh = <TData = AxiosResponse<AccessTokenResponseDto>>(
-     options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/auth/refresh`,undefined,options
-    );
-  }
+export const authControllerRefresh = <
+  TData = AxiosResponse<AccessTokenResponseDto>,
+>(
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/auth/refresh`, undefined, options);
+};
 
 export const authControllerLogout = <TData = AxiosResponse<LogoutResponseDto>>(
-     options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/auth/logout`,undefined,options
-    );
-  }
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/auth/logout`, undefined, options);
+};
 
 export const mapControllerGetMarkers = <TData = AxiosResponse<MapMarkerDto[]>>(
-    params?: MapControllerGetMarkersParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/map/markers`,{
+  params?: MapControllerGetMarkersParams,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/map/markers`, {
     ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
+    params: { ...params, ...options?.params },
+  });
+};
 
 /**
  * @summary 目撃情報を作成する
  */
 export const sightingsControllerCreate = <TData = AxiosResponse<void>>(
-    createSightingDto: CreateSightingDto, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/sightings`,
-      createSightingDto,options
-    );
-  }
+  createSightingDto: CreateSightingDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/sightings`, createSightingDto, options);
+};
 
 /**
  * @summary postId別の目撃情報一覧を取得する
  */
 export const sightingsControllerFindByPost = <TData = AxiosResponse<void>>(
-    params: SightingsControllerFindByPostParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/sightings`,{
+  params: SightingsControllerFindByPostParams,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/sightings`, {
     ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
+    params: { ...params, ...options?.params },
+  });
+};
 
 /**
  * @summary 目撃情報を削除する（本人または管理者）
  */
 export const sightingsControllerRemove = <TData = AxiosResponse<void>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.delete(
-      `/api/sightings/${id}`,options
-    );
-  }
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.delete(`/api/sightings/${id}`, options);
+};
 
 /**
  * @summary 目撃情報のお気に入りをトグルする
  */
-export const sightingsControllerToggleFavorite = <TData = AxiosResponse<SightingsControllerToggleFavorite201>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/sightings/${id}/favorite`,undefined,options
-    );
-  }
+export const sightingsControllerToggleFavorite = <
+  TData = AxiosResponse<SightingsControllerToggleFavorite201>,
+>(
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/sightings/${id}/favorite`, undefined, options);
+};
 
 /**
  * @summary 会話を作成する
  */
 export const conversationsControllerCreate = <TData = AxiosResponse<void>>(
-    createConversationDto: CreateConversationDto, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/conversations`,
-      createConversationDto,options
-    );
-  }
+  createConversationDto: CreateConversationDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/conversations`, createConversationDto, options);
+};
 
 /**
  * @summary 自分が参加する会話一覧を取得する
  */
 export const conversationsControllerFindAll = <TData = AxiosResponse<void>>(
-     options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/conversations`,options
-    );
-  }
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/conversations`, options);
+};
 
 /**
  * @summary メッセージを送信する
  */
-export const conversationsControllerCreateMessage = <TData = AxiosResponse<void>>(
-    id: string,
-    createMessageDto: CreateMessageDto, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/conversations/${id}/messages`,
-      createMessageDto,options
-    );
-  }
+export const conversationsControllerCreateMessage = <
+  TData = AxiosResponse<void>,
+>(
+  id: string,
+  createMessageDto: CreateMessageDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(
+    `/api/conversations/${id}/messages`,
+    createMessageDto,
+    options
+  );
+};
 
 /**
  * @summary メッセージ一覧を取得する
  */
-export const conversationsControllerFindMessages = <TData = AxiosResponse<void>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/conversations/${id}/messages`,options
-    );
-  }
+export const conversationsControllerFindMessages = <
+  TData = AxiosResponse<void>,
+>(
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/conversations/${id}/messages`, options);
+};
 
 /**
  * @summary 会話内の未読メッセージを既読にする
  */
 export const conversationsControllerMarkAsRead = <TData = AxiosResponse<void>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.patch(
-      `/api/conversations/${id}/messages/read`,undefined,options
-    );
-  }
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.patch(
+    `/api/conversations/${id}/messages/read`,
+    undefined,
+    options
+  );
+};
 
-export type UsersControllerFindAllResult = AxiosResponse<UserResponseDto[]>
-export type UsersControllerRemoveResult = AxiosResponse<void>
-export type UsersControllerRegisterResult = AxiosResponse<UserResponseDto>
-export type PostsControllerCreateResult = AxiosResponse<PostResponseDto>
-export type PostsControllerListResult = AxiosResponse<PostListResponseDto>
-export type PostsControllerGetResult = AxiosResponse<PostResponseDto>
-export type PostsControllerUpdateResult = AxiosResponse<PostResponseDto>
-export type PostsControllerRemoveResult = AxiosResponse<PostResponseDto>
-export type PostsControllerAddImagesResult = AxiosResponse<AddImagesResponseDto>
-export type PostsControllerRemoveImageResult = AxiosResponse<ImageResponseDto>
-export type PostsControllerToggleFavoriteResult = AxiosResponse<PostsControllerToggleFavorite201>
-export type AuthControllerLoginResult = AxiosResponse<AccessTokenResponseDto>
-export type AuthControllerRefreshResult = AxiosResponse<AccessTokenResponseDto>
-export type AuthControllerLogoutResult = AxiosResponse<LogoutResponseDto>
-export type MapControllerGetMarkersResult = AxiosResponse<MapMarkerDto[]>
-export type SightingsControllerCreateResult = AxiosResponse<void>
-export type SightingsControllerFindByPostResult = AxiosResponse<void>
-export type SightingsControllerRemoveResult = AxiosResponse<void>
-export type SightingsControllerToggleFavoriteResult = AxiosResponse<SightingsControllerToggleFavorite201>
-export type ConversationsControllerCreateResult = AxiosResponse<void>
-export type ConversationsControllerFindAllResult = AxiosResponse<void>
-export type ConversationsControllerCreateMessageResult = AxiosResponse<void>
-export type ConversationsControllerFindMessagesResult = AxiosResponse<void>
-export type ConversationsControllerMarkAsReadResult = AxiosResponse<void>
+export type UsersControllerFindAllResult = AxiosResponse<UserResponseDto[]>;
+export type UsersControllerRemoveResult = AxiosResponse<void>;
+export type UsersControllerRegisterResult = AxiosResponse<UserResponseDto>;
+export type PostsControllerCreateResult = AxiosResponse<PostResponseDto>;
+export type PostsControllerListResult = AxiosResponse<PostListResponseDto>;
+export type PostsControllerGetResult = AxiosResponse<PostResponseDto>;
+export type PostsControllerUpdateResult = AxiosResponse<PostResponseDto>;
+export type PostsControllerRemoveResult = AxiosResponse<PostResponseDto>;
+export type PostsControllerAddImagesResult =
+  AxiosResponse<AddImagesResponseDto>;
+export type PostsControllerRemoveImageResult = AxiosResponse<ImageResponseDto>;
+export type PostsControllerToggleFavoriteResult =
+  AxiosResponse<PostsControllerToggleFavorite201>;
+export type AuthControllerLoginResult = AxiosResponse<AccessTokenResponseDto>;
+export type AuthControllerRefreshResult = AxiosResponse<AccessTokenResponseDto>;
+export type AuthControllerLogoutResult = AxiosResponse<LogoutResponseDto>;
+export type MapControllerGetMarkersResult = AxiosResponse<MapMarkerDto[]>;
+export type SightingsControllerCreateResult = AxiosResponse<void>;
+export type SightingsControllerFindByPostResult = AxiosResponse<void>;
+export type SightingsControllerRemoveResult = AxiosResponse<void>;
+export type SightingsControllerToggleFavoriteResult =
+  AxiosResponse<SightingsControllerToggleFavorite201>;
+export type ConversationsControllerCreateResult = AxiosResponse<void>;
+export type ConversationsControllerFindAllResult = AxiosResponse<void>;
+export type ConversationsControllerCreateMessageResult = AxiosResponse<void>;
+export type ConversationsControllerFindMessagesResult = AxiosResponse<void>;
+export type ConversationsControllerMarkAsReadResult = AxiosResponse<void>;

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -179,6 +179,13 @@
 ### CreateSightingDto (`src/sightings/dto/create-sighting.dto.spec.ts`)
 
 - [x] postId がなくてもバリデーションエラーにならないこと
+- [x] postId が空文字のときはバリデーションエラーになること
+
+### SightingsService (`src/sightings/sighting.service.spec.ts`)
+
+#### create
+
+- [x] postId が空文字の時は Post チェックを行って NotFoundException になること
 
 #### findByPost
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -176,6 +176,10 @@
 
 - [x] 目撃情報を作成してサービスの結果を返すこと
 
+### CreateSightingDto (`src/sightings/dto/create-sighting.dto.spec.ts`)
+
+- [x] postId がなくてもバリデーションエラーにならないこと
+
 #### findByPost
 
 - [x] postIdに紐づく目撃情報一覧を返すこと
@@ -203,6 +207,7 @@
 - [x] 存在しないpostIdはNotFoundException
 - [x] 存在しないsightingIdはNotFoundException
 - [x] 会話参加者以外（無関係なユーザー）はForbiddenException
+- [x] standalone Sighting は NotFoundException で会話を作成できないこと
 
 #### findAllForUser
 
@@ -263,6 +268,7 @@
 
 - [x] bbox内のPostマーカーが type='post' で返ること
 - [x] bbox内のSightingマーカーが type='sighting' で返ること
+- [x] standalone Sighting は statusなしで lost として返ること
 - [x] statusフィルタ指定時にPostクエリのwhereにstatusが含まれること
 - [x] statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
 - [x] bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -105,6 +105,7 @@ apps/api/src/
 │       └── getMarkers
 │           ├── bbox内のPostマーカーが type='post' で返ること
 │           ├── bbox内のSightingマーカーが type='sighting' で返ること
+│           ├── standalone Sighting は statusなしで lost として返ること
 │           ├── statusフィルタ指定時にPostクエリのwhereにstatusが含まれること
 │           ├── statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
 │           ├── bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
@@ -120,6 +121,7 @@ apps/api/src/
 │   │   │   ├── 存在しないpostIdはNotFoundException
 │   │   │   ├── 存在しないsightingIdはNotFoundException
 │   │   │   └── 会話参加者以外（無関係なユーザー）はForbiddenException
+│   │   │   └── standalone Sighting は NotFoundException で会話を作成できないこと
 │   │   ├── findAllForUser
 │   │   │   └── 自分がownerまたはsighterとして参加する会話一覧を返すこと
 │   │   ├── createMessage
@@ -150,9 +152,14 @@ apps/api/src/
 │       └── markAsRead
 │           └── 既読更新結果を返すこと
 ├── sightings/
+│   ├── dto/
+│   │   └── create-sighting.dto.spec.ts
+│   │       └── CreateSightingDto
+│   │           └── postId がなくてもバリデーションエラーにならないこと
 │   ├── sighting.service.spec.ts
 │   │   ├── create
 │   │   │   ├── 有効なデータでSightingを作成できること
+│   │   │   ├── postId がない時は Post チェックをスキップして Sighting を作成できること
 │   │   │   ├── 投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException
 │   │   │   └── 存在しないPostにSightingを作成しようとすると NotFoundException
 │   │   ├── findByPost

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -155,11 +155,13 @@ apps/api/src/
 │   ├── dto/
 │   │   └── create-sighting.dto.spec.ts
 │   │       └── CreateSightingDto
-│   │           └── postId がなくてもバリデーションエラーにならないこと
+│   │           ├── postId がなくてもバリデーションエラーにならないこと
+│   │           └── postId が空文字のときはバリデーションエラーになること
 │   ├── sighting.service.spec.ts
 │   │   ├── create
 │   │   │   ├── 有効なデータでSightingを作成できること
 │   │   │   ├── postId がない時は Post チェックをスキップして Sighting を作成できること
+│   │   │   ├── postId が空文字の時は Post チェックを行って NotFoundException になること
 │   │   │   ├── 投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException
 │   │   │   └── 存在しないPostにSightingを作成しようとすると NotFoundException
 │   │   ├── findByPost


### PR DESCRIPTION
## 概要
- Sighting.postId を nullable 化
- standalone Sighting を Map / Conversation / Service で安全に扱うよう調整
- テスト一覧と生成物を更新

## 確認
- npm run test
- prisma migrate status
