### PR TITLE
feat: issue#92 SightingModal 地図から選択（Nominatim 逆ジオコーディング）

### DIFF
--- a/apps/web/src/components/SightingModal.test.tsx
+++ b/apps/web/src/components/SightingModal.test.tsx
@@ -115,4 +115,103 @@ describe("SightingModal", () => {
     await user.click(screen.getByRole("button", { name: "閉じる" }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  describe("地図から選択", () => {
+    it("「地図から選択」ボタンが表示されること（postId あり・なし両方）", () => {
+      const { rerender } = renderModal();
+      expect(
+        screen.getByRole("button", { name: "地図から選択" })
+      ).toBeInTheDocument();
+
+      rerender(
+        <SightingModal
+          isOpen={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          postId="post-1"
+        />
+      );
+      expect(
+        screen.getByRole("button", { name: "地図から選択" })
+      ).toBeInTheDocument();
+    });
+
+    it("「地図から選択」クリックで onSelectFromMap が呼ばれること", async () => {
+      const user = userEvent.setup();
+      const onSelectFromMap = vi.fn();
+      renderModal({ onSelectFromMap });
+
+      await user.click(screen.getByRole("button", { name: "地図から選択" }));
+      expect(onSelectFromMap).toHaveBeenCalledTimes(1);
+    });
+
+    it("pickedLocation が更新された時、lat/lng/address フィールドに反映されること", async () => {
+      const { rerender } = renderModal();
+
+      rerender(
+        <SightingModal
+          isOpen={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          pickedLocation={{
+            lat: 35.9,
+            lng: 139.6,
+            address: "埼玉県さいたま市",
+          }}
+        />
+      );
+
+      expect(screen.getByLabelText("緯度")).toHaveValue("35.9");
+      expect(screen.getByLabelText("経度")).toHaveValue("139.6");
+      expect(screen.getByLabelText("住所")).toHaveValue("埼玉県さいたま市");
+    });
+
+    it("pickedLocation に geocodeError がある時、エラーメッセージが表示されること", async () => {
+      const { rerender } = renderModal();
+
+      rerender(
+        <SightingModal
+          isOpen={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          pickedLocation={{
+            lat: 35.9,
+            lng: 139.6,
+            geocodeError:
+              "住所の自動取得に失敗しました。手動で入力してください",
+          }}
+        />
+      );
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "住所の自動取得に失敗しました。手動で入力してください"
+      );
+    });
+
+    it("forceMount 時、isOpen=false になった後も isOpen=true に戻るとコメント等フォーム値が保持されること", async () => {
+      const user = userEvent.setup();
+      const { rerender } = renderModal({ forceMount: true });
+
+      await user.type(screen.getByLabelText("コメント"), "テストコメント");
+
+      rerender(
+        <SightingModal
+          isOpen={false}
+          forceMount={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+        />
+      );
+      rerender(
+        <SightingModal
+          isOpen={true}
+          forceMount={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+        />
+      );
+
+      expect(screen.getByLabelText("コメント")).toHaveValue("テストコメント");
+    });
+  });
 });

--- a/apps/web/src/components/SightingModal.tsx
+++ b/apps/web/src/components/SightingModal.tsx
@@ -1,12 +1,22 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useApiClient } from "../api/orvalClient";
 import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
+
+interface PickedLocation {
+  lat: number;
+  lng: number;
+  address?: string;
+  geocodeError?: string;
+}
 
 interface SightingModalProps {
   isOpen: boolean;
   onClose: () => void;
   postId?: string;
   onSuccess: () => void;
+  onSelectFromMap?: () => void;
+  pickedLocation?: PickedLocation | null;
+  forceMount?: true;
 }
 
 export default function SightingModal({
@@ -14,6 +24,9 @@ export default function SightingModal({
   onClose,
   postId,
   onSuccess,
+  onSelectFromMap,
+  pickedLocation,
+  forceMount,
 }: SightingModalProps) {
   const api = useApiClient();
   const [lat, setLat] = useState("");
@@ -23,6 +36,15 @@ export default function SightingModal({
   const [comment, setComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!pickedLocation) return;
+    setLat(String(pickedLocation.lat));
+    setLng(String(pickedLocation.lng));
+    if (pickedLocation.address !== undefined)
+      setAddress(pickedLocation.address);
+    if (pickedLocation.geocodeError) setError(pickedLocation.geocodeError);
+  }, [pickedLocation]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -61,6 +83,7 @@ export default function SightingModal({
     <Sheet open={isOpen} onOpenChange={(open: boolean) => !open && onClose()}>
       <SheetContent
         side="bottom"
+        forceMount={forceMount}
         className="h-[80vh] p-0 overflow-hidden"
         aria-label="目撃を報告する"
       >
@@ -84,6 +107,15 @@ export default function SightingModal({
           </div>
 
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <button
+              type="button"
+              aria-label="地図から選択"
+              onClick={onSelectFromMap}
+              className="w-full py-2 rounded-xl border border-blue-500 text-blue-600 font-bold text-sm hover:bg-blue-50"
+            >
+              地図から選択
+            </button>
+
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="sighting-lat"

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -24,13 +24,14 @@ type SheetContentProps = React.ComponentPropsWithoutRef<
   typeof SheetPrimitive.Content
 > & {
   side?: "top" | "right" | "bottom" | "left";
+  forceMount?: true;
 };
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "bottom", className, children, ...props }, ref) => (
-  <SheetPortal>
+>(({ side = "bottom", className, children, forceMount, ...props }, ref) => (
+  <SheetPortal forceMount={forceMount}>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}

--- a/apps/web/src/lib/reverseGeocode.test.ts
+++ b/apps/web/src/lib/reverseGeocode.test.ts
@@ -17,10 +17,8 @@ describe("reverseGeocode", () => {
     const result = await reverseGeocode(35.9062, 139.6236);
     expect(result).toEqual({ address: "埼玉県さいたま市浦和区" });
 
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("lat=35.9062"),
-      expect.objectContaining({ headers: expect.anything() })
-    );
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("lat=35.9062"));
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("email="));
   });
 
   it("HTTP エラー時、geocodeError を返すこと", async () => {

--- a/apps/web/src/lib/reverseGeocode.test.ts
+++ b/apps/web/src/lib/reverseGeocode.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { reverseGeocode } from "./reverseGeocode";
+
+describe("reverseGeocode", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("正常時、Nominatim から住所文字列を返すこと", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        display_name: "埼玉県さいたま市浦和区",
+      }),
+    } as Response);
+
+    const result = await reverseGeocode(35.9062, 139.6236);
+    expect(result).toEqual({ address: "埼玉県さいたま市浦和区" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("lat=35.9062"),
+      expect.objectContaining({ headers: expect.anything() })
+    );
+  });
+
+  it("HTTP エラー時、geocodeError を返すこと", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    const result = await reverseGeocode(35.9062, 139.6236);
+    expect(result).toEqual({
+      geocodeError: "住所の自動取得に失敗しました。手動で入力してください",
+    });
+  });
+
+  it("ネットワークエラー時、geocodeError を返すこと", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"));
+
+    const result = await reverseGeocode(35.9062, 139.6236);
+    expect(result).toEqual({
+      geocodeError: "住所の自動取得に失敗しました。手動で入力してください",
+    });
+  });
+});

--- a/apps/web/src/lib/reverseGeocode.ts
+++ b/apps/web/src/lib/reverseGeocode.ts
@@ -1,0 +1,26 @@
+const NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse";
+
+type ReverseGeocodeResult = { address: string } | { geocodeError: string };
+
+export async function reverseGeocode(
+  lat: number,
+  lng: number
+): Promise<ReverseGeocodeResult> {
+  const url = `${NOMINATIM_URL}?lat=${lat}&lon=${lng}&format=json`;
+  try {
+    const res = await fetch(url, {
+      headers: { Referer: window.location.origin },
+    });
+    if (!res.ok) {
+      return {
+        geocodeError: "住所の自動取得に失敗しました。手動で入力してください",
+      };
+    }
+    const data = (await res.json()) as { display_name?: string };
+    return { address: data.display_name ?? "" };
+  } catch {
+    return {
+      geocodeError: "住所の自動取得に失敗しました。手動で入力してください",
+    };
+  }
+}

--- a/apps/web/src/lib/reverseGeocode.ts
+++ b/apps/web/src/lib/reverseGeocode.ts
@@ -6,11 +6,9 @@ export async function reverseGeocode(
   lat: number,
   lng: number
 ): Promise<ReverseGeocodeResult> {
-  const url = `${NOMINATIM_URL}?lat=${lat}&lon=${lng}&format=json`;
+  const url = `${NOMINATIM_URL}?lat=${lat}&lon=${lng}&format=json&email=troqy.kitamura@gmail.com`;
   try {
-    const res = await fetch(url, {
-      headers: { Referer: window.location.origin },
-    });
+    const res = await fetch(url);
     if (!res.ok) {
       return {
         geocodeError: "住所の自動取得に失敗しました。手動で入力してください",

--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { vi } from "vitest";
@@ -11,6 +11,16 @@ const mockCreateConversation = vi.fn();
 const mockFlyTo = vi.fn();
 const mockGetCurrentPosition = vi.fn();
 const mockNavigate = vi.fn();
+const { mockReverseGeocode } = vi.hoisted(() => ({
+  mockReverseGeocode:
+    vi.fn<
+      (
+        lat: number,
+        lng: number
+      ) => Promise<{ address?: string; geocodeError?: string }>
+    >(),
+}));
+let triggerMapClick: ((lat: number, lng: number) => void) | null = null;
 const mockMapInstance = {
   flyTo: mockFlyTo,
 };
@@ -22,6 +32,15 @@ vi.mock("react-leaflet", () => ({
   ),
   TileLayer: () => <div data-testid="tile-layer" />,
   useMap: () => mockMapInstance,
+  useMapEvents: (handlers: {
+    click?: (e: { latlng: { lat: number; lng: number } }) => void;
+  }) => {
+    if (handlers.click) {
+      triggerMapClick = (lat: number, lng: number) =>
+        handlers.click?.({ latlng: { lat, lng } });
+    }
+    return mockMapInstance;
+  },
   Marker: ({
     children,
     title,
@@ -44,6 +63,10 @@ vi.mock("react-leaflet", () => ({
   Popup: ({ children }: { children: ReactNode }) => (
     <div data-testid="popup">{children}</div>
   ),
+}));
+
+vi.mock("../lib/reverseGeocode", () => ({
+  reverseGeocode: mockReverseGeocode,
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -119,6 +142,9 @@ describe("Map", () => {
     mockNavigate.mockReset();
     mockFlyTo.mockReset();
     mockGetCurrentPosition.mockReset();
+    mockReverseGeocode.mockReset();
+    mockReverseGeocode.mockResolvedValue({ address: "埼玉県さいたま市" });
+    triggerMapClick = null;
     mockGetMapMarkers.mockResolvedValue([]);
     mockGetPost.mockResolvedValue(samplePost);
     mockCreateSighting.mockResolvedValue(undefined);
@@ -285,6 +311,77 @@ describe("Map", () => {
       expect(
         await screen.findByRole("heading", { name: "目撃を報告する" })
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("地図から選択モード", () => {
+    it("「目撃投稿」ボタンクリックで SightingModal が開くこと", async () => {
+      const user = userEvent.setup();
+      renderMap();
+
+      await user.click(await screen.findByRole("button", { name: "目撃投稿" }));
+
+      expect(
+        await screen.findByRole("heading", { name: "目撃を報告する" })
+      ).toBeInTheDocument();
+    });
+
+    it("「地図から選択」クリック後、モーダルが非表示になり「タップして場所を選択」バナーが表示されること", async () => {
+      const user = userEvent.setup();
+      renderMap();
+
+      await user.click(await screen.findByRole("button", { name: "目撃投稿" }));
+      await screen.findByRole("heading", { name: "目撃を報告する" });
+
+      await user.click(screen.getByRole("button", { name: "地図から選択" }));
+
+      expect(screen.getByText("タップして場所を選択")).toBeInTheDocument();
+    });
+
+    it("選択モード中に地図クリックで lat/lng・住所が SightingModal にセットされ再表示されること", async () => {
+      const user = userEvent.setup();
+      renderMap();
+
+      await user.click(await screen.findByRole("button", { name: "目撃投稿" }));
+      await screen.findByRole("heading", { name: "目撃を報告する" });
+
+      await user.click(screen.getByRole("button", { name: "地図から選択" }));
+
+      triggerMapClick?.(35.91, 139.61);
+
+      await waitFor(() => {
+        expect(mockReverseGeocode).toHaveBeenCalledWith(35.91, 139.61);
+      });
+
+      expect(
+        await screen.findByRole("heading", { name: "目撃を報告する" })
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("緯度")).toHaveValue("35.91");
+      expect(screen.getByLabelText("経度")).toHaveValue("139.61");
+      expect(screen.getByLabelText("住所")).toHaveValue("埼玉県さいたま市");
+    });
+
+    it("Nominatim 失敗時、lat/lng セット済みでモーダルが再表示され、エラーメッセージが表示されること", async () => {
+      const user = userEvent.setup();
+      mockReverseGeocode.mockResolvedValue({
+        geocodeError: "住所の自動取得に失敗しました。手動で入力してください",
+      });
+      renderMap();
+
+      await user.click(await screen.findByRole("button", { name: "目撃投稿" }));
+      await screen.findByRole("heading", { name: "目撃を報告する" });
+
+      await user.click(screen.getByRole("button", { name: "地図から選択" }));
+
+      triggerMapClick?.(35.91, 139.61);
+
+      expect(
+        await screen.findByRole("heading", { name: "目撃を報告する" })
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("緯度")).toHaveValue("35.91");
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "住所の自動取得に失敗しました。手動で入力してください"
+      );
     });
   });
 });

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -306,8 +306,8 @@ export default function Map() {
             <MapClickHandler
               enabled={pickingLocation}
               onClick={async (lat, lng) => {
-                const result = await reverseGeocode(lat, lng);
                 setPickingLocation(false);
+                const result = await reverseGeocode(lat, lng);
                 setPickedLocation({ lat, lng, ...result });
                 setSightingModalOpen(true);
               }}

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
-import { MapContainer, Marker, TileLayer, useMap } from "react-leaflet";
+import {
+  MapContainer,
+  Marker,
+  TileLayer,
+  useMap,
+  useMapEvents,
+} from "react-leaflet";
 import { Link, useNavigate } from "react-router-dom";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
-import type { Map as LeafletMap } from "leaflet";
+import type { Map as LeafletMap, LeafletMouseEvent } from "leaflet";
 import type {
   MapMarkerDto,
   PostResponseDto,
@@ -12,6 +18,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { useApiClient } from "../api/orvalClient";
 import PostDetailSheet from "../components/PostDetailSheet";
 import SightingModal from "../components/SightingModal";
+import { reverseGeocode } from "../lib/reverseGeocode";
 import "../styles/map.css";
 
 delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)
@@ -94,9 +101,15 @@ export default function Map() {
     null
   );
   const [isLoadingPost, setIsLoadingPost] = useState(false);
-  const [sightingModalPostId, setSightingModalPostId] = useState<string | null>(
-    null
-  );
+  const [sightingModalOpen, setSightingModalOpen] = useState(false);
+  const [sightingPostId, setSightingPostId] = useState<string | null>(null);
+  const [pickingLocation, setPickingLocation] = useState(false);
+  const [pickedLocation, setPickedLocation] = useState<{
+    lat: number;
+    lng: number;
+    address?: string;
+    geocodeError?: string;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [locationError, setLocationError] = useState<string | null>(null);
   const [isLocating, setIsLocating] = useState(false);
@@ -290,6 +303,15 @@ export default function Map() {
             className="map-stage__map"
           >
             <MapInstanceBridge onReady={setMapInstance} />
+            <MapClickHandler
+              enabled={pickingLocation}
+              onClick={async (lat, lng) => {
+                const result = await reverseGeocode(lat, lng);
+                setPickingLocation(false);
+                setPickedLocation({ lat, lng, ...result });
+                setSightingModalOpen(true);
+              }}
+            />
             <TileLayer
               attribution="&copy; OpenStreetMap contributors"
               url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -333,12 +355,23 @@ export default function Map() {
         </Link>
         <button
           type="button"
+          aria-label="目撃投稿"
           className="map-bottom-bar__button map-bottom-bar__button--sighting"
+          onClick={() => {
+            setSightingPostId(null);
+            setSightingModalOpen(true);
+          }}
         >
           <PlusIcon />
           <span>目撃投稿</span>
         </button>
       </nav>
+
+      {pickingLocation && (
+        <div className="map-picking-banner" aria-live="polite">
+          タップして場所を選択
+        </div>
+      )}
 
       <PostDetailSheet
         isOpen={selectedMarker !== null}
@@ -360,7 +393,8 @@ export default function Map() {
             navigate("/login");
             return;
           }
-          setSightingModalPostId(postId);
+          setSightingPostId(postId);
+          setSightingModalOpen(true);
         }}
         onSendMessage={async (postId, sightingId) => {
           try {
@@ -373,11 +407,22 @@ export default function Map() {
       />
 
       <SightingModal
-        isOpen={sightingModalPostId !== null}
-        onClose={() => setSightingModalPostId(null)}
-        postId={sightingModalPostId ?? undefined}
+        isOpen={sightingModalOpen}
+        forceMount={pickingLocation ? true : undefined}
+        onClose={() => {
+          setSightingModalOpen(false);
+          setSightingPostId(null);
+        }}
+        postId={sightingPostId ?? undefined}
+        pickedLocation={pickedLocation}
+        onSelectFromMap={() => {
+          setSightingModalOpen(false);
+          setPickingLocation(true);
+          setPickedLocation(null);
+        }}
         onSuccess={() => {
-          setSightingModalPostId(null);
+          setSightingModalOpen(false);
+          setSightingPostId(null);
           api
             .getMapMarkers()
             .then((data) => setMarkers(data))
@@ -441,5 +486,20 @@ function MapInstanceBridge({
   useEffect(() => {
     onReady(map);
   }, [map, onReady]);
+  return null;
+}
+
+function MapClickHandler({
+  enabled,
+  onClick,
+}: {
+  enabled: boolean;
+  onClick: (lat: number, lng: number) => void;
+}) {
+  useMapEvents({
+    click(e: LeafletMouseEvent) {
+      if (enabled) onClick(e.latlng.lat, e.latlng.lng);
+    },
+  });
   return null;
 }

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   MapContainer,
   Marker,
@@ -113,6 +113,7 @@ export default function Map() {
   const [error, setError] = useState<string | null>(null);
   const [locationError, setLocationError] = useState<string | null>(null);
   const [isLocating, setIsLocating] = useState(false);
+  const geocodingInProgress = useRef(false);
   const [viewportHeight, setViewportHeight] = useState(() =>
     getViewportHeight()
   );
@@ -306,8 +307,11 @@ export default function Map() {
             <MapClickHandler
               enabled={pickingLocation}
               onClick={async (lat, lng) => {
-                setPickingLocation(false);
+                if (geocodingInProgress.current) return;
+                geocodingInProgress.current = true;
                 const result = await reverseGeocode(lat, lng);
+                geocodingInProgress.current = false;
+                setPickingLocation(false);
                 setPickedLocation({ lat, lng, ...result });
                 setSightingModalOpen(true);
               }}

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -486,6 +486,18 @@
 - [x] SightingModal で閉じるボタンを押した時、onClose が呼ばれること
 - [x] SightingModal で緯度が数値でない時、エラーメッセージが表示されること
 - [x] SightingModal で postId なしで送信すると、postId を含まずに createSighting が呼ばれること
+- [x] SightingModal で「地図から選択」ボタンが表示されること（postId あり・なし両方）
+- [x] SightingModal で「地図から選択」クリックで onSelectFromMap が呼ばれること
+- [x] SightingModal で pickedLocation が更新された時、lat/lng/address フィールドに反映されること
+- [x] SightingModal で pickedLocation に geocodeError がある時、エラーメッセージが表示されること
+- [x] SightingModal で forceMount 時、isOpen=false → true でフォーム値が保持されること
+- [x] Map で「目撃投稿」ボタンクリックで SightingModal が開くこと
+- [x] Map で「地図から選択」クリック後、「タップして場所を選択」バナーが表示されること
+- [x] Map で地図クリックで lat/lng・住所が SightingModal にセットされ再表示されること
+- [x] Map で Nominatim 失敗時、lat/lng セット済みでモーダルが再表示されエラーメッセージが表示されること
+- [x] reverseGeocode で正常時、Nominatim から住所文字列を返すこと
+- [x] reverseGeocode で HTTP エラー時、geocodeError を返すこと
+- [x] reverseGeocode でネットワークエラー時、geocodeError を返すこと
 - [x] Conversations で会話一覧が表示される時、相手ニックネームと投稿タイトルが表示されること
 - [x] Conversations で lastMessageがある時、最新メッセージ本文が表示されること
 - [x] Conversations で lastMessageがない時、メッセージなし文言が表示されること

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -296,9 +296,14 @@ apps/web/src/
     │       ├── 目撃マーカーを押した時、目撃情報シートが開くこと
     │       ├── 迷子フィルターを押した時、迷子マーカーだけが表示されること
     │       ├── 現在地ボタンを押すと現在地へ移動すること
-    │       └── 目撃を報告するボタン
-    │           ├── 未認証でボタンをクリックした時、/loginにリダイレクトされること
-    │           └── 認証済みかつ他者のPostでボタンをクリックした時、SightingModalが開くこと
+    │       ├── 目撃を報告するボタン
+    │       │   ├── 未認証でボタンをクリックした時、/loginにリダイレクトされること
+    │       │   └── 認証済みかつ他者のPostでボタンをクリックした時、SightingModalが開くこと
+    │       └── 地図から選択モード
+    │           ├── 「目撃投稿」ボタンクリックで SightingModal が開くこと
+    │           ├── 「地図から選択」クリック後、「タップして場所を選択」バナーが表示されること
+    │           ├── 選択モード中に地図クリックで lat/lng・住所が SightingModal にセットされ再表示されること
+    │           └── Nominatim 失敗時、lat/lng セット済みでモーダルが再表示されエラーメッセージが表示されること
     ├── components/PostDetailSheet.test.tsx
     │   └── PostDetailSheet
     │       ├── isOpen=true の時、ダイアログが表示されること
@@ -335,7 +340,18 @@ apps/web/src/
     │       ├── 必須項目未入力で送信しても、createSighting が呼ばれないこと
     │       ├── 閉じるボタンを押した時、onClose が呼ばれること
     │       ├── 緯度が数値でない時、エラーメッセージが表示されること
-    │       └── postId なしで送信すると、postId を含まずに createSighting が呼ばれること
+    │       ├── postId なしで送信すると、postId を含まずに createSighting が呼ばれること
+    │       └── 地図から選択
+    │           ├── 「地図から選択」ボタンが表示されること（postId あり・なし両方）
+    │           ├── 「地図から選択」クリックで onSelectFromMap が呼ばれること
+    │           ├── pickedLocation が更新された時、lat/lng/address フィールドに反映されること
+    │           ├── pickedLocation に geocodeError がある時、エラーメッセージが表示されること
+    │           └── forceMount 時、isOpen=false → true でフォーム値が保持されること
+    ├── lib/reverseGeocode.test.ts
+    │   └── reverseGeocode
+    │       ├── 正常時、Nominatim から住所文字列を返すこと
+    │       ├── HTTP エラー時、geocodeError を返すこと
+    │       └── ネットワークエラー時、geocodeError を返すこと
     ├── EditPost.test.tsx
     │   └── EditPost
     │       └── 取得した postType を表示し、送信時に postType を含める


### PR DESCRIPTION
## Summary

- `SightingModal` に「地図から選択」ボタンを追加（`postId` あり・なし両方で表示）
- ボタンクリックでモーダルを閉じ、地図クリックモードへ遷移（モバイル: 「タップして場所を選択」バナー表示）
- 地図タップで `lat/lng` を取得し、Nominatim 逆ジオコーディングで住所を自動入力後にモーダルを再表示
- 住所取得失敗時は `lat/lng` セット済みでモーダルを再表示し、エラーメッセージを表示
- `SheetContent` に `forceMount` prop を追加し、地図選択モード中も DOM を維持してフォーム state を保持

## Test plan

- [x] SightingModal: 「地図から選択」ボタン表示（postId あり・なし）
- [x] SightingModal: クリックで `onSelectFromMap` コールバック呼び出し
- [x] SightingModal: `pickedLocation` 変化時に lat/lng/address フィールドへ反映
- [x] SightingModal: `geocodeError` 時にエラーメッセージ表示
- [x] SightingModal: `forceMount` 時にフォーム値が保持されること
- [x] Map: 「目撃投稿」ボタンで SightingModal が開くこと
- [x] Map: 「地図から選択」後バナーが表示されること
- [x] Map: 地図クリックで lat/lng・住所が SightingModal にセットされ再表示
- [x] Map: Nominatim 失敗時にエラーメッセージが表示されること
- [x] reverseGeocode: 正常・HTTP エラー・ネットワークエラーのテスト
- [x] `TESTS.md` / `TESTS_TREE.md` 更新済み

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)