### PR TITLE
test: issue#83 conversations モジュール疎通確認・テスト補完

### DIFF
--- a/apps/api/src/conversations/conversations.gateway.spec.ts
+++ b/apps/api/src/conversations/conversations.gateway.spec.ts
@@ -58,6 +58,23 @@ describe("ConversationsGateway", () => {
     });
   });
 
+  // ─── handleJoin / handleLeave ──────────────────────────────
+  describe("handleJoin", () => {
+    it("指定した会話ルームにjoinすること", () => {
+      const client = makeSocket();
+      gateway.handleJoin("conv-1", client);
+      expect(client.join).toHaveBeenCalledWith("conversation:conv-1");
+    });
+  });
+
+  describe("handleLeave", () => {
+    it("指定した会話ルームからleaveすること", () => {
+      const client = makeSocket();
+      gateway.handleLeave("conv-1", client);
+      expect(client.leave).toHaveBeenCalledWith("conversation:conv-1");
+    });
+  });
+
   // ─── broadcastMessage ──────────────────────────────────────
   describe("broadcastMessage", () => {
     it("最小化されたペイロードのみemitする", () => {

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -275,6 +275,14 @@
 - [x] 有効なトークンで接続した場合はsocket.data.userIdが設定される
 - [x] Authorizationヘッダー（Bearer形式）でも認証できる
 
+#### handleJoin
+
+- [x] 指定した会話ルームにjoinすること
+
+#### handleLeave
+
+- [x] 指定した会話ルームからleaveすること
+
 #### broadcastMessage
 
 - [x] 最小化されたペイロードのみemitする（readAtを含まない）

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -165,6 +165,10 @@ apps/api/src/
 │   │   │   ├── 無効なトークンで接続した場合は切断される
 │   │   │   ├── 有効なトークンで接続した場合はsocket.data.userIdが設定される
 │   │   │   └── Authorizationヘッダー（Bearer形式）でも認証できる
+│   │   ├── handleJoin
+│   │   │   └── 指定した会話ルームにjoinすること
+│   │   ├── handleLeave
+│   │   │   └── 指定した会話ルームからleaveすること
 │   │   └── broadcastMessage
 │   │       └── 最小化されたペイロードのみemitする（readAtを含まない）
 │   └── conversation.controller.spec.ts


### PR DESCRIPTION
## Summary

- `ConversationsModule` が AppModule に登録済みで全エンドポイント・Gateway が正常動作することを確認
- `conversations.gateway.spec.ts` に `handleJoin` / `handleLeave` のテストを追加（2ケース）
- 全193テスト通過

## Test plan

- [x] ConversationsService: 16ケース通過
- [x] ConversationsGateway: 7ケース通過（handleJoin/handleLeave 追加）
- [x] ConversationsController: 5ケース通過
- [x] 全テスト 193ケース通過

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)