### PR TITLE
feat: issue#71 迷い猫投稿導線と Geolocation による位置入力を実装

### DIFF
--- a/apps/web/src/pages/CreatePost.test.tsx
+++ b/apps/web/src/pages/CreatePost.test.tsx
@@ -21,6 +21,7 @@ vi.mock("react-leaflet", () => ({
   ),
   TileLayer: () => null,
   Marker: () => null,
+  useMap: () => ({ flyTo: vi.fn() }),
   useMapEvents: (events: {
     click?: (e: { latlng: { lat: number; lng: number } }) => void;
   }) => {

--- a/apps/web/src/pages/CreatePost.tsx
+++ b/apps/web/src/pages/CreatePost.tsx
@@ -1,10 +1,18 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { CheckedState } from "@radix-ui/react-checkbox";
 import { useNavigate } from "react-router-dom";
-import { MapContainer, TileLayer, Marker, useMapEvents } from "react-leaflet";
+import {
+  MapContainer,
+  TileLayer,
+  Marker,
+  useMap,
+  useMapEvents,
+} from "react-leaflet";
 import L from "leaflet";
+import type { Map as LeafletMap } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { useApiClient } from "../api/orvalClient";
+import { reverseGeocode } from "../lib/reverseGeocode";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,6 +35,7 @@ import {
   Calendar,
   ChevronLeft,
   Upload,
+  LocateFixed,
 } from "lucide-react";
 
 // Leaflet デフォルトアイコン修正
@@ -57,6 +66,18 @@ function MapClickHandler({
       onMapClick({ lat: e.latlng.lat, lng: e.latlng.lng });
     },
   });
+  return null;
+}
+
+function MapInstanceBridge({
+  onReady,
+}: {
+  onReady: (map: LeafletMap) => void;
+}) {
+  const map = useMap();
+  useEffect(() => {
+    onReady(map);
+  }, [map, onReady]);
   return null;
 }
 
@@ -106,12 +127,43 @@ export default function CreatePost() {
   // UI
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
+  const [isLocating, setIsLocating] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
 
   useEffect(() => {
     return () => {
       previews.forEach((preview) => URL.revokeObjectURL(preview));
     };
   }, [previews]);
+
+  const handleCurrentLocation = () => {
+    if (!navigator.geolocation) {
+      setLocationError("このブラウザでは現在地を取得できません");
+      return;
+    }
+    setIsLocating(true);
+    setLocationError(null);
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        const { latitude: lat, longitude: lng } = position.coords;
+        setPinPos({ lat, lng });
+        mapRef.current?.flyTo([lat, lng], 16, { animate: true });
+        const result = await reverseGeocode(lat, lng);
+        if ("address" in result) {
+          setAddress(result.address);
+        } else {
+          setLocationError(result.geocodeError);
+        }
+        setIsLocating(false);
+      },
+      () => {
+        setLocationError("現在地の取得に失敗しました");
+        setIsLocating(false);
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+    );
+  };
 
   const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
@@ -503,9 +555,23 @@ export default function CreatePost() {
 
           {/* Leaflet 地図 */}
           <div className="space-y-2">
-            <Label className="text-xs font-bold text-slate-500 ml-1">
-              地図でピンを指定 <span className="text-red-500">*</span>
-            </Label>
+            <div className="flex items-center justify-between ml-1">
+              <Label className="text-xs font-bold text-slate-500">
+                地図でピンを指定 <span className="text-red-500">*</span>
+              </Label>
+              <button
+                type="button"
+                onClick={handleCurrentLocation}
+                disabled={isLocating}
+                className="flex items-center gap-1 text-xs font-bold text-blue-600 hover:text-blue-700 disabled:opacity-50"
+              >
+                <LocateFixed size={14} />
+                {isLocating ? "取得中…" : "現在地を使う"}
+              </button>
+            </div>
+            {locationError && (
+              <p className="text-xs text-red-500 ml-1">{locationError}</p>
+            )}
             <div className="relative h-64 rounded-[2rem] overflow-hidden">
               <MapContainer
                 center={DEFAULT_CENTER}
@@ -513,6 +579,11 @@ export default function CreatePost() {
                 style={{ height: "100%", width: "100%" }}
                 scrollWheelZoom={false}
               >
+                <MapInstanceBridge
+                  onReady={(m) => {
+                    mapRef.current = m;
+                  }}
+                />
                 <TileLayer
                   attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                   url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -164,10 +164,9 @@ describe("Map", () => {
     expect(screen.getByRole("button", { name: "すべて" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "迷子" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "目撃" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "迷い猫投稿" })).toHaveAttribute(
-      "href",
-      "/create"
-    );
+    expect(
+      screen.getByRole("button", { name: "迷い猫投稿" })
+    ).toBeInTheDocument();
   });
 
   it("迷子マーカーを押した時、詳細シートが開くこと", async () => {

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -6,7 +6,7 @@ import {
   useMap,
   useMapEvents,
 } from "react-leaflet";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import type { Map as LeafletMap, LeafletMouseEvent } from "leaflet";
@@ -350,13 +350,20 @@ export default function Map() {
       </main>
 
       <nav className="map-bottom-bar" aria-label="投稿アクション">
-        <Link
-          to="/create"
+        <button
+          type="button"
           className="map-bottom-bar__button map-bottom-bar__button--lost"
+          onClick={() => {
+            if (!currentUserId) {
+              navigate("/login");
+              return;
+            }
+            navigate("/create");
+          }}
         >
           <PlusIcon />
           <span>迷い猫投稿</span>
-        </Link>
+        </button>
         <button
           type="button"
           aria-label="目撃投稿"


### PR DESCRIPTION
## Summary

- `Map.tsx`: 「迷い猫投稿」ボタンを `<Link>` から `<button>` に変更。未認証時は `/login` にリダイレクト（目撃投稿ボタンと同じ挙動に統一）
- `CreatePost.tsx`: 地図ピン指定欄に「現在地を使う」ボタンを追加。Geolocation で座標取得 → ピン配置 + Nominatim 逆ジオコーディングで住所欄を自動入力

## 設計変更

Issue #71 は当初「モーダル」を AC に記載していたが、フォーム項目が多く SightingModal と二重管理になるため、フルページ（`/create`）方式に統一。Issue の AC を更新済み。

## Test plan

- [ ] 未認証状態で「迷い猫投稿」ボタンをタップ → `/login` にリダイレクトされること
- [ ] 認証済み状態で「迷い猫投稿」ボタンをタップ → `/create` に遷移すること
- [ ] `/create` ページで「現在地を使う」ボタンをタップ → ブラウザの位置情報許可ダイアログが出ること
- [ ] 位置情報を許可 → 地図がその地点に移動しピンが立ち、住所欄が自動入力されること
- [ ] 位置情報を拒否 → エラーメッセージが表示されること
- [ ] 地図タップでもピンが指定できること（既存動作の確認）

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)