### PR TITLE
feat: issue#40 投稿のpostType選択を追加

### DIFF
--- a/apps/api/src/posts/dto/update-post.dto.spec.ts
+++ b/apps/api/src/posts/dto/update-post.dto.spec.ts
@@ -1,0 +1,20 @@
+import { validate } from "class-validator";
+import { UpdatePostDto } from "./update-post.dto";
+
+describe("UpdatePostDto", () => {
+  it("postType が未指定のときはバリデーションは通ること", async () => {
+    const dto = new UpdatePostDto();
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("postType が null のときはバリデーションエラーになること", async () => {
+    const dto = Object.assign(new UpdatePostDto(), { postType: null });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === "postType")).toBe(true);
+  });
+});

--- a/apps/api/src/posts/dto/update-post.dto.ts
+++ b/apps/api/src/posts/dto/update-post.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Type, Transform, plainToInstance } from "class-transformer";
+import { PostType } from "@prisma/client";
 import {
   IsString,
   MinLength,
@@ -46,6 +47,11 @@ export class UpdateLocationDto {
 }
 
 export class UpdatePostDto {
+  @ApiProperty({ required: false, enum: PostType, default: PostType.cat })
+  @IsOptional()
+  @IsEnum(PostType)
+  postType?: PostType;
+
   @ApiProperty({ required: false })
   @IsOptional()
   @IsString()

--- a/apps/api/src/posts/dto/update-post.dto.ts
+++ b/apps/api/src/posts/dto/update-post.dto.ts
@@ -11,6 +11,7 @@ import {
   IsNumber,
   IsBoolean,
   IsEnum,
+  ValidateIf,
 } from "class-validator";
 
 export class UpdatePetDetailDto {
@@ -48,7 +49,7 @@ export class UpdateLocationDto {
 
 export class UpdatePostDto {
   @ApiProperty({ required: false, enum: PostType, default: PostType.cat })
-  @IsOptional()
+  @ValidateIf((_object, value) => value !== undefined)
   @IsEnum(PostType)
   postType?: PostType;
 

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -619,6 +619,27 @@ describe("PostsService", () => {
       expect(result).toHaveProperty("images");
     });
 
+    it("postType を更新できる", async () => {
+      mockPrisma.post.findUnique
+        .mockResolvedValueOnce(existingPost)
+        .mockResolvedValueOnce({
+          ...existingPost,
+          postType: "cat",
+          petDetail: null,
+          location: null,
+          images: [],
+        });
+      mockPrisma.post.update.mockResolvedValue({});
+
+      await service.update("post1", "user1", { postType: "cat" });
+
+      expect(mockPrisma.post.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ postType: "cat" }),
+        })
+      );
+    });
+
     it("オーナー以外は ForbiddenException", async () => {
       mockPrisma.post.findUnique.mockResolvedValue(existingPost);
 

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -243,7 +243,15 @@ export class PostsService {
     }
 
     return this.prisma.$transaction(async (tx) => {
-      const { petDetail, location, lostDate, status, title, description } = dto;
+      const {
+        petDetail,
+        location,
+        lostDate,
+        status,
+        title,
+        description,
+        postType,
+      } = dto;
 
       await tx.post.update({
         where: { id },
@@ -251,6 +259,7 @@ export class PostsService {
           ...(title !== undefined && { title }),
           ...(description !== undefined && { description }),
           ...(lostDate !== undefined && { lostDate: new Date(lostDate) }),
+          ...(postType !== undefined && { postType: postType as PostType }),
           ...(status !== undefined && { status: status as PostStatus }),
           ...(status === "resolved" && { resolvedAt: new Date() }),
           ...(status === "lost" && { resolvedAt: null }),

--- a/apps/web/src/constants/postTypeOptions.ts
+++ b/apps/web/src/constants/postTypeOptions.ts
@@ -1,0 +1,7 @@
+import { PostsControllerCreateBodyPostType } from "../../../../packages/api-client/src/index";
+
+export const POST_TYPE_OPTIONS = [
+  { value: PostsControllerCreateBodyPostType.cat, label: "猫" },
+] as const;
+
+export const POST_TYPE_SELECT_ID = "postType";

--- a/apps/web/src/pages/CreatePost.test.tsx
+++ b/apps/web/src/pages/CreatePost.test.tsx
@@ -30,7 +30,7 @@ describe("CreatePost", () => {
     const user = userEvent.setup();
     render(<CreatePost />);
 
-    expect(screen.getByRole("combobox")).toHaveValue("cat");
+    expect(screen.getByLabelText("投稿種別")).toHaveValue("cat");
 
     await user.type(screen.getByPlaceholderText("title"), "迷い猫の投稿");
     await user.type(screen.getByPlaceholderText("description"), "白い猫です");

--- a/apps/web/src/pages/CreatePost.test.tsx
+++ b/apps/web/src/pages/CreatePost.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+const mockNavigate = vi.fn();
+const mockCreatePost = vi.fn().mockResolvedValue({});
+
+vi.mock("../api/orvalClient", () => ({
+  useApiClient: () => ({
+    createPost: mockCreatePost,
+  }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom"
+    );
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import CreatePost from "./CreatePost";
+
+describe("CreatePost", () => {
+  it("未選択時は cat を送信する", async () => {
+    const user = userEvent.setup();
+    render(<CreatePost />);
+
+    expect(screen.getByRole("combobox")).toHaveValue("cat");
+
+    await user.type(screen.getByPlaceholderText("title"), "迷い猫の投稿");
+    await user.type(screen.getByPlaceholderText("description"), "白い猫です");
+    await user.type(screen.getByPlaceholderText("lostDate"), "2026-04-21");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(mockCreatePost).toHaveBeenCalledWith({
+        title: "迷い猫の投稿",
+        description: "白い猫です",
+        lostDate: "2026-04-21",
+        postType: "cat",
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+});

--- a/apps/web/src/pages/CreatePost.tsx
+++ b/apps/web/src/pages/CreatePost.tsx
@@ -2,14 +2,19 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { PostsControllerCreateBodyPostType } from "../../../../packages/api-client/src/index";
 import { useApiClient } from "../api/orvalClient";
+import {
+  POST_TYPE_OPTIONS,
+  POST_TYPE_SELECT_ID,
+} from "../constants/postTypeOptions";
 
 export default function CreatePost() {
   const api = useApiClient();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [lostDate, setLostDate] = useState("");
-  const [postType, setPostType] =
-    useState<PostsControllerCreateBodyPostType>("cat");
+  const [postType, setPostType] = useState<PostsControllerCreateBodyPostType>(
+    POST_TYPE_OPTIONS[0].value
+  );
   const navigate = useNavigate();
 
   const submit = async (e: React.FormEvent) => {
@@ -26,13 +31,19 @@ export default function CreatePost() {
     <form onSubmit={submit}>
       <h2>Create Post</h2>
       <div>
+        <label htmlFor={POST_TYPE_SELECT_ID}>投稿種別</label>
         <select
+          id={POST_TYPE_SELECT_ID}
           value={postType}
           onChange={(e) =>
             setPostType(e.target.value as PostsControllerCreateBodyPostType)
           }
         >
-          <option value="cat">猫</option>
+          {POST_TYPE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
       </div>
       <div>

--- a/apps/web/src/pages/CreatePost.tsx
+++ b/apps/web/src/pages/CreatePost.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import type { PostsControllerCreateBodyPostType } from "../../../../packages/api-client/src/index";
 import { useApiClient } from "../api/orvalClient";
 
 export default function CreatePost() {
@@ -7,12 +8,14 @@ export default function CreatePost() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [lostDate, setLostDate] = useState("");
+  const [postType, setPostType] =
+    useState<PostsControllerCreateBodyPostType>("cat");
   const navigate = useNavigate();
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await api.createPost({ title, description, lostDate });
+      await api.createPost({ title, description, lostDate, postType });
       navigate("/");
     } catch (err) {
       alert("Failed to create post");
@@ -22,6 +25,16 @@ export default function CreatePost() {
   return (
     <form onSubmit={submit}>
       <h2>Create Post</h2>
+      <div>
+        <select
+          value={postType}
+          onChange={(e) =>
+            setPostType(e.target.value as PostsControllerCreateBodyPostType)
+          }
+        >
+          <option value="cat">猫</option>
+        </select>
+      </div>
       <div>
         <input
           placeholder="title"

--- a/apps/web/src/pages/EditPost.test.tsx
+++ b/apps/web/src/pages/EditPost.test.tsx
@@ -39,7 +39,7 @@ describe("EditPost", () => {
     render(<EditPost />);
 
     await waitFor(() => {
-      expect(screen.getByRole("combobox")).toHaveValue("cat");
+      expect(screen.getByLabelText("投稿種別")).toHaveValue("cat");
     });
 
     expect(screen.getByPlaceholderText("title")).toHaveValue("迷い猫の投稿");

--- a/apps/web/src/pages/EditPost.test.tsx
+++ b/apps/web/src/pages/EditPost.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+const mockNavigate = vi.fn();
+const mockGetPost = vi.fn().mockResolvedValue({
+  title: "迷い猫の投稿",
+  description: "白い猫です",
+  postType: "cat",
+});
+const mockUpdatePost = vi.fn().mockResolvedValue({});
+
+vi.mock("../api/orvalClient", () => ({
+  useApiClient: () => ({
+    getPost: mockGetPost,
+    updatePost: mockUpdatePost,
+    deletePost: vi.fn(),
+  }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom"
+    );
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: "post-1" }),
+  };
+});
+
+import EditPost from "./EditPost";
+
+describe("EditPost", () => {
+  it("取得した postType を表示し、送信時に postType を含める", async () => {
+    const user = userEvent.setup();
+    render(<EditPost />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toHaveValue("cat");
+    });
+
+    expect(screen.getByPlaceholderText("title")).toHaveValue("迷い猫の投稿");
+    expect(screen.getByPlaceholderText("description")).toHaveValue(
+      "白い猫です"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdatePost).toHaveBeenCalledWith("post-1", {
+        title: "迷い猫の投稿",
+        description: "白い猫です",
+        postType: "cat",
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+});

--- a/apps/web/src/pages/EditPost.tsx
+++ b/apps/web/src/pages/EditPost.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import type { PostsControllerCreateBodyPostType } from "../../../../packages/api-client/src/index";
 import { useApiClient } from "../api/orvalClient";
 
 export default function EditPost() {
@@ -7,6 +8,8 @@ export default function EditPost() {
   const { id } = useParams<{ id: string }>();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [postType, setPostType] =
+    useState<PostsControllerCreateBodyPostType>("cat");
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -16,6 +19,7 @@ export default function EditPost() {
         const data = await api.getPost(id);
         setTitle(data.title || "");
         setDescription(data.description || "");
+        setPostType(data.postType);
       } catch (err) {
         alert("Failed to load post");
       }
@@ -26,7 +30,7 @@ export default function EditPost() {
     e.preventDefault();
     if (!id) return;
     try {
-      await api.updatePost(id, { title, description });
+      await api.updatePost(id, { title, description, postType });
       navigate("/");
     } catch (err) {
       alert("Failed to update post");
@@ -47,6 +51,16 @@ export default function EditPost() {
   return (
     <form onSubmit={submit}>
       <h2>Edit Post</h2>
+      <div>
+        <select
+          value={postType}
+          onChange={(e) =>
+            setPostType(e.target.value as PostsControllerCreateBodyPostType)
+          }
+        >
+          <option value="cat">猫</option>
+        </select>
+      </div>
       <div>
         <input
           placeholder="title"

--- a/apps/web/src/pages/EditPost.tsx
+++ b/apps/web/src/pages/EditPost.tsx
@@ -2,14 +2,19 @@ import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import type { PostsControllerCreateBodyPostType } from "../../../../packages/api-client/src/index";
 import { useApiClient } from "../api/orvalClient";
+import {
+  POST_TYPE_OPTIONS,
+  POST_TYPE_SELECT_ID,
+} from "../constants/postTypeOptions";
 
 export default function EditPost() {
   const api = useApiClient();
   const { id } = useParams<{ id: string }>();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [postType, setPostType] =
-    useState<PostsControllerCreateBodyPostType>("cat");
+  const [postType, setPostType] = useState<PostsControllerCreateBodyPostType>(
+    POST_TYPE_OPTIONS[0].value
+  );
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -19,7 +24,7 @@ export default function EditPost() {
         const data = await api.getPost(id);
         setTitle(data.title || "");
         setDescription(data.description || "");
-        setPostType(data.postType);
+        setPostType(data.postType ?? POST_TYPE_OPTIONS[0].value);
       } catch (err) {
         alert("Failed to load post");
       }
@@ -52,13 +57,19 @@ export default function EditPost() {
     <form onSubmit={submit}>
       <h2>Edit Post</h2>
       <div>
+        <label htmlFor={POST_TYPE_SELECT_ID}>投稿種別</label>
         <select
+          id={POST_TYPE_SELECT_ID}
           value={postType}
           onChange={(e) =>
             setPostType(e.target.value as PostsControllerCreateBodyPostType)
           }
         >
-          <option value="cat">猫</option>
+          {POST_TYPE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
       </div>
       <div>

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -5,7 +5,7 @@ import {
   authControllerRefresh,
   authControllerLogout,
   type PostsControllerCreateBody,
-  type PostsControllerCreateBodyPostType,
+  type UpdatePostDto,
   postsControllerList,
   postsControllerCreate,
   postsControllerUpdate,
@@ -126,11 +126,7 @@ export function createClient(options: ClientOptions) {
     },
     updatePost: async (
       id: string,
-      data: {
-        title?: string;
-        description?: string;
-        postType?: PostsControllerCreateBodyPostType;
-      }
+      data: Pick<UpdatePostDto, "title" | "description" | "postType">
     ) => {
       const r = await postsControllerUpdate(id, data);
       return r.data;

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -5,6 +5,7 @@ import {
   authControllerRefresh,
   authControllerLogout,
   type PostsControllerCreateBody,
+  type PostsControllerCreateBodyPostType,
   postsControllerList,
   postsControllerCreate,
   postsControllerUpdate,
@@ -125,7 +126,11 @@ export function createClient(options: ClientOptions) {
     },
     updatePost: async (
       id: string,
-      data: { title?: string; description?: string }
+      data: {
+        title?: string;
+        description?: string;
+        postType?: PostsControllerCreateBodyPostType;
+      }
     ) => {
       const r = await postsControllerUpdate(id, data);
       return r.data;

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -139,6 +139,7 @@ export interface UpdatePostDto {
   location?: UpdateLocationDto;
   lostDate?: string;
   petDetail?: UpdatePetDetailDto;
+  postType?: PostsControllerCreateBodyPostType;
   status?: UpdatePostDtoStatus;
   title?: string;
 }

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -50,6 +50,7 @@
 - [x] 存在しない投稿は HttpException (404)
 - [x] lostDate を更新できる
 - [x] status を更新できる
+- [x] postType を更新できる
 - [x] status を lost に戻すと resolvedAt が null になる
 - [x] petDetail を upsert できる
 - [x] petDetail 未存在かつ必須フィールドなしは BadRequestException
@@ -398,6 +399,13 @@
 ### POST /api/auth/logout
 
 - [x] ログアウトで Cookie が削除される (200)
+
+---
+
+## Web Unit (`apps/web/src/pages/*.test.tsx`)
+
+- [x] CreatePost で未選択時は cat を送信する
+- [x] EditPost で取得した postType を表示し、送信時に postType を含める
 
 ---
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -57,6 +57,11 @@
 - [x] location を upsert できる
 - [x] location 未存在かつ必須フィールドなしは BadRequestException
 
+#### dto
+
+- [x] postType が未指定のときはバリデーションは通ること
+- [x] postType が null のときはバリデーションエラーになること
+
 #### remove
 
 - [x] オーナーが削除できる

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -49,6 +49,9 @@ apps/api/src/
 │   │   │   ├── postType を更新できる
 │   │   │   ├── petDetail を upsert できる
 │   │   │   └── location を upsert できる
+│   │   ├── dto
+│   │   │   ├── postType が未指定のときはバリデーションは通ること
+│   │   │   └── postType が null のときはバリデーションエラーになること
 │   │   └── remove
 │   │       ├── オーナーが削除できる
 │   │       ├── 画像ファイルも削除する

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -46,6 +46,7 @@ apps/api/src/
 │   │   │   ├── 存在しない投稿は HttpException (404)
 │   │   │   ├── lostDate を更新できる
 │   │   │   ├── status を更新できる
+│   │   │   ├── postType を更新できる
 │   │   │   ├── petDetail を upsert できる
 │   │   │   └── location を upsert できる
 │   │   └── remove
@@ -247,4 +248,11 @@ apps/api/test/
     │   └── Cookie なしは 401 を返す
     └── POST /api/auth/logout
         └── ログアウトで Cookie が削除される (200)
+apps/web/src/pages/
+├── CreatePost.test.tsx
+│   └── CreatePost
+│       └── 未選択時は cat を送信する
+└── EditPost.test.tsx
+    └── EditPost
+        └── 取得した postType を表示し、送信時に postType を含める
 ```


### PR DESCRIPTION
## 概要
- CreatePost/EditPost に postType の選択欄を追加
- postType を作成・更新リクエストに含めるように対応
- API client と backend の update DTO/service も postType 対応に更新
- テスト一覧を更新

## 確認
- cd apps/web && npx vitest run
- cd apps/api && npx jest src/posts/post.service.spec.ts --runInBand
- cd apps/api && npm run test
- cd apps/web && npm run test

Closes #40