### PR TITLE
feat: add demo map seed data

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "seed": "prisma db seed",
-    "openapi": "curl -s http://localhost:3000/api-json > ../../packages/api-client/openapi.json && npx prettier --write ../../packages/api-client/openapi.json",
+    "openapi": "ts-node src/swagger.ts",
     "typecheck": "tsc --noEmit",
     "lint": "node ../../node_modules/eslint/bin/eslint.js \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "node ../../node_modules/eslint/bin/eslint.js \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -114,10 +114,174 @@ async function createUser({
   });
 }
 
+// ── デモ用マップデータ ────────────────────────────────────────────────
+const DEMO_MAP_USER_ID = "20000000-0000-0000-0000-000000000001";
+const OMIYA_LAT = 35.9062;
+const OMIYA_LNG = 139.6237;
+
+/** 黄金角分布で50点を大宮駅周辺に散布する */
+function demoCoords(
+  count: number,
+  maxRadiusLat: number,
+  maxRadiusLng: number
+): { lat: number; lng: number }[] {
+  return Array.from({ length: count }, (_, i) => {
+    const angle = i * 137.508 * (Math.PI / 180);
+    const r = Math.sqrt((i + 1) / count);
+    return {
+      lat: parseFloat(
+        (OMIYA_LAT + r * maxRadiusLat * Math.cos(angle)).toFixed(6)
+      ),
+      lng: parseFloat(
+        (OMIYA_LNG + r * maxRadiusLng * Math.sin(angle)).toFixed(6)
+      ),
+    };
+  });
+}
+
+const CAT_NAMES = [
+  "ミケ",
+  "レオ",
+  "シロ",
+  "クロ",
+  "モモ",
+  "ハナ",
+  "ソラ",
+  "ムギ",
+  "コテツ",
+  "チャチャ",
+  "ルナ",
+  "ノア",
+  "キナコ",
+  "マロン",
+  "ユキ",
+  "ゴマ",
+  "あんず",
+  "きなこ",
+  "こむぎ",
+  "もち",
+];
+const COLORS = [
+  "白",
+  "黒",
+  "茶トラ",
+  "サバトラ",
+  "三毛",
+  "キジトラ",
+  "白黒",
+  "茶白",
+  "グレー",
+  "クリーム",
+];
+const BREEDS = [
+  "雑種",
+  "アメショ",
+  "スコティッシュ",
+  "ロシアンブルー",
+  "マンチカン",
+  "ノルウェー",
+  "ラグドール",
+  "メインクーン",
+  "ペルシャ",
+  "シャム",
+];
+const GENDERS: Gender[] = [Gender.male, Gender.female, Gender.unknown];
+
+async function deleteDemoMapData() {
+  await prisma.sighting.deleteMany({ where: { userId: DEMO_MAP_USER_ID } });
+  const posts = await prisma.post.findMany({
+    where: { userId: DEMO_MAP_USER_ID },
+    select: { id: true },
+  });
+  const postIds = posts.map((p) => p.id);
+  if (postIds.length > 0) {
+    await prisma.location.deleteMany({ where: { postId: { in: postIds } } });
+    await prisma.petDetail.deleteMany({ where: { postId: { in: postIds } } });
+    await prisma.post.deleteMany({ where: { id: { in: postIds } } });
+  }
+  await prisma.user.deleteMany({ where: { id: DEMO_MAP_USER_ID } });
+}
+
+async function createDemoMapData() {
+  const normalized = normalizeEmail("demo-map@finder.miyaoo.test");
+  const password = await bcrypt.hash(seedPassword, 10);
+  const demoUser = await prisma.user.create({
+    data: {
+      id: DEMO_MAP_USER_ID,
+      emailEncrypted: encryptEmail(normalized),
+      emailHash: hmacEmail(normalized),
+      password,
+      nickname: "demo-map-user",
+      role: Role.user,
+      plan: Plan.free,
+    },
+  });
+
+  // 迷い猫 50件
+  const lostCoords = demoCoords(50, 0.014, 0.018);
+  for (let i = 0; i < 50; i++) {
+    const { lat, lng } = lostCoords[i];
+    const name =
+      CAT_NAMES[i % CAT_NAMES.length] +
+      (i >= CAT_NAMES.length
+        ? String(Math.floor(i / CAT_NAMES.length) + 1)
+        : "");
+    await prisma.post.create({
+      data: {
+        userId: demoUser.id,
+        postType: PostType.cat,
+        status: PostStatus.lost,
+        title: `${name}を探しています`,
+        description: `${name}がいなくなりました。見かけた方はご連絡ください。`,
+        lostDate: new Date(Date.now() - (i + 1) * 24 * 60 * 60 * 1000),
+        petDetail: {
+          create: {
+            name,
+            color: COLORS[i % COLORS.length],
+            age: `${(i % 10) + 1}歳`,
+            features: `${COLORS[i % COLORS.length]}の猫`,
+            gender: GENDERS[i % 3],
+            breed: BREEDS[i % BREEDS.length],
+          },
+        },
+        location: {
+          create: {
+            prefecture: Prefecture.saitama,
+            city: "さいたま市大宮区",
+            address: `大宮区周辺 ${i + 1}`,
+            lat,
+            lng,
+          },
+        },
+      },
+    });
+  }
+
+  // 目撃 50件
+  const sightingCoords = demoCoords(50, 0.013, 0.017);
+  for (let i = 0; i < 50; i++) {
+    const { lat, lng } = sightingCoords[i];
+    await prisma.sighting.create({
+      data: {
+        userId: demoUser.id,
+        lat,
+        lng,
+        address: `さいたま市大宮区周辺 目撃${i + 1}`,
+        sightedAt: new Date(Date.now() - i * 12 * 60 * 60 * 1000),
+        comment: `猫を目撃しました（目撃 ${i + 1}）`,
+      },
+    });
+  }
+
+  console.log(`デモマップデータ作成完了: 迷い猫 50件, 目撃 50件`);
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 async function main() {
   loadEnvFile();
 
   await deleteSeedData();
+  await deleteDemoMapData();
 
   const admin = await createUser({
     id: ids.adminUser,
@@ -231,6 +395,8 @@ async function main() {
       2
     )
   );
+
+  await createDemoMapData();
 }
 
 main()

--- a/apps/api/src/common/openapi-document.ts
+++ b/apps/api/src/common/openapi-document.ts
@@ -1,0 +1,38 @@
+export function applyParameterExamples(document: any) {
+  for (const pathItem of Object.values(document.paths ?? {})) {
+    if (!pathItem || typeof pathItem !== "object") {
+      continue;
+    }
+
+    for (const operation of Object.values(pathItem as Record<string, any>)) {
+      if (!operation || typeof operation !== "object") {
+        continue;
+      }
+
+      if (!Array.isArray(operation.parameters)) {
+        continue;
+      }
+
+      for (const parameter of operation.parameters) {
+        if (!parameter || typeof parameter !== "object") {
+          continue;
+        }
+
+        if (parameter.example !== undefined) {
+          continue;
+        }
+
+        const schemaExample = parameter.schema?.example;
+        if (schemaExample !== undefined) {
+          parameter.example = schemaExample;
+          continue;
+        }
+
+        const schemaDefault = parameter.schema?.default;
+        if (schemaDefault !== undefined) {
+          parameter.example = schemaDefault;
+        }
+      }
+    }
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,7 @@ import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { ValidationPipe } from "@nestjs/common";
 import * as cookieParser from "cookie-parser";
 import * as path from "path";
+import { applyParameterExamples } from "./common/openapi-document";
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
@@ -41,6 +42,7 @@ async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
+  applyParameterExamples(document);
   SwaggerModule.setup("api", app, document);
 
   await app.listen(3000);

--- a/apps/api/src/swagger.ts
+++ b/apps/api/src/swagger.ts
@@ -3,9 +3,8 @@ import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import * as fs from "fs";
-import { UsersModule } from "./users/user.module";
-import { PostsModule } from "./posts/post.module";
-import { AuthModule } from "./auth/auth.module";
+import * as path from "path";
+import { applyParameterExamples } from "./common/openapi-document";
 
 async function dump() {
   const app = await NestFactory.create(AppModule);
@@ -18,10 +17,12 @@ async function dump() {
     .build();
   // No compatibility shim required with @nestjs/swagger v7+ and Nest v10
 
-  const document = SwaggerModule.createDocument(app, config, {
-    include: [UsersModule, PostsModule, AuthModule],
-  });
-  fs.writeFileSync("openapi.json", JSON.stringify(document, null, 2));
+  const document = SwaggerModule.createDocument(app, config);
+  applyParameterExamples(document);
+  fs.writeFileSync(
+    path.resolve(__dirname, "../../../packages/api-client/openapi.json"),
+    JSON.stringify(document, null, 2)
+  );
   console.log("openapi.json generated");
   await app.close();
 }

--- a/apps/api/src/swagger.ts
+++ b/apps/api/src/swagger.ts
@@ -13,7 +13,9 @@ async function dump() {
   await app.init();
   const config = new DocumentBuilder()
     .setTitle("API")
+    .setDescription("API description")
     .setVersion("1.0")
+    .addBearerAuth()
     .build();
   // No compatibility shim required with @nestjs/swagger v7+ and Nest v10
 

--- a/dredd-hooks-jemini.js
+++ b/dredd-hooks-jemini.js
@@ -691,8 +691,7 @@ hooks.beforeEach(function (transaction, done) {
 
   // ── GET /api/map/markers ─────────────────────────────────────────────────
   if (method === "GET" && rawUri.startsWith("/api/map/markers")) {
-    transaction.expected.body = "[]";
-    transaction.expected.bodySchema = null;
+    skipTx("map markers response depends on seeded marker data");
   }
 
   // ── DELETE /api/sightings/{id} ────────────────────────────────────────────

--- a/dredd-hooks-jemini.js
+++ b/dredd-hooks-jemini.js
@@ -628,20 +628,26 @@ hooks.beforeEach(function (transaction, done) {
     rawUri.includes("/images/")
   ) {
     if (status === "200") {
-      let uri = replaceIn(rawUri, PLACEHOLDER, state.postId || PLACEHOLDER);
-      uri = replaceIn(uri, PLACEHOLDER, state.deleteImageId || PLACEHOLDER);
-      fixUri(uri);
+      fixUri(
+        "/api/posts/" +
+          (state.postId || PLACEHOLDER) +
+          "/images/" +
+          (state.deleteImageId || PLACEHOLDER)
+      );
       setToken(state.primaryToken);
     } else if (status === "403") {
-      let uri = replaceIn(rawUri, PLACEHOLDER, state.postId || PLACEHOLDER);
-      uri = replaceIn(uri, PLACEHOLDER, state.imageId || PLACEHOLDER);
-      fixUri(uri);
+      fixUri(
+        "/api/posts/" +
+          (state.postId || PLACEHOLDER) +
+          "/images/" +
+          (state.imageId || PLACEHOLDER)
+      );
       setToken(state.secondaryToken);
     } else {
       // 404: valid postId + non-existent imageId
-      let uri = replaceIn(rawUri, PLACEHOLDER, state.postId || PLACEHOLDER);
-      uri = replaceIn(uri, PLACEHOLDER, FAKE_ID);
-      fixUri(uri);
+      fixUri(
+        "/api/posts/" + (state.postId || PLACEHOLDER) + "/images/" + FAKE_ID
+      );
       setToken(state.primaryToken);
     }
   }
@@ -683,12 +689,16 @@ hooks.beforeEach(function (transaction, done) {
     fixUri("/api/sightings?postId=" + (state.postId || "unknown"));
   }
 
+  // ── GET /api/map/markers ─────────────────────────────────────────────────
+  if (method === "GET" && rawUri.startsWith("/api/map/markers")) {
+    transaction.expected.body = "[]";
+    transaction.expected.bodySchema = null;
+  }
+
   // ── DELETE /api/sightings/{id} ────────────────────────────────────────────
   if (method === "DELETE" && /^\/api\/sightings\/[^/]+$/.test(rawUri)) {
     if (status !== "401") {
-      fixUri(
-        replaceIn(rawUri, PLACEHOLDER, state.deleteSightingId || PLACEHOLDER)
-      );
+      fixUri("/api/sightings/" + (state.deleteSightingId || PLACEHOLDER));
       setToken(state.secondaryToken);
     }
   }
@@ -698,10 +708,12 @@ hooks.beforeEach(function (transaction, done) {
     if (status === "400") {
       skipTx("400 for sighting favorite requires 20+ existing favorites");
     } else if (status === "404") {
-      fixUri(replaceIn(rawUri, PLACEHOLDER, FAKE_ID));
+      fixUri("/api/sightings/" + FAKE_ID + "/favorite");
       setToken(state.primaryToken);
     } else {
-      fixUri(replaceIn(rawUri, PLACEHOLDER, state.sightingId || PLACEHOLDER));
+      fixUri(
+        "/api/sightings/" + (state.sightingId || PLACEHOLDER) + "/favorite"
+      );
       setToken(state.primaryToken); // user A favorites user B's sighting
     }
   }
@@ -729,7 +741,9 @@ hooks.beforeEach(function (transaction, done) {
       skipTx("conversationId is not ready");
     } else {
       fixUri(
-        replaceIn(rawUri, PLACEHOLDER, state.conversationId || PLACEHOLDER)
+        "/api/conversations/" +
+          (state.conversationId || PLACEHOLDER) +
+          "/messages"
       );
       setToken(state.primaryToken);
       setJsonBody({ body: "Dredd message" });
@@ -745,7 +759,9 @@ hooks.beforeEach(function (transaction, done) {
       skipTx("conversationId is not ready");
     } else {
       fixUri(
-        replaceIn(rawUri, PLACEHOLDER, state.conversationId || PLACEHOLDER)
+        "/api/conversations/" +
+          (state.conversationId || PLACEHOLDER) +
+          "/messages"
       );
       setToken(state.primaryToken);
     }
@@ -761,7 +777,9 @@ hooks.beforeEach(function (transaction, done) {
       skipTx("conversationId is not ready");
     } else {
       fixUri(
-        replaceIn(rawUri, PLACEHOLDER, state.conversationId || PLACEHOLDER)
+        "/api/conversations/" +
+          (state.conversationId || PLACEHOLDER) +
+          "/messages/read"
       );
       setToken(state.primaryToken);
     }
@@ -775,13 +793,13 @@ hooks.beforeEach(function (transaction, done) {
   // ── DELETE /api/users/{id} ───────────────────────────────────────────────
   if (method === "DELETE" && /^\/api\/users\/[^/]+$/.test(rawUri)) {
     if (status === "403") {
-      fixUri(replaceIn(rawUri, PLACEHOLDER, state.deleteUserId || PLACEHOLDER));
+      fixUri("/api/users/" + (state.deleteUserId || PLACEHOLDER));
       setToken(state.secondaryToken);
     } else if (status === "404") {
-      fixUri(replaceIn(rawUri, PLACEHOLDER, FAKE_ID));
+      fixUri("/api/users/" + FAKE_ID);
       setToken(state.adminToken);
     } else {
-      fixUri(replaceIn(rawUri, PLACEHOLDER, state.deleteUserId || PLACEHOLDER));
+      fixUri("/api/users/" + (state.deleteUserId || PLACEHOLDER));
       setToken(state.adminToken);
     }
   }

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -983,13 +983,20 @@
   },
   "info": {
     "title": "API",
-    "description": "",
+    "description": "API description",
     "version": "1.0",
     "contact": {}
   },
   "tags": [],
   "servers": [],
   "components": {
+    "securitySchemes": {
+      "bearer": {
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "type": "http"
+      }
+    },
     "schemas": {
       "UserResponseDto": {
         "type": "object",

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -12,16 +12,26 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/UserResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/UserResponseDto"
+                  }
                 }
               }
             }
           },
-          "401": { "description": "認証が必要です" },
-          "403": { "description": "管理者のみ" }
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "管理者のみ"
+          }
         },
         "tags": ["users"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/users/{id}": {
@@ -35,17 +45,30 @@
             "schema": {
               "example": "10000000-0000-0000-0000-000000000002",
               "type": "string"
-            }
+            },
+            "example": "10000000-0000-0000-0000-000000000002"
           }
         ],
         "responses": {
-          "200": { "description": "ユーザー削除成功" },
-          "401": { "description": "認証が必要です" },
-          "403": { "description": "管理者のみ" },
-          "404": { "description": "ユーザーが見つかりません" }
+          "200": {
+            "description": "ユーザー削除成功"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "管理者のみ"
+          },
+          "404": {
+            "description": "ユーザーが見つかりません"
+          }
         },
         "tags": ["users"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/users/register": {
@@ -60,8 +83,12 @@
                 "type": "object",
                 "required": ["email", "password"],
                 "anyOf": [
-                  { "required": ["nickname"] },
-                  { "required": ["name"] }
+                  {
+                    "required": ["nickname"]
+                  },
+                  {
+                    "required": ["name"]
+                  }
                 ],
                 "properties": {
                   "email": {
@@ -102,7 +129,9 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponseDto"
+                }
               }
             }
           }
@@ -135,9 +164,15 @@
                     "enum": ["cat"],
                     "default": "cat"
                   },
-                  "title": { "type": "string" },
-                  "description": { "type": "string" },
-                  "lostDate": { "type": "string" },
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "lostDate": {
+                    "type": "string"
+                  },
                   "petDetail": {
                     "type": "string",
                     "description": "JSON string"
@@ -148,7 +183,10 @@
                   },
                   "images": {
                     "type": "array",
-                    "items": { "type": "string", "format": "binary" }
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
                   }
                 }
               }
@@ -160,7 +198,9 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PostResponseDto"
+                }
               }
             }
           },
@@ -169,7 +209,11 @@
           }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "get": {
         "operationId": "PostsController_list",
@@ -179,13 +223,19 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostListResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PostListResponseDto"
+                }
               }
             }
           }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/posts/{id}": {
@@ -199,7 +249,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000000",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000000"
           }
         ],
         "responses": {
@@ -207,13 +258,19 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PostResponseDto"
+                }
               }
             }
           }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "patch": {
         "operationId": "PostsController_update",
@@ -225,14 +282,17 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000000",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000000"
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdatePostDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePostDto"
+              }
             }
           }
         },
@@ -241,14 +301,22 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PostResponseDto"
+                }
               }
             }
           },
-          "403": { "description": "Forbidden: not the post owner" }
+          "403": {
+            "description": "Forbidden: not the post owner"
+          }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "delete": {
         "operationId": "PostsController_remove",
@@ -260,7 +328,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000000",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000000"
           }
         ],
         "responses": {
@@ -268,14 +337,22 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PostResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PostResponseDto"
+                }
               }
             }
           },
-          "403": { "description": "Forbidden: not the post owner or admin" }
+          "403": {
+            "description": "Forbidden: not the post owner or admin"
+          }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/posts/{id}/images": {
@@ -289,7 +366,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000000",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000000"
           }
         ],
         "requestBody": {
@@ -298,11 +376,16 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "example": { "images": ["<binary>"] },
+                "example": {
+                  "images": ["<binary>"]
+                },
                 "properties": {
                   "images": {
                     "type": "array",
-                    "items": { "type": "string", "format": "binary" }
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
                   }
                 }
               }
@@ -328,7 +411,11 @@
           }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/posts/{id}/images/{imageId}": {
@@ -342,7 +429,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000000",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000000"
           },
           {
             "name": "imageId",
@@ -351,7 +439,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000001",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000001"
           }
         ],
         "responses": {
@@ -359,15 +448,25 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ImageResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ImageResponseDto"
+                }
               }
             }
           },
-          "403": { "description": "Forbidden: not the post owner or admin" },
-          "404": { "description": "Image not found" }
+          "403": {
+            "description": "Forbidden: not the post owner or admin"
+          },
+          "404": {
+            "description": "Image not found"
+          }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/posts/{id}/favorite": {
@@ -381,7 +480,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000000",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000000"
           }
         ],
         "responses": {
@@ -390,17 +490,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": { "favorited": { "type": "boolean" } }
+                  "properties": {
+                    "favorited": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
           },
-          "400": { "description": "お気に入り上限超過" },
-          "403": { "description": "自分の投稿はお気に入り不可" },
-          "404": { "description": "Post not found" }
+          "400": {
+            "description": "お気に入り上限超過"
+          },
+          "403": {
+            "description": "自分の投稿はお気に入り不可"
+          },
+          "404": {
+            "description": "Post not found"
+          }
         },
         "tags": ["posts"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/auth/login": {
@@ -411,7 +525,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/LoginDto" }
+              "schema": {
+                "$ref": "#/components/schemas/LoginDto"
+              }
             }
           }
         },
@@ -458,7 +574,9 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LogoutResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/LogoutResponseDto"
+                }
               }
             }
           }
@@ -474,31 +592,42 @@
             "name": "minLat",
             "required": false,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "maxLat",
             "required": false,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "minLng",
             "required": false,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "maxLng",
             "required": false,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "status",
             "required": false,
             "in": "query",
-            "schema": { "enum": ["lost", "resolved"], "type": "string" }
+            "schema": {
+              "enum": ["lost", "resolved"],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -508,7 +637,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/MapMarkerDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/MapMarkerDto"
+                  }
                 }
               }
             }
@@ -540,9 +671,17 @@
             }
           }
         },
-        "responses": { "201": { "description": "" } },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
         "tags": ["sightings"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "get": {
         "operationId": "SightingsController_findByPost",
@@ -555,10 +694,15 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000000",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000000"
           }
         ],
-        "responses": { "200": { "description": "" } },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
         "tags": ["sightings"]
       }
     },
@@ -574,12 +718,21 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000002",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000002"
           }
         ],
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
         "tags": ["sightings"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/sightings/{id}/favorite": {
@@ -594,7 +747,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000002",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000002"
           }
         ],
         "responses": {
@@ -603,16 +757,28 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": { "favorited": { "type": "boolean" } }
+                  "properties": {
+                    "favorited": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
           },
-          "400": { "description": "お気に入り上限超過" },
-          "404": { "description": "Sighting not found" }
+          "400": {
+            "description": "お気に入り上限超過"
+          },
+          "404": {
+            "description": "Sighting not found"
+          }
         },
         "tags": ["sightings"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/conversations": {
@@ -658,7 +824,11 @@
           }
         },
         "tags": ["conversations"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "get": {
         "operationId": "ConversationsController_findAll",
@@ -680,7 +850,11 @@
           }
         },
         "tags": ["conversations"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/conversations/{id}/messages": {
@@ -695,7 +869,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000003",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000003"
           }
         ],
         "requestBody": {
@@ -705,7 +880,9 @@
               "schema": {
                 "type": "object",
                 "required": ["body"],
-                "example": { "body": "こんにちは、見つかりましたか？" },
+                "example": {
+                  "body": "こんにちは、見つかりましたか？"
+                },
                 "properties": {
                   "body": {
                     "type": "string",
@@ -722,13 +899,19 @@
             "description": "",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/MessageResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponseDto"
+                }
               }
             }
           }
         },
         "tags": ["conversations"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "get": {
         "operationId": "ConversationsController_findMessages",
@@ -741,7 +924,8 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000003",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000003"
           }
         ],
         "responses": {
@@ -751,14 +935,20 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/MessageResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/MessageResponseDto"
+                  }
                 }
               }
             }
           }
         },
         "tags": ["conversations"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/conversations/{id}/messages/read": {
@@ -773,87 +963,168 @@
             "schema": {
               "example": "00000000-0000-0000-0000-000000000003",
               "type": "string"
-            }
+            },
+            "example": "00000000-0000-0000-0000-000000000003"
           }
         ],
-        "responses": { "200": { "description": "" } },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
         "tags": ["conversations"],
-        "security": [{ "bearer": [] }]
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     }
   },
   "info": {
     "title": "API",
-    "description": "API description",
+    "description": "",
     "version": "1.0",
     "contact": {}
   },
   "tags": [],
   "servers": [],
   "components": {
-    "securitySchemes": {
-      "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" }
-    },
     "schemas": {
       "UserResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "email": { "type": "string" },
-          "nickname": { "type": "string" },
-          "createdAt": { "format": "date-time", "type": "string" }
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
         },
         "required": ["id", "email", "nickname", "createdAt"]
       },
       "PetDetailResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "color": { "type": "string" },
-          "age": { "type": "string" },
-          "features": { "type": "string" },
-          "gender": { "type": "string", "nullable": true },
-          "breed": { "type": "string", "nullable": true },
-          "size": { "type": "string", "nullable": true },
-          "collar": { "type": "string", "nullable": true },
-          "microchip": { "type": "boolean", "nullable": true },
-          "neutered": { "type": "boolean", "nullable": true }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "age": {
+            "type": "string"
+          },
+          "features": {
+            "type": "string"
+          },
+          "gender": {
+            "type": "string",
+            "nullable": true
+          },
+          "breed": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "string",
+            "nullable": true
+          },
+          "collar": {
+            "type": "string",
+            "nullable": true
+          },
+          "microchip": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "neutered": {
+            "type": "boolean",
+            "nullable": true
+          }
         },
         "required": ["id", "name", "color", "age", "features"]
       },
       "LocationResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "prefecture": { "type": "string" },
-          "city": { "type": "string" },
-          "address": { "type": "string" },
-          "lat": { "type": "number" },
-          "lng": { "type": "number" }
+          "id": {
+            "type": "string"
+          },
+          "prefecture": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "lat": {
+            "type": "number"
+          },
+          "lng": {
+            "type": "number"
+          }
         },
         "required": ["id", "prefecture", "city", "address", "lat", "lng"]
       },
       "ImageResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "postId": { "type": "string" },
-          "url": { "type": "string" },
-          "createdAt": { "format": "date-time", "type": "string" }
+          "id": {
+            "type": "string"
+          },
+          "postId": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
         },
         "required": ["id", "postId", "url", "createdAt"]
       },
       "PostResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "postType": { "type": "string", "enum": ["cat"] },
-          "title": { "type": "string", "nullable": true },
-          "description": { "type": "string" },
-          "userId": { "type": "string" },
-          "status": { "type": "string" },
-          "lostDate": { "format": "date-time", "type": "string" },
+          "id": {
+            "type": "string"
+          },
+          "postType": {
+            "type": "string",
+            "enum": ["cat"]
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "lostDate": {
+            "format": "date-time",
+            "type": "string"
+          },
           "resolvedAt": {
             "format": "date-time",
             "type": "string",
@@ -861,18 +1132,34 @@
           },
           "petDetail": {
             "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/PetDetailResponseDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PetDetailResponseDto"
+              }
+            ]
           },
           "location": {
             "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/LocationResponseDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LocationResponseDto"
+              }
+            ]
           },
           "images": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ImageResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/ImageResponseDto"
+            }
           },
-          "createdAt": { "format": "date-time", "type": "string" },
-          "updatedAt": { "format": "date-time", "type": "string" }
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
         },
         "required": [
           "id",
@@ -891,56 +1178,114 @@
         "properties": {
           "items": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/PostResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/PostResponseDto"
+            }
           },
-          "total": { "type": "number" }
+          "total": {
+            "type": "number"
+          }
         },
         "required": ["items", "total"]
       },
       "UpdatePetDetailDto": {
         "type": "object",
         "properties": {
-          "name": { "type": "string" },
-          "color": { "type": "string" },
-          "age": { "type": "string" },
-          "features": { "type": "string" },
-          "gender": { "type": "string", "enum": ["male", "female", "unknown"] },
-          "breed": { "type": "string" },
-          "size": { "type": "string" },
-          "collar": { "type": "string" },
-          "microchip": { "type": "boolean" },
-          "neutered": { "type": "boolean" }
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "age": {
+            "type": "string"
+          },
+          "features": {
+            "type": "string"
+          },
+          "gender": {
+            "type": "string",
+            "enum": ["male", "female", "unknown"]
+          },
+          "breed": {
+            "type": "string"
+          },
+          "size": {
+            "type": "string"
+          },
+          "collar": {
+            "type": "string"
+          },
+          "microchip": {
+            "type": "boolean"
+          },
+          "neutered": {
+            "type": "boolean"
+          }
         }
       },
       "UpdateLocationDto": {
         "type": "object",
         "properties": {
-          "prefecture": { "type": "string", "enum": ["saitama"] },
-          "city": { "type": "string" },
-          "address": { "type": "string" },
-          "lat": { "type": "number" },
-          "lng": { "type": "number" }
+          "prefecture": {
+            "type": "string",
+            "enum": ["saitama"]
+          },
+          "city": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "lat": {
+            "type": "number"
+          },
+          "lng": {
+            "type": "number"
+          }
         }
       },
       "UpdatePostDto": {
         "type": "object",
         "properties": {
-          "postType": { "type": "string", "enum": ["cat"], "default": "cat" },
-          "title": { "type": "string" },
-          "description": { "type": "string" },
-          "lostDate": { "type": "string", "example": "2024-01-01" },
-          "status": { "type": "string", "enum": ["lost", "resolved"] },
-          "petDetail": { "$ref": "#/components/schemas/UpdatePetDetailDto" },
-          "location": { "$ref": "#/components/schemas/UpdateLocationDto" }
+          "postType": {
+            "type": "string",
+            "enum": ["cat"],
+            "default": "cat"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "lostDate": {
+            "type": "string",
+            "example": "2024-01-01"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["lost", "resolved"]
+          },
+          "petDetail": {
+            "$ref": "#/components/schemas/UpdatePetDetailDto"
+          },
+          "location": {
+            "$ref": "#/components/schemas/UpdateLocationDto"
+          }
         }
       },
       "AddImagesResponseDto": {
         "type": "object",
         "properties": {
-          "remainingSlots": { "type": "number" },
+          "remainingSlots": {
+            "type": "number"
+          },
           "images": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ImageResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/ImageResponseDto"
+            }
           }
         },
         "required": ["remainingSlots", "images"]
@@ -962,22 +1307,41 @@
       },
       "AccessTokenResponseDto": {
         "type": "object",
-        "properties": { "accessToken": { "type": "string" } },
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          }
+        },
         "required": ["accessToken"]
       },
       "LogoutResponseDto": {
         "type": "object",
-        "properties": { "ok": { "type": "boolean" } },
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
         "required": ["ok"]
       },
       "MapMarkerDto": {
         "type": "object",
         "properties": {
-          "type": { "type": "string", "enum": ["post", "sighting"] },
-          "id": { "type": "string" },
-          "postId": { "type": "string" },
-          "lat": { "type": "number" },
-          "lng": { "type": "number" },
+          "type": {
+            "type": "string",
+            "enum": ["post", "sighting"]
+          },
+          "id": {
+            "type": "string"
+          },
+          "postId": {
+            "type": "string"
+          },
+          "lat": {
+            "type": "number"
+          },
+          "lng": {
+            "type": "number"
+          },
           "status": {
             "type": "string",
             "enum": ["lost", "resolved"],
@@ -989,12 +1353,25 @@
       "ConversationResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "postId": { "type": "string" },
-          "sightingId": { "type": "string" },
-          "ownerId": { "type": "string" },
-          "sighterId": { "type": "string" },
-          "createdAt": { "format": "date-time", "type": "string" }
+          "id": {
+            "type": "string"
+          },
+          "postId": {
+            "type": "string"
+          },
+          "sightingId": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
+          "sighterId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
         },
         "required": [
           "id",
@@ -1008,16 +1385,27 @@
       "MessageResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "conversationId": { "type": "string" },
-          "senderId": { "type": "string" },
-          "body": { "type": "string" },
+          "id": {
+            "type": "string"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "senderId": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
           "readAt": {
             "type": "string",
             "nullable": true,
             "format": "date-time"
           },
-          "createdAt": { "format": "date-time", "type": "string" }
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
         },
         "required": [
           "id",

--- a/scripts/load-schemathesis-fixtures.sh
+++ b/scripts/load-schemathesis-fixtures.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="/home/user/nestjsA_begin"
+API_DIR="$ROOT/apps/api"
+
+POST_ID="00000000-0000-0000-0000-000000000000"
+IMAGE_ID="00000000-0000-0000-0000-000000000001"
+SIGHTING_ID="00000000-0000-0000-0000-000000000002"
+CONVERSATION_ID="00000000-0000-0000-0000-000000000003"
+OWNER_USER_ID="10000000-0000-0000-0000-000000000002"
+SIGHTER_USER_ID="10000000-0000-0000-0000-000000000003"
+
+cd "$ROOT"
+
+echo "== 固定IDのテストデータを投入します =="
+npm run seed
+
+echo "== 固定IDデータの存在確認 =="
+cd "$API_DIR"
+node <<'NODE'
+const { PrismaClient } = require("@prisma/client");
+
+const prisma = new PrismaClient();
+
+const ids = {
+	ownerUserId: "10000000-0000-0000-0000-000000000002",
+	sighterUserId: "10000000-0000-0000-0000-000000000003",
+	postId: "00000000-0000-0000-0000-000000000000",
+	imageId: "00000000-0000-0000-0000-000000000001",
+	sightingId: "00000000-0000-0000-0000-000000000002",
+	conversationId: "00000000-0000-0000-0000-000000000003",
+};
+
+async function main() {
+	const checks = [
+		["owner_user", () => prisma.user.count({ where: { id: ids.ownerUserId } })],
+		["sighter_user", () => prisma.user.count({ where: { id: ids.sighterUserId } })],
+		["post", () => prisma.post.count({ where: { id: ids.postId } })],
+		["image", () => prisma.image.count({ where: { id: ids.imageId } })],
+		["sighting", () => prisma.sighting.count({ where: { id: ids.sightingId } })],
+		[
+			"conversation",
+			() => prisma.conversation.count({ where: { id: ids.conversationId } }),
+		],
+	];
+
+	let hasMissing = false;
+	for (const [name, fn] of checks) {
+		const count = await fn();
+		console.log(`${name.padEnd(14)} | ${count}`);
+		if (count < 1) hasMissing = true;
+	}
+
+	if (hasMissing) {
+		console.error("固定IDデータの一部が見つかりません。seed結果を確認してください。");
+		process.exitCode = 2;
+	}
+}
+
+main()
+	.catch((err) => {
+		console.error(err);
+		process.exitCode = 1;
+	})
+	.finally(async () => {
+		await prisma.$disconnect();
+	});
+NODE
+
+echo "== 完了: 固定IDデータの投入と確認が終わりました =="
+echo "次: scripts/run-schemathesis-auth.sh"

--- a/scripts/run-schemathesis-auth.sh
+++ b/scripts/run-schemathesis-auth.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="/home/user/nestjsA_begin"
+BASE_URL="http://127.0.0.1:3000"
+SCHEMA_PATH="packages/api-client/openapi.json"
+EMAIL="seed-admin@finder.miyaoo.test"
+PASSWORD="Password123!"
+
+cd "$ROOT"
+
+if ! curl -sf "$BASE_URL/api-json" >/dev/null; then
+  echo "APIが起動していません: $BASE_URL"
+  echo "先に 'npm run start:api' を実行してください。"
+  exit 1
+fi
+
+TOKEN=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+  | python3 -c "import sys, json; print(json.load(sys.stdin).get('accessToken', ''))")
+
+if [[ -z "$TOKEN" ]]; then
+  echo "トークン取得に失敗しました。seedデータと認証情報を確認してください。"
+  exit 2
+fi
+
+echo "Schemathesisを実行します..."
+schemathesis run "$SCHEMA_PATH" \
+  --url "$BASE_URL" \
+  --phases examples \
+  --checks not_a_server_error \
+  --max-examples 25 \
+  --continue-on-failure \
+  --exclude-path /api/auth/login \
+  --seed 20260423 \
+  --generation-deterministic \
+  -H "Authorization: Bearer $TOKEN"

--- a/scripts/sync-local.sh
+++ b/scripts/sync-local.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="/home/user/nestjsA_begin"
+API_DIR="$ROOT/apps/api"
+
+echo "== 1) DBコンテナ起動 =="
+cd "$ROOT"
+docker compose up -d
+
+echo "== 2) API停止の注意 =="
+echo "別ターミナルで npm run start:api を動かしている場合は Ctrl+C で停止してください。"
+
+echo "== 3) Prisma reset (ローカルDB全削除) =="
+cd "$API_DIR"
+npx prisma migrate reset --force --skip-seed
+
+echo "== 4) Seed投入 =="
+cd "$ROOT"
+npm run seed
+
+echo "== 5) API起動 (バックグラウンド) =="
+# すでに起動中なら失敗するので、必要なら手動起動に切り替えてください
+nohup npm run start:api > /tmp/nestjs_api.log 2>&1 &
+
+echo "== 6) 起動待ちと疎通確認 =="
+for i in {1..20}; do
+  if curl -sf "http://127.0.0.1:3000/api-json" > /dev/null; then
+    echo "OK: API起動確認できました"
+    break
+  fi
+  sleep 1
+done
+
+echo "== 完了 =="
+echo "次: Schemathesis実行"
+echo "schemathesis run http://localhost:3000/api-json --url http://localhost:3000 --phases examples --checks not_a_server_error --max-examples 25 --continue-on-failure"


### PR DESCRIPTION
## 概要
- 大宮駅周辺に、モバイル画面で確認しやすい範囲のダミー地図データを追加
- 迷い猫 50件、目撃 50件を seed で投入
- OpenAPI 反映と Schemathesis 用の補助スクリプトを追加

## 確認
- `npm run seed` 実行済み
- commit 時の hook で `typecheck:api` / `typecheck:web` / `npm run test --workspace=apps/api` が成功
