### PR TITLE
fix: issue#51 Post.createdAt を timestamptz に変更

### DIFF
--- a/apps/api/prisma/migrations/20260421075706_fix_post_createdat_timestamptz/migration.sql
+++ b/apps/api/prisma/migrations/20260421075706_fix_post_createdat_timestamptz/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ALTER COLUMN "createdAt" SET DATA TYPE TIMESTAMPTZ(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -72,7 +72,7 @@ model Post {
   sightings   Sighting[]
   conversations Conversation[]
   favorites   PostFavorite[]
-  createdAt   DateTime   @default(now())
+  createdAt   DateTime   @default(now()) @db.Timestamptz(3)
   updatedAt   DateTime   @updatedAt
 }
 


### PR DESCRIPTION
## 概要\n- Post.createdAt を timestamptz にして UTC 月境界の判定差異を防止\n- 対応 migration を追加\n\n## 確認\n- npm test -- --runInBand src/posts/post.service.spec.ts\n- commit hook で typecheck と API の全テストも通過