### PR TITLE
feat: 画像アップロード枚数制限（プラン別）

### DIFF
--- a/apps/api/src/common/plan-limits.ts
+++ b/apps/api/src/common/plan-limits.ts
@@ -3,12 +3,18 @@ import { Plan } from "@prisma/client";
 export const PLAN_LIMITS = {
   [Plan.free]: {
     monthlyPostLimit: 3,
+    imageUploadLimit: 3,
   },
   [Plan.premium]: {
     monthlyPostLimit: null,
+    imageUploadLimit: 10,
   },
 } as const;
 
 export function getMonthlyPostLimit(plan: Plan): number | null {
   return PLAN_LIMITS[plan].monthlyPostLimit;
+}
+
+export function getImageUploadLimit(plan: Plan): number {
+  return PLAN_LIMITS[plan].imageUploadLimit;
 }

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -77,6 +77,10 @@ export class PostsController {
   )
   @ApiConsumes("multipart/form-data")
   @ApiResponse({ status: 201, type: PostResponseDto })
+  @ApiResponse({
+    status: 403,
+    description: "プラン上限超過（無料プランは3枚まで、有料プランは10枚まで）",
+  })
   @ApiBody({
     schema: {
       type: "object",
@@ -147,7 +151,14 @@ export class PostsController {
   )
   @ApiConsumes("multipart/form-data")
   @ApiResponse({ status: 201, type: AddImagesResponseDto })
-  @ApiResponse({ status: 400, description: "画像枚数上限超過" })
+  @ApiResponse({
+    status: 400,
+    description: "1リクエストあたりの画像枚数上限超過（最大10枚）",
+  })
+  @ApiResponse({
+    status: 403,
+    description: "プラン上限超過（無料プランは3枚まで、有料プランは10枚まで）",
+  })
   @ApiResponse({ status: 403, description: "Forbidden: not the post owner" })
   @ApiBody({
     schema: {

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -32,6 +32,8 @@ import { CreatePostDto } from "./dto/create-post.dto";
 import { UpdatePostDto } from "./dto/update-post.dto";
 import { PostsService } from "./post.service";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { Plan } from "@prisma/client";
+import { PLAN_LIMITS } from "../common/plan-limits";
 
 const ALLOWED_MIME_TYPES = [
   "image/jpeg",
@@ -40,6 +42,7 @@ const ALLOWED_MIME_TYPES = [
   "image/webp",
 ];
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_IMAGES_PER_POST = PLAN_LIMITS[Plan.premium].imageUploadLimit;
 
 export function imageFileFilter(_req: any, file: Express.Multer.File, cb: any) {
   if (!file || !file.originalname || !file.mimetype) {
@@ -69,7 +72,9 @@ export class PostsController {
 
   @HttpPost()
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FilesInterceptor("images", 5, imageUploadOptions))
+  @UseInterceptors(
+    FilesInterceptor("images", MAX_IMAGES_PER_POST, imageUploadOptions)
+  )
   @ApiConsumes("multipart/form-data")
   @ApiResponse({ status: 201, type: PostResponseDto })
   @ApiBody({
@@ -137,7 +142,9 @@ export class PostsController {
 
   @HttpPost(":id/images")
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FilesInterceptor("images", 5, imageUploadOptions))
+  @UseInterceptors(
+    FilesInterceptor("images", MAX_IMAGES_PER_POST, imageUploadOptions)
+  )
   @ApiConsumes("multipart/form-data")
   @ApiResponse({ status: 201, type: AddImagesResponseDto })
   @ApiResponse({ status: 400, description: "画像枚数上限超過" })

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -327,15 +327,17 @@ describe("PostsService", () => {
       );
     });
 
-    it("lostDate なしは BadRequestException をスローする", async () => {
-      await expect(
-        service.create("u1", { description: "C" } as any)
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it("画像が5枚超の場合 BadRequestException をスローする", async () => {
+    it("無料プランの画像が3枚を超えると ForbiddenException をスローする", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ plan: "free" });
+      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post1",
+        petDetail: null,
+        location: null,
+        images: [],
+      });
       const files = Array.from(
-        { length: 6 },
+        { length: 4 },
         () => ({ originalname: "p.png", buffer: Buffer.from("") }) as any
       );
 
@@ -345,7 +347,54 @@ describe("PostsService", () => {
           { description: "C", lostDate: "2024-01-01" },
           files
         )
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("premium ユーザーは画像を10枚まで添付できる", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ plan: "premium" });
+      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: "post1",
+        petDetail: null,
+        location: null,
+        images: [],
+      });
+      mockPrisma.image.create.mockResolvedValue({});
+      const files = Array.from(
+        { length: 10 },
+        (_, index) =>
+          ({ originalname: `p${index}.png`, buffer: Buffer.from("") }) as any
+      );
+
+      await service.create(
+        "u1",
+        { description: "C", lostDate: "2024-01-01" },
+        files
+      );
+
+      expect(mockPrisma.image.create).toHaveBeenCalledTimes(10);
+    });
+
+    it("lostDate なしは BadRequestException をスローする", async () => {
+      await expect(
+        service.create("u1", { description: "C" } as any)
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it("無料プランの画像が4枚を超えると ForbiddenException をスローする", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ plan: "free" });
+      const files = Array.from(
+        { length: 4 },
+        () => ({ originalname: "p.png", buffer: Buffer.from("") }) as any
+      );
+
+      await expect(
+        service.create(
+          "u1",
+          { description: "C", lostDate: "2024-01-01" },
+          files
+        )
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it("petDetail と location を含む時、トランザクションで一括作成する", async () => {
@@ -604,6 +653,7 @@ describe("PostsService", () => {
 
     it("画像を追加できる", async () => {
       mockPrisma.post.findUnique.mockResolvedValue(existingPost);
+      mockPrisma.user.findUnique.mockResolvedValue({ plan: "free" });
       const newImage = {
         id: "img1",
         postId: "post1",
@@ -621,7 +671,48 @@ describe("PostsService", () => {
       expect(mockPrisma.image.create).toHaveBeenCalledWith({
         data: expect.objectContaining({ postId: "post1" }),
       });
-      expect(result.remainingSlots).toBe(4);
+      expect(result.remainingSlots).toBe(2);
+      expect(result.images).toHaveLength(1);
+    });
+
+    it("無料プランで追加後の合計が3枚を超えると ForbiddenException", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        ...existingPost,
+        images: [
+          { id: "img1", url: "u1" },
+          { id: "img2", url: "u2" },
+          { id: "img3", url: "u3" },
+        ],
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({ plan: "free" });
+      const files = [{ originalname: "a.png", buffer: Buffer.from("") } as any];
+
+      await expect(service.addImages("post1", "user1", files)).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it("premium ユーザーは10枚まで追加できる", async () => {
+      mockPrisma.post.findUnique.mockResolvedValue({
+        ...existingPost,
+        images: Array.from({ length: 9 }, (_, index) => ({
+          id: `img${index + 1}`,
+          url: `u${index + 1}`,
+        })),
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({ plan: "premium" });
+      const newImage = {
+        id: "img10",
+        postId: "post1",
+        url: "uploads/post1/xyz.png",
+        createdAt: new Date(),
+      };
+      mockPrisma.image.create.mockResolvedValue(newImage);
+      const files = [{ originalname: "a.png", buffer: Buffer.from("") } as any];
+
+      const result = await service.addImages("post1", "user1", files);
+
+      expect(result.remainingSlots).toBe(0);
       expect(result.images).toHaveLength(1);
     });
 
@@ -641,11 +732,12 @@ describe("PostsService", () => {
       );
     });
 
-    it("5枚超になる場合は BadRequestException", async () => {
+    it("追加後の合計が上限を超える場合は ForbiddenException", async () => {
       mockPrisma.post.findUnique.mockResolvedValue({
         ...existingPost,
         images: [1, 2, 3],
       });
+      mockPrisma.user.findUnique.mockResolvedValue({ plan: "free" });
       const files = [
         { originalname: "a.png", buffer: Buffer.from("") } as any,
         { originalname: "b.png", buffer: Buffer.from("") } as any,
@@ -653,7 +745,7 @@ describe("PostsService", () => {
       ];
 
       await expect(service.addImages("post1", "user1", files)).rejects.toThrow(
-        BadRequestException
+        ForbiddenException
       );
     });
 

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -108,6 +108,13 @@ export class PostsService {
               throw new NotFoundException("ユーザーが見つかりません");
             }
 
+            const imageUploadLimit = getImageUploadLimit(user.plan);
+            if (files.length > imageUploadLimit) {
+              throw new ForbiddenException(
+                `このプランでは画像は最大${imageUploadLimit}枚までです`
+              );
+            }
+
             const monthlyPostLimit = getMonthlyPostLimit(user.plan);
             if (monthlyPostLimit !== null) {
               const { start, end } = getMonthRange();
@@ -126,13 +133,6 @@ export class PostsService {
                   "無料プランの月間投稿数上限に達しています"
                 );
               }
-            }
-
-            const imageUploadLimit = getImageUploadLimit(user.plan);
-            if (files.length > imageUploadLimit) {
-              throw new ForbiddenException(
-                `このプランでは画像は最大${imageUploadLimit}枚までです`
-              );
             }
 
             const post = await tx.post.create({

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -20,9 +20,11 @@ import { v4 as uuidv4 } from "uuid";
 import * as sharp from "sharp";
 import { CreatePostDto } from "./dto/create-post.dto";
 import { UpdatePostDto } from "./dto/update-post.dto";
-import { getMonthlyPostLimit } from "../common/plan-limits";
+import {
+  getImageUploadLimit,
+  getMonthlyPostLimit,
+} from "../common/plan-limits";
 
-const MAX_IMAGES = 5;
 const MAX_FAVORITES_LIMIT = 20;
 const MAX_TRANSACTION_RETRIES = 3;
 
@@ -86,10 +88,6 @@ export class PostsService {
     dto: CreatePostDto,
     files: Express.Multer.File[] = []
   ) {
-    if (files.length > MAX_IMAGES) {
-      throw new BadRequestException(`最大${MAX_IMAGES}枚まで添付できます`);
-    }
-
     if (!dto.lostDate) {
       throw new BadRequestException("lostDateは必須です");
     }
@@ -128,6 +126,13 @@ export class PostsService {
                   "無料プランの月間投稿数上限に達しています"
                 );
               }
+            }
+
+            const imageUploadLimit = getImageUploadLimit(user.plan);
+            if (files.length > imageUploadLimit) {
+              throw new ForbiddenException(
+                `このプランでは画像は最大${imageUploadLimit}枚までです`
+              );
             }
 
             const post = await tx.post.create({
@@ -246,10 +251,17 @@ export class PostsService {
     if (post.userId !== userId)
       throw new ForbiddenException("投稿のオーナーではありません");
 
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { plan: true },
+    });
+    if (!user) throw new NotFoundException("ユーザーが見つかりません");
+
     const currentCount = post.images.length;
-    if (currentCount + files.length > MAX_IMAGES) {
-      throw new BadRequestException(
-        `画像は最大${MAX_IMAGES}枚です（現在${currentCount}枚、追加可能: ${MAX_IMAGES - currentCount}枚）`
+    const imageUploadLimit = getImageUploadLimit(user.plan);
+    if (currentCount + files.length > imageUploadLimit) {
+      throw new ForbiddenException(
+        `画像は最大${imageUploadLimit}枚です（現在${currentCount}枚、追加可能: ${imageUploadLimit - currentCount}枚）`
       );
     }
 
@@ -268,7 +280,7 @@ export class PostsService {
       });
 
       return {
-        remainingSlots: MAX_IMAGES - currentCount - files.length,
+        remainingSlots: imageUploadLimit - currentCount - files.length,
         images: newImages,
       };
     } catch (error) {

--- a/apps/api/test/app.e2e.ts
+++ b/apps/api/test/app.e2e.ts
@@ -281,7 +281,7 @@ describe("API E2E", () => {
 
       expect(res.status).toBe(201);
       expect(res.body.images).toHaveLength(1);
-      expect(res.body.remainingSlots).toBe(4);
+      expect(res.body.remainingSlots).toBe(2);
       createdImageId = res.body.images[0].id;
     });
   });

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -21,9 +21,11 @@
 - [x] ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
 - [x] アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
 - [x] 画像が sharp でリサイズ・JPEG変換されること
+- [x] 無料プランの画像が3枚を超えると ForbiddenException をスローする
+- [x] premium ユーザーは画像を10枚まで添付できる
 - [x] 画像処理でSharpエラーが発生した場合 BadRequestException をスローする
 - [x] lostDate なしは BadRequestException をスローする
-- [x] 画像が5枚超の場合 BadRequestException をスローする
+- [x] 無料プランの画像が4枚を超えると ForbiddenException をスローする
 - [x] petDetail と location を含む時、トランザクションで一括作成する
 - [x] lostDate を指定して作成できる
 - [x] トランザクション失敗時に保存済みファイルを削除する
@@ -34,9 +36,11 @@
 #### addImages
 
 - [x] 画像を追加できる
+- [x] 無料プランで追加後の合計が3枚を超えると ForbiddenException
+- [x] premium ユーザーは10枚まで追加できる
 - [x] オーナー以外は ForbiddenException
 - [x] 存在しない投稿は NotFoundException
-- [x] 5枚超になる場合は BadRequestException
+- [x] DB作成失敗時に保存済みファイルを削除する
 
 #### removeImage
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -25,10 +25,12 @@ apps/api/src/
 │   │   │   ├── ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
 │   │   │   ├── アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
 │   │   │   ├── 画像が sharp でリサイズ・JPEG変換されること
+│   │   │   ├── 無料プランの画像が3枚を超えると ForbiddenException をスローする
+│   │   │   ├── premium ユーザーは画像を10枚まで添付できる
 │   │   │   ├── 画像処理でSharpエラーが発生した場合 BadRequestException をスローする
-│   │   │   ├── 画像が5枚超の場合 BadRequestException をスローする
 │   │   │   ├── petDetail と location を含む時、トランザクションで一括作成する
 │   │   │   ├── lostDate を指定して作成できる
+│   │   │   ├── 無料プランの画像が4枚を超えると ForbiddenException をスローする
 │   │   │   ├── 無料プランの月間投稿数が3件に達している時は ForbiddenException をスローする
 │   │   │   ├── 月間投稿数の集計は UTC 境界で判定する
 │   │   │   ├── トランザクション競合時は再試行して投稿を作成する
@@ -36,9 +38,11 @@ apps/api/src/
 │   │   │   └── premium ユーザーは月間投稿数の制限を受けない
 │   │   ├── addImages
 │   │   │   ├── 画像を追加できる
+│   │   │   ├── 無料プランで追加後の合計が3枚を超えると ForbiddenException
+│   │   │   ├── premium ユーザーは10枚まで追加できる
 │   │   │   ├── オーナー以外は ForbiddenException
 │   │   │   ├── 存在しない投稿は NotFoundException
-│   │   │   └── 5枚超になる場合は BadRequestException
+│   │   │   └── DB作成失敗時に保存済みファイルを削除する
 │   │   ├── removeImage
 │   │   │   ├── オーナーが画像を削除できる
 │   │   │   ├── ファイルが存在しない場合 unlinkSync を呼ばない


### PR DESCRIPTION
## 概要\n- PLAN_LIMITS に画像アップロード上限を追加\n- create / addImages で free=3, premium=10 を判定\n- controller の multipart 受け付け上限を premium 基準の 10 枚に更新\n- PostService のユニットテストとテスト一覧を更新\n\n## テスト\n- npm run test\n\nCloses #52