### PR TITLE
feat: issue#50 ユーザープランを追加

### DIFF
--- a/apps/api/prisma/migrations/20260421064818_add_user_plan/migration.sql
+++ b/apps/api/prisma/migrations/20260421064818_add_user_plan/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "Plan" AS ENUM ('free', 'premium');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "plan" "Plan" NOT NULL DEFAULT 'free',
+ADD COLUMN     "planExpiresAt" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,6 +31,11 @@ enum Role {
   admin
 }
 
+enum Plan {
+  free
+  premium
+}
+
 model User {
   id            String         @id @default(cuid())
   emailEncrypted String
@@ -38,6 +43,8 @@ model User {
   password      String
   nickname      String         @unique
   role          Role           @default(user)
+  plan          Plan           @default(free)
+  planExpiresAt DateTime?
   posts         Post[]
   sightings     Sighting[]
   refreshTokens RefreshToken[]


### PR DESCRIPTION
## 概要\n- Plan enum を追加\n- User に plan / planExpiresAt を追加\n- 既存ユーザーは plan のデフォルト値 free で扱う\n\n## 確認\n- npm run prisma:migrate\n- npm run prisma:generate\n- npm run test (commit hook で実行済み)\n\nCloses #50