### PR TITLE
feat: issue#73,#74,#75 Post編集・削除UIと画像管理を実装

### DIFF
--- a/apps/web/src/components/PostDetailSheet.test.tsx
+++ b/apps/web/src/components/PostDetailSheet.test.tsx
@@ -284,4 +284,43 @@ describe("PostDetailSheet", () => {
       expect(onSendMessage).toHaveBeenCalledWith("post-1", "sighting-1");
     });
   });
+
+  describe("編集ボタン", () => {
+    it("markerType=post かつ自分の投稿の時、編集ボタンが表示されること", () => {
+      const onEdit = vi.fn();
+      renderSheet({
+        markerType: "post",
+        currentUserId: "user-1",
+        post: { ...basePost, userId: "user-1" },
+        onEdit,
+      });
+      expect(
+        screen.getByRole("button", { name: "編集する" })
+      ).toBeInTheDocument();
+    });
+
+    it("他人の投稿の時、編集ボタンが非表示であること", () => {
+      renderSheet({
+        markerType: "post",
+        currentUserId: "user-2",
+        post: { ...basePost, userId: "user-1" },
+      });
+      expect(
+        screen.queryByRole("button", { name: "編集する" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("編集ボタンをクリックした時、onEdit が postId で呼ばれること", async () => {
+      const user = userEvent.setup();
+      const onEdit = vi.fn();
+      renderSheet({
+        markerType: "post",
+        currentUserId: "user-1",
+        post: { ...basePost, userId: "user-1" },
+        onEdit,
+      });
+      await user.click(screen.getByRole("button", { name: "編集する" }));
+      expect(onEdit).toHaveBeenCalledWith("post-1");
+    });
+  });
 });

--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -12,6 +12,7 @@ interface PostDetailSheetProps {
   sightingUserId?: string | null;
   onSendMessage?: (postId: string, sightingId: string) => void;
   onReportSighting?: (postId: string) => void;
+  onEdit?: (postId: string) => void;
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -35,6 +36,7 @@ export default function PostDetailSheet({
   sightingUserId,
   onSendMessage,
   onReportSighting,
+  onEdit,
 }: PostDetailSheetProps) {
   const title = markerType === "post" ? "迷い猫投稿" : "目撃情報";
 
@@ -47,6 +49,12 @@ export default function PostDetailSheet({
 
   const showReportSightingButton =
     markerType === "post" && !!post && currentUserId !== post.userId;
+
+  const showEditButton =
+    markerType === "post" &&
+    !!post &&
+    !!currentUserId &&
+    currentUserId === post.userId;
 
   return (
     <Sheet open={isOpen} onOpenChange={(open: boolean) => !open && onClose()}>
@@ -71,6 +79,19 @@ export default function PostDetailSheet({
               ×
             </button>
           </div>
+
+          {showEditButton && post && (
+            <div className="mt-4">
+              <button
+                type="button"
+                aria-label="編集する"
+                onClick={() => onEdit?.(post.id)}
+                className="w-full py-3 rounded-2xl bg-slate-100 text-slate-800 font-bold text-sm hover:bg-slate-200"
+              >
+                編集する
+              </button>
+            </div>
+          )}
 
           {showReportSightingButton && (
             <div className="mt-4">

--- a/apps/web/src/pages/EditPost.test.tsx
+++ b/apps/web/src/pages/EditPost.test.tsx
@@ -1,21 +1,90 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { vi } from "vitest";
 
 const mockNavigate = vi.fn();
-const mockGetPost = vi.fn().mockResolvedValue({
-  title: "迷い猫の投稿",
+const mockUpdatePost = vi.fn().mockResolvedValue({});
+const mockDeletePost = vi.fn().mockResolvedValue({});
+const mockAddImages = vi
+  .fn()
+  .mockResolvedValue({ images: [], remainingSlots: 2 });
+const mockDeleteImage = vi.fn().mockResolvedValue(undefined);
+
+const basePost = {
+  id: "post-1",
+  userId: "user-1",
+  title: "レオを探しています",
   description: "白い猫です",
   postType: "cat",
-});
-const mockUpdatePost = vi.fn().mockResolvedValue({});
+  status: "lost",
+  lostDate: "2026-04-22T00:00:00.000Z",
+  createdAt: "2026-04-23T00:00:00.000Z",
+  updatedAt: "2026-04-23T00:00:00.000Z",
+  authorNickname: "テスト",
+  images: [],
+  petDetail: {
+    id: "pd-1",
+    name: "レオ",
+    color: "茶トラ",
+    age: "3歳",
+    features: "右耳にV字カット",
+    gender: "male",
+    size: null,
+    breed: "日本猫",
+    collar: null,
+    microchip: false,
+    neutered: true,
+  },
+  location: {
+    id: "loc-1",
+    prefecture: "saitama",
+    city: "さいたま市",
+    address: "大宮区1-2-3",
+    lat: 35.9,
+    lng: 139.6,
+  },
+};
+
+const mockGetPost = vi.fn().mockResolvedValue(basePost);
+
+let mapClickHandler:
+  | ((e: { latlng: { lat: number; lng: number } }) => void)
+  | null = null;
+
+vi.mock("react-leaflet", () => ({
+  MapContainer: ({ children }: { children: ReactNode }) => (
+    <button
+      type="button"
+      data-testid="mock-map"
+      onClick={() => mapClickHandler?.({ latlng: { lat: 35.91, lng: 139.62 } })}
+    >
+      {children}
+    </button>
+  ),
+  TileLayer: () => null,
+  Marker: () => null,
+  useMap: () => ({ flyTo: vi.fn() }),
+  useMapEvents: (events: {
+    click?: (e: { latlng: { lat: number; lng: number } }) => void;
+  }) => {
+    mapClickHandler = events.click ?? null;
+    return null;
+  },
+}));
 
 vi.mock("../api/orvalClient", () => ({
   useApiClient: () => ({
     getPost: mockGetPost,
     updatePost: mockUpdatePost,
-    deletePost: vi.fn(),
+    deletePost: mockDeletePost,
+    addImages: mockAddImages,
+    deleteImage: mockDeleteImage,
   }),
+}));
+
+vi.mock("../lib/reverseGeocode", () => ({
+  reverseGeocode: vi.fn().mockResolvedValue({ address: "埼玉県さいたま市" }),
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -23,7 +92,6 @@ vi.mock("react-router-dom", async () => {
     await vi.importActual<typeof import("react-router-dom")>(
       "react-router-dom"
     );
-
   return {
     ...actual,
     useNavigate: () => mockNavigate,
@@ -34,29 +102,177 @@ vi.mock("react-router-dom", async () => {
 import EditPost from "./EditPost";
 
 describe("EditPost", () => {
-  it("取得した postType を表示し、送信時に postType を含める", async () => {
-    const user = userEvent.setup();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPost.mockResolvedValue(basePost);
+    mockUpdatePost.mockResolvedValue({});
+    mockDeletePost.mockResolvedValue({});
+    mockAddImages.mockResolvedValue({ images: [], remainingSlots: 2 });
+  });
+
+  it("投稿データ取得後、petDetail を含むフォームに初期値がセットされること", async () => {
     render(<EditPost />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("投稿種別")).toHaveValue("cat");
+      expect(screen.getByDisplayValue("レオ")).toBeInTheDocument();
     });
+    expect(screen.getByDisplayValue("茶トラ")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("3歳")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("白い猫です")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("さいたま市")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("大宮区1-2-3")).toBeInTheDocument();
+  });
 
-    expect(screen.getByPlaceholderText("title")).toHaveValue("迷い猫の投稿");
-    expect(screen.getByPlaceholderText("description")).toHaveValue(
-      "白い猫です"
+  it("変更して保存した時、updatePost が petDetail/location を含むデータで呼ばれること", async () => {
+    const user = userEvent.setup();
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("白い猫です")).toBeInTheDocument()
     );
 
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    const descInput = screen.getByDisplayValue("白い猫です");
+    await user.clear(descInput);
+    await user.type(descInput, "更新した説明");
+
+    await user.click(screen.getByRole("button", { name: "保存する" }));
 
     await waitFor(() => {
-      expect(mockUpdatePost).toHaveBeenCalledWith("post-1", {
-        title: "迷い猫の投稿",
-        description: "白い猫です",
-        postType: "cat",
-      });
+      expect(mockUpdatePost).toHaveBeenCalledWith(
+        "post-1",
+        expect.objectContaining({
+          description: "更新した説明",
+          petDetail: expect.objectContaining({ name: "レオ" }),
+          location: expect.objectContaining({ city: "さいたま市" }),
+        })
+      );
     });
-
     expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+
+  it("削除ボタンをクリックした時、確認ダイアログが表示されること", async () => {
+    const user = userEvent.setup();
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("レオ")).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    expect(
+      screen.getByRole("dialog", { name: "投稿を削除しますか？" })
+    ).toBeInTheDocument();
+  });
+
+  it("削除ダイアログで「削除を確定する」を押した時、deletePost が呼ばれ / にリダイレクトされること", async () => {
+    const user = userEvent.setup();
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("レオ")).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await user.click(screen.getByRole("button", { name: "削除を確定する" }));
+
+    await waitFor(() => expect(mockDeletePost).toHaveBeenCalledWith("post-1"));
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+
+  it("削除ダイアログで「キャンセル」を押した時、deletePost が呼ばれないこと", async () => {
+    const user = userEvent.setup();
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("レオ")).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(mockDeletePost).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("dialog", { name: "投稿を削除しますか？" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("既存画像がサムネイル表示されること", async () => {
+    const postWithImages = {
+      ...basePost,
+      images: [
+        {
+          id: "img-1",
+          postId: "post-1",
+          url: "https://example.com/cat.jpg",
+          createdAt: "2026-04-23T00:00:00.000Z",
+        },
+      ],
+    };
+    mockGetPost.mockResolvedValue(postWithImages);
+    render(<EditPost />);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("既存画像1")).toBeInTheDocument();
+    });
+  });
+
+  it("既存画像の個別削除ボタンをクリックした時、deleteImage が imageId で呼ばれること", async () => {
+    const user = userEvent.setup();
+    const postWithImages = {
+      ...basePost,
+      images: [
+        {
+          id: "img-1",
+          postId: "post-1",
+          url: "https://example.com/cat.jpg",
+          createdAt: "2026-04-23T00:00:00.000Z",
+        },
+      ],
+    };
+    mockGetPost.mockResolvedValue(postWithImages);
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByAltText("既存画像1")).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole("button", { name: "既存画像1を削除" }));
+    expect(mockDeleteImage).toHaveBeenCalledWith("post-1", "img-1");
+  });
+
+  it("画像追加アップロードで addImages が呼ばれること", async () => {
+    const user = userEvent.setup();
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("レオ")).toBeInTheDocument()
+    );
+
+    const file = new File(["dummy"], "cat.jpg", { type: "image/jpeg" });
+    const input = screen.getByTestId("image-upload-input");
+    await user.upload(input, file);
+
+    expect(mockAddImages).toHaveBeenCalledWith("post-1", [file]);
+  });
+
+  it("remainingSlots=0 の時、追加アップロードボタンが非表示になること", async () => {
+    mockAddImages.mockResolvedValue({ images: [], remainingSlots: 0 });
+    const postWithImages = {
+      ...basePost,
+      images: Array.from({ length: 3 }, (_, i) => ({
+        id: `img-${i}`,
+        postId: "post-1",
+        url: `https://example.com/cat${i}.jpg`,
+        createdAt: "2026-04-23T00:00:00.000Z",
+      })),
+    };
+    mockGetPost.mockResolvedValue(postWithImages);
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByAltText("既存画像1")).toBeInTheDocument()
+    );
+
+    expect(screen.queryByTestId("image-upload-input")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/EditPost.test.tsx
+++ b/apps/web/src/pages/EditPost.test.tsx
@@ -256,7 +256,6 @@ describe("EditPost", () => {
   });
 
   it("remainingSlots=0 の時、追加アップロードボタンが非表示になること", async () => {
-    mockAddImages.mockResolvedValue({ images: [], remainingSlots: 0 });
     const postWithImages = {
       ...basePost,
       images: Array.from({ length: 3 }, (_, i) => ({
@@ -274,5 +273,28 @@ describe("EditPost", () => {
     );
 
     expect(screen.queryByTestId("image-upload-input")).not.toBeInTheDocument();
+  });
+
+  it("remainingSlots を超える枚数を選択した時、エラーメッセージが表示され addImages が呼ばれないこと", async () => {
+    const user = userEvent.setup();
+    render(<EditPost />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("レオ")).toBeInTheDocument()
+    );
+
+    const files = [
+      new File(["a"], "cat1.jpg", { type: "image/jpeg" }),
+      new File(["b"], "cat2.jpg", { type: "image/jpeg" }),
+      new File(["c"], "cat3.jpg", { type: "image/jpeg" }),
+      new File(["d"], "cat4.jpg", { type: "image/jpeg" }),
+    ];
+    const input = screen.getByTestId("image-upload-input");
+    await user.upload(input, files);
+
+    expect(mockAddImages).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("追加できる画像は残り 3 枚です")
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/EditPost.tsx
+++ b/apps/web/src/pages/EditPost.tsx
@@ -116,6 +116,10 @@ export default function EditPost() {
   const [locationError, setLocationError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const handleMapReady = useCallback((m: LeafletMap) => {
+    mapRef.current = m;
+  }, []);
+
   const loadPost = useCallback(async (postId: string) => {
     const post = await apiRef.current.getPost(postId);
     setDescription(post.description ?? "");
@@ -149,6 +153,12 @@ export default function EditPost() {
     loadPost(id).catch(() => setError("投稿の取得に失敗しました"));
   }, [id, loadPost]);
 
+  useEffect(() => {
+    if (pinPos && mapRef.current) {
+      mapRef.current.flyTo([pinPos.lat, pinPos.lng], 15);
+    }
+  }, [pinPos]);
+
   const handleCurrentLocation = () => {
     if (!navigator.geolocation) {
       setLocationError("このブラウザでは現在地を取得できません");
@@ -178,6 +188,11 @@ export default function EditPost() {
     const files = Array.from(e.target.files ?? []);
     if (!files.length || !id) return;
     e.target.value = "";
+    setError(null);
+    if (files.length > remainingSlots) {
+      setError(`追加できる画像は残り ${remainingSlots} 枚です`);
+      return;
+    }
     try {
       const result = await api.addImages(id, files);
       setExistingImages(result.images);
@@ -189,6 +204,7 @@ export default function EditPost() {
 
   const handleDeleteImage = async (imageId: string) => {
     if (!id) return;
+    setError(null);
     try {
       await api.deleteImage(id, imageId);
       setExistingImages((prev) => prev.filter((img) => img.id !== imageId));
@@ -201,6 +217,7 @@ export default function EditPost() {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!id) return;
+    setError(null);
     setSubmitting(true);
     try {
       await api.updatePost(id, {
@@ -236,6 +253,7 @@ export default function EditPost() {
 
   const confirmDelete = async () => {
     if (!id) return;
+    setError(null);
     setDeleting(true);
     try {
       await api.deletePost(id);
@@ -571,11 +589,7 @@ export default function EditPost() {
                 style={{ height: "100%", width: "100%" }}
                 scrollWheelZoom={false}
               >
-                <MapInstanceBridge
-                  onReady={(m) => {
-                    mapRef.current = m;
-                  }}
-                />
+                <MapInstanceBridge onReady={handleMapReady} />
                 <TileLayer
                   attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                   url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/apps/web/src/pages/EditPost.tsx
+++ b/apps/web/src/pages/EditPost.tsx
@@ -1,95 +1,617 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
 import { useNavigate, useParams } from "react-router-dom";
-import type { PostsControllerCreateBodyPostType } from "../../../../packages/api-client/src/index";
-import { useApiClient } from "../api/orvalClient";
 import {
-  POST_TYPE_OPTIONS,
-  POST_TYPE_SELECT_ID,
-} from "../constants/postTypeOptions";
+  MapContainer,
+  TileLayer,
+  Marker,
+  useMap,
+  useMapEvents,
+} from "react-leaflet";
+import L from "leaflet";
+import type { Map as LeafletMap } from "leaflet";
+import "leaflet/dist/leaflet.css";
+import type { ImageResponseDto } from "../../../../packages/api-client/src/index";
+import { useApiClient } from "../api/orvalClient";
+import { reverseGeocode } from "../lib/reverseGeocode";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Camera,
+  MapPin,
+  Cat,
+  Calendar,
+  ChevronLeft,
+  LocateFixed,
+  Trash2,
+  Upload,
+} from "lucide-react";
+
+delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)
+  ._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl:
+    "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+});
+
+const DEFAULT_CENTER: [number, number] = [35.9062, 139.6236];
+const MAX_IMAGES = 3;
+
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+function MapClickHandler({
+  onMapClick,
+}: {
+  onMapClick: (pos: LatLng) => void;
+}) {
+  useMapEvents({
+    click(e) {
+      onMapClick({ lat: e.latlng.lat, lng: e.latlng.lng });
+    },
+  });
+  return null;
+}
+
+function MapInstanceBridge({
+  onReady,
+}: {
+  onReady: (map: LeafletMap) => void;
+}) {
+  const map = useMap();
+  useEffect(() => {
+    onReady(map);
+  }, [map, onReady]);
+  return null;
+}
 
 export default function EditPost() {
   const api = useApiClient();
   const { id } = useParams<{ id: string }>();
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [postType, setPostType] = useState<PostsControllerCreateBodyPostType>(
-    POST_TYPE_OPTIONS[0].value
-  );
   const navigate = useNavigate();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+  const apiRef = useRef(api);
+  apiRef.current = api;
+
+  // petDetail
+  const [name, setName] = useState("");
+  const [color, setColor] = useState("");
+  const [age, setAge] = useState("");
+  const [features, setFeatures] = useState("");
+  const [gender, setGender] = useState<"male" | "female" | "unknown">(
+    "unknown"
+  );
+  const [breed, setBreed] = useState("");
+  const [microchip, setMicrochip] = useState(false);
+  const [neutered, setNeutered] = useState(false);
+
+  // post
+  const [description, setDescription] = useState("");
+  const [lostDate, setLostDate] = useState("");
+
+  // location
+  const [city, setCity] = useState("");
+  const [address, setAddress] = useState("");
+  const [pinPos, setPinPos] = useState<LatLng | null>(null);
+
+  // images
+  const [existingImages, setExistingImages] = useState<ImageResponseDto[]>([]);
+  const [remainingSlots, setRemainingSlots] = useState(MAX_IMAGES);
+
+  // UI
+  const [submitting, setSubmitting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [isLocating, setIsLocating] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPost = useCallback(async (postId: string) => {
+    const post = await apiRef.current.getPost(postId);
+    setDescription(post.description ?? "");
+    setLostDate(
+      post.lostDate ? new Date(post.lostDate).toISOString().slice(0, 16) : ""
+    );
+    setExistingImages(post.images ?? []);
+    setRemainingSlots(MAX_IMAGES - (post.images?.length ?? 0));
+
+    if (post.petDetail) {
+      setName(post.petDetail.name ?? "");
+      setColor(post.petDetail.color ?? "");
+      setAge(post.petDetail.age ?? "");
+      setFeatures(post.petDetail.features ?? "");
+      setGender(
+        (post.petDetail.gender as "male" | "female" | "unknown") ?? "unknown"
+      );
+      setBreed(post.petDetail.breed ?? "");
+      setMicrochip(post.petDetail.microchip ?? false);
+      setNeutered(post.petDetail.neutered ?? false);
+    }
+    if (post.location) {
+      setCity(post.location.city ?? "");
+      setAddress(post.location.address ?? "");
+      setPinPos({ lat: post.location.lat, lng: post.location.lng });
+    }
+  }, []);
 
   useEffect(() => {
     if (!id) return;
-    (async () => {
-      try {
-        const data = await api.getPost(id);
-        setTitle(data.title || "");
-        setDescription(data.description || "");
-        setPostType(data.postType ?? POST_TYPE_OPTIONS[0].value);
-      } catch (err) {
-        alert("Failed to load post");
-      }
-    })();
-  }, [id, api]);
+    loadPost(id).catch(() => setError("投稿の取得に失敗しました"));
+  }, [id, loadPost]);
+
+  const handleCurrentLocation = () => {
+    if (!navigator.geolocation) {
+      setLocationError("このブラウザでは現在地を取得できません");
+      return;
+    }
+    setIsLocating(true);
+    setLocationError(null);
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        const { latitude: lat, longitude: lng } = position.coords;
+        setPinPos({ lat, lng });
+        mapRef.current?.flyTo([lat, lng], 16, { animate: true });
+        const result = await reverseGeocode(lat, lng);
+        if ("address" in result) setAddress(result.address);
+        else setLocationError(result.geocodeError);
+        setIsLocating(false);
+      },
+      () => {
+        setLocationError("現在地の取得に失敗しました");
+        setIsLocating(false);
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+    );
+  };
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (!files.length || !id) return;
+    e.target.value = "";
+    try {
+      const result = await api.addImages(id, files);
+      setExistingImages(result.images);
+      setRemainingSlots(result.remainingSlots);
+    } catch {
+      setError("画像のアップロードに失敗しました");
+    }
+  };
+
+  const handleDeleteImage = async (imageId: string) => {
+    if (!id) return;
+    try {
+      await api.deleteImage(id, imageId);
+      setExistingImages((prev) => prev.filter((img) => img.id !== imageId));
+      setRemainingSlots((prev) => prev + 1);
+    } catch {
+      setError("画像の削除に失敗しました");
+    }
+  };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!id) return;
+    setSubmitting(true);
     try {
-      await api.updatePost(id, { title, description, postType });
+      await api.updatePost(id, {
+        description: description.trim(),
+        lostDate: lostDate ? new Date(lostDate).toISOString() : undefined,
+        petDetail: {
+          name: name.trim() || undefined,
+          color: color.trim() || undefined,
+          age: age.trim() || undefined,
+          features: features.trim() || undefined,
+          gender,
+          breed: breed.trim() || undefined,
+          microchip,
+          neutered,
+        },
+        location: pinPos
+          ? {
+              prefecture: "saitama",
+              city: city.trim() || undefined,
+              address: address.trim() || undefined,
+              lat: pinPos.lat,
+              lng: pinPos.lng,
+            }
+          : undefined,
+      });
       navigate("/");
-    } catch (err) {
-      alert("Failed to update post");
+    } catch {
+      setError("保存に失敗しました");
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  const remove = async () => {
+  const confirmDelete = async () => {
     if (!id) return;
-    if (!confirm("Delete this post?")) return;
+    setDeleting(true);
     try {
       await api.deletePost(id);
       navigate("/");
-    } catch (err) {
-      alert("Failed to delete post");
+    } catch {
+      setError("削除に失敗しました");
+      setDeleting(false);
+      setShowDeleteDialog(false);
     }
   };
 
   return (
-    <form onSubmit={submit}>
-      <h2>Edit Post</h2>
-      <div>
-        <label htmlFor={POST_TYPE_SELECT_ID}>投稿種別</label>
-        <select
-          id={POST_TYPE_SELECT_ID}
-          value={postType}
-          onChange={(e) =>
-            setPostType(e.target.value as PostsControllerCreateBodyPostType)
-          }
+    <div className="max-w-2xl mx-auto p-4 sm:p-8 font-manrope">
+      <div className="flex items-center gap-4 mb-8">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="rounded-full"
+          onClick={() => navigate(-1)}
         >
-          {POST_TYPE_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
+          <ChevronLeft size={24} />
+        </Button>
+        <h1 className="text-3xl font-black tracking-tight text-slate-900">
+          投稿を編集
+        </h1>
       </div>
-      <div>
-        <input
-          placeholder="title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-        />
-      </div>
-      <div>
-        <textarea
-          placeholder="description"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
-      </div>
-      <button type="submit">Save</button>
-      <button type="button" onClick={remove} style={{ marginLeft: 8 }}>
-        Delete
-      </button>
-    </form>
+
+      {error && (
+        <p className="mb-4 text-sm text-red-500 bg-red-50 p-3 rounded-xl">
+          {error}
+        </p>
+      )}
+
+      {/* 削除確認ダイアログ */}
+      {showDeleteDialog && (
+        <div
+          role="dialog"
+          aria-label="投稿を削除しますか？"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        >
+          <div className="bg-white rounded-2xl p-6 mx-4 max-w-sm w-full space-y-4">
+            <h2 className="text-lg font-black text-slate-900">
+              投稿を削除しますか？
+            </h2>
+            <p className="text-sm text-slate-600">この操作は取り消せません。</p>
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1"
+                onClick={() => setShowDeleteDialog(false)}
+              >
+                キャンセル
+              </Button>
+              <Button
+                type="button"
+                className="flex-1 bg-red-600 hover:bg-red-700 text-white"
+                onClick={confirmDelete}
+                disabled={deleting}
+              >
+                削除を確定する
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={submit} className="space-y-12">
+        {/* 画像管理 */}
+        <section className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Camera className="text-blue-600" size={20} />
+            <h2 className="text-lg font-black text-slate-800">お写真</h2>
+          </div>
+          <Card className="border-none bg-slate-50 rounded-[2rem] overflow-hidden">
+            <CardContent className="p-6">
+              <div className="grid grid-cols-3 gap-3">
+                {existingImages.map((img, i) => (
+                  <div key={img.id} className="relative aspect-square">
+                    <img
+                      src={img.url}
+                      alt={`既存画像${i + 1}`}
+                      className="w-full h-full object-cover rounded-2xl"
+                    />
+                    <button
+                      type="button"
+                      aria-label={`既存画像${i + 1}を削除`}
+                      onClick={() => handleDeleteImage(img.id)}
+                      className="absolute top-1 right-1 bg-black/50 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+                {remainingSlots > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="aspect-square rounded-2xl border-2 border-dashed border-slate-200 bg-white flex flex-col items-center justify-center cursor-pointer hover:bg-blue-50 transition-colors"
+                  >
+                    <Upload size={24} className="text-slate-400 mb-1" />
+                    <span className="text-[10px] font-bold text-slate-400">
+                      追加
+                    </span>
+                  </button>
+                )}
+              </div>
+              {remainingSlots > 0 && (
+                <input
+                  ref={fileInputRef}
+                  data-testid="image-upload-input"
+                  type="file"
+                  accept="image/jpeg,image/png,image/gif,image/webp"
+                  multiple
+                  className="hidden"
+                  onChange={handleImageUpload}
+                />
+              )}
+              <p className="mt-4 text-[10px] font-medium text-slate-400 text-center">
+                残り {remainingSlots} 枚追加できます
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* ねこちゃんの情報 */}
+        <section className="space-y-6">
+          <div className="flex items-center gap-2">
+            <Cat className="text-blue-600" size={20} />
+            <h2 className="text-lg font-black text-slate-800">
+              ねこちゃんの情報
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <Label className="text-xs font-bold text-slate-500 ml-1">
+                お名前
+              </Label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="h-12 border-none bg-slate-50 rounded-2xl px-4"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-bold text-slate-500 ml-1">
+                種類
+              </Label>
+              <Input
+                value={breed}
+                onChange={(e) => setBreed(e.target.value)}
+                className="h-12 border-none bg-slate-50 rounded-2xl px-4"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <Label className="text-xs font-bold text-slate-500 ml-1">
+              性別
+            </Label>
+            <RadioGroup
+              value={gender}
+              onValueChange={(v: string) =>
+                setGender(v as "male" | "female" | "unknown")
+              }
+              className="flex gap-4"
+            >
+              {(
+                [
+                  { value: "male", label: "オス" },
+                  { value: "female", label: "メス" },
+                  { value: "unknown", label: "不明" },
+                ] as const
+              ).map((g) => (
+                <div
+                  key={g.value}
+                  className="flex items-center space-x-2 bg-slate-50 px-4 py-2 rounded-full"
+                >
+                  <RadioGroupItem value={g.value} id={`gender-${g.value}`} />
+                  <Label
+                    htmlFor={`gender-${g.value}`}
+                    className="text-sm font-bold"
+                  >
+                    {g.label}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <Label className="text-xs font-bold text-slate-500 ml-1">
+                年齢
+              </Label>
+              <Input
+                value={age}
+                onChange={(e) => setAge(e.target.value)}
+                className="h-12 border-none bg-slate-50 rounded-2xl px-4"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-bold text-slate-500 ml-1">
+                毛色
+              </Label>
+              <Input
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="h-12 border-none bg-slate-50 rounded-2xl px-4"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs font-bold text-slate-500 ml-1">
+              特徴
+            </Label>
+            <Textarea
+              value={features}
+              onChange={(e) => setFeatures(e.target.value)}
+              className="min-h-[80px] border-none bg-slate-50 rounded-2xl p-4 resize-none"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs font-bold text-slate-500 ml-1">
+              詳しい説明
+            </Label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="min-h-[80px] border-none bg-slate-50 rounded-2xl p-4 resize-none"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex items-center space-x-3 bg-slate-50 p-4 rounded-2xl">
+              <Checkbox
+                id="microchip"
+                checked={microchip}
+                onCheckedChange={(v: CheckedState) => setMicrochip(v === true)}
+              />
+              <Label htmlFor="microchip" className="text-sm font-bold">
+                マイクロチップあり
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3 bg-slate-50 p-4 rounded-2xl">
+              <Checkbox
+                id="neutered"
+                checked={neutered}
+                onCheckedChange={(v: CheckedState) => setNeutered(v === true)}
+              />
+              <Label htmlFor="neutered" className="text-sm font-bold">
+                避妊去勢済
+              </Label>
+            </div>
+          </div>
+        </section>
+
+        {/* いつ・どこで？ */}
+        <section className="space-y-6">
+          <div className="flex items-center gap-2">
+            <MapPin className="text-blue-600" size={20} />
+            <h2 className="text-lg font-black text-slate-800">
+              いつ・どこで？
+            </h2>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs font-bold text-slate-500 ml-1">
+              いなくなった日時
+            </Label>
+            <div className="relative">
+              <Calendar
+                className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
+                size={18}
+              />
+              <Input
+                type="datetime-local"
+                value={lostDate}
+                onChange={(e) => setLostDate(e.target.value)}
+                className="h-12 border-none bg-slate-50 rounded-2xl pl-12"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs font-bold text-slate-500 ml-1">
+              市区町村
+            </Label>
+            <Input
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              className="h-12 border-none bg-slate-50 rounded-2xl px-4"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs font-bold text-slate-500 ml-1">
+              住所・目印
+            </Label>
+            <Input
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              className="h-12 border-none bg-slate-50 rounded-2xl px-4"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between ml-1">
+              <Label className="text-xs font-bold text-slate-500">
+                地図でピンを指定
+              </Label>
+              <button
+                type="button"
+                onClick={handleCurrentLocation}
+                disabled={isLocating}
+                className="flex items-center gap-1 text-xs font-bold text-blue-600 hover:text-blue-700 disabled:opacity-50"
+              >
+                <LocateFixed size={14} />
+                {isLocating ? "取得中…" : "現在地を使う"}
+              </button>
+            </div>
+            {locationError && (
+              <p className="text-xs text-red-500 ml-1">{locationError}</p>
+            )}
+            <div className="relative h-64 rounded-[2rem] overflow-hidden">
+              <MapContainer
+                center={pinPos ? [pinPos.lat, pinPos.lng] : DEFAULT_CENTER}
+                zoom={pinPos ? 15 : 11}
+                style={{ height: "100%", width: "100%" }}
+                scrollWheelZoom={false}
+              >
+                <MapInstanceBridge
+                  onReady={(m) => {
+                    mapRef.current = m;
+                  }}
+                />
+                <TileLayer
+                  attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                  url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+                <MapClickHandler onMapClick={setPinPos} />
+                {pinPos && <Marker position={[pinPos.lat, pinPos.lng]} />}
+              </MapContainer>
+            </div>
+            {pinPos && (
+              <p className="text-xs text-slate-400 ml-1">
+                緯度: {pinPos.lat.toFixed(5)} / 経度: {pinPos.lng.toFixed(5)}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* アクションボタン */}
+        <div className="pt-6 pb-12 space-y-4">
+          <Button
+            type="submit"
+            disabled={submitting}
+            className="w-full h-16 bg-blue-600 hover:bg-blue-700 text-white text-lg font-black rounded-full"
+          >
+            {submitting ? "保存中…" : "保存する"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full h-12 border-red-200 text-red-600 hover:bg-red-50 rounded-full font-bold"
+            onClick={() => setShowDeleteDialog(true)}
+          >
+            <Trash2 size={16} className="mr-2" />
+            削除する
+          </Button>
+        </div>
+      </form>
+    </div>
   );
 }

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -419,6 +419,7 @@ export default function Map() {
             setError("メッセージの送信に失敗しました");
           }
         }}
+        onEdit={(postId) => navigate(`/edit/${postId}`)}
       />
 
       <SightingModal

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -6,11 +6,14 @@ import {
   authControllerLogout,
   type PostsControllerCreateBody,
   type UpdatePostDto,
+  type AddImagesResponseDto,
   postsControllerList,
   postsControllerCreate,
   postsControllerUpdate,
   postsControllerGet,
   postsControllerRemove,
+  postsControllerAddImages,
+  postsControllerRemoveImage,
   usersControllerRegister,
   mapControllerGetMarkers,
   conversationsControllerFindAll,
@@ -141,16 +144,23 @@ export function createClient(options: ClientOptions) {
       const r = await postsControllerGet(id);
       return r.data;
     },
-    updatePost: async (
-      id: string,
-      data: Pick<UpdatePostDto, "title" | "description" | "postType">
-    ) => {
+    updatePost: async (id: string, data: UpdatePostDto) => {
       const r = await postsControllerUpdate(id, data);
       return r.data;
     },
     deletePost: async (id: string) => {
       const r = await postsControllerRemove(id);
       return r.data;
+    },
+    addImages: async (
+      id: string,
+      images: File[]
+    ): Promise<AddImagesResponseDto> => {
+      const r = await postsControllerAddImages(id, { images });
+      return r.data;
+    },
+    deleteImage: async (id: string, imageId: string) => {
+      await postsControllerRemoveImage(id, imageId);
     },
     getMapMarkers: async () => {
       const r = await mapControllerGetMarkers();

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -446,7 +446,15 @@
 - [x] App で /posts を開いて認証済みの時、Logout が表示され Login が表示されない
 - [x] App でヘッダーに会話一覧リンクが表示されること
 - [x] CreatePost で必須項目を入力して送信した時、lostDate を正規化して cat投稿として作成し /posts へ戻る
-- [x] EditPost で取得した postType を表示し、送信時に postType を含める
+- [x] EditPost で投稿データ取得後、petDetail を含むフォームに初期値がセットされること
+- [x] EditPost で変更して保存した時、updatePost が petDetail/location を含むデータで呼ばれること
+- [x] EditPost で削除ボタンをクリックした時、確認ダイアログが表示されること
+- [x] EditPost で削除ダイアログで「削除を確定する」を押した時、deletePost が呼ばれ / にリダイレクトされること
+- [x] EditPost で削除ダイアログで「キャンセル」を押した時、deletePost が呼ばれないこと
+- [x] EditPost で既存画像がサムネイル表示されること
+- [x] EditPost で既存画像の個別削除ボタンをクリックした時、deleteImage が imageId で呼ばれること
+- [x] EditPost で画像追加アップロードで addImages が呼ばれること
+- [x] EditPost で remainingSlots=0 の時、追加アップロードボタンが非表示になること
 - [x] Map で検索バーと種別フィルターを表示する
 - [x] Map で迷い猫投稿を押すと /create に遷移する
 - [x] Map で迷子マーカーを押すと詳細シートが開き投稿者名を表示する

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -455,6 +455,7 @@
 - [x] EditPost で既存画像の個別削除ボタンをクリックした時、deleteImage が imageId で呼ばれること
 - [x] EditPost で画像追加アップロードで addImages が呼ばれること
 - [x] EditPost で remainingSlots=0 の時、追加アップロードボタンが非表示になること
+- [x] EditPost で remainingSlots を超える枚数を選択した時、エラーメッセージが表示され addImages が呼ばれないこと
 - [x] Map で検索バーと種別フィルターを表示する
 - [x] Map で迷い猫投稿を押すと /create に遷移する
 - [x] Map で迷子マーカーを押すと詳細シートが開き投稿者名を表示する

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -327,13 +327,17 @@ apps/web/src/
     │       │   ├── 自分がPost投稿者の時、ボタンが非表示であること
     │       │   ├── markerType=sighting の時、ボタンが非表示であること
     │       │   └── ボタンを押した時、onReportSighting が postId で呼ばれること
-    │       └── メッセージを送るボタン
-    │           ├── ログイン済みかつ自分がSighting投稿者かつPost投稿者でない時、ボタンが表示されること
-    │           ├── currentUserIdが未指定（未ログイン）の時、ボタンが非表示であること
-    │           ├── 自分がPost投稿者の時、ボタンが非表示であること
-    │           ├── 自分がSighting投稿者でない時、ボタンが非表示であること
-    │           ├── markerType=postの時、ボタンが非表示であること
-    │           └── ボタンを押した時、onSendMessageが呼ばれること
+    │       ├── メッセージを送るボタン
+    │       │   ├── ログイン済みかつ自分がSighting投稿者かつPost投稿者でない時、ボタンが表示されること
+    │       │   ├── currentUserIdが未指定（未ログイン）の時、ボタンが非表示であること
+    │       │   ├── 自分がPost投稿者の時、ボタンが非表示であること
+    │       │   ├── 自分がSighting投稿者でない時、ボタンが非表示であること
+    │       │   ├── markerType=postの時、ボタンが非表示であること
+    │       │   └── ボタンを押した時、onSendMessageが呼ばれること
+    │       └── 編集ボタン
+    │           ├── markerType=post かつ自分の投稿の時、編集ボタンが表示されること
+    │           ├── 他人の投稿の時、編集ボタンが非表示であること
+    │           └── 編集ボタンをクリックした時、onEdit が postId で呼ばれること
     ├── components/SightingModal.test.tsx
     │   └── SightingModal
     │       ├── isOpen=true の時、フォームが表示されること
@@ -356,7 +360,15 @@ apps/web/src/
     │       └── ネットワークエラー時、geocodeError を返すこと
     ├── EditPost.test.tsx
     │   └── EditPost
-    │       └── 取得した postType を表示し、送信時に postType を含める
+    │       ├── 投稿データ取得後、petDetail を含むフォームに初期値がセットされること
+    │       ├── 変更して保存した時、updatePost が petDetail/location を含むデータで呼ばれること
+    │       ├── 削除ボタンをクリックした時、確認ダイアログが表示されること
+    │       ├── 削除ダイアログで「削除を確定する」を押した時、deletePost が呼ばれ / にリダイレクトされること
+    │       ├── 削除ダイアログで「キャンセル」を押した時、deletePost が呼ばれないこと
+    │       ├── 既存画像がサムネイル表示されること
+    │       ├── 既存画像の個別削除ボタンをクリックした時、deleteImage が imageId で呼ばれること
+    │       ├── 画像追加アップロードで addImages が呼ばれること
+    │       └── remainingSlots=0 の時、追加アップロードボタンが非表示になること
     ├── Conversations.test.tsx
     │   └── Conversations
     │       ├── 会話一覧の表示

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -368,7 +368,8 @@ apps/web/src/
     │       ├── 既存画像がサムネイル表示されること
     │       ├── 既存画像の個別削除ボタンをクリックした時、deleteImage が imageId で呼ばれること
     │       ├── 画像追加アップロードで addImages が呼ばれること
-    │       └── remainingSlots=0 の時、追加アップロードボタンが非表示になること
+    │       ├── remainingSlots=0 の時、追加アップロードボタンが非表示になること
+    │       └── remainingSlots を超える枚数を選択した時、エラーメッセージが表示され addImages が呼ばれないこと
     ├── Conversations.test.tsx
     │   └── Conversations
     │       ├── 会話一覧の表示


### PR DESCRIPTION
## Summary

- **EditPost** を完全リニューアル — petDetail（名前・種類・性別・年齢・毛色・特徴・マイクロチップ・避妊去勢）、location（日時・市区町村・住所・地図ピン）、画像管理を含む編集フォームを実装 (closes #73, #74, #75)
- **PostDetailSheet** に「編集する」ボタンを追加 — 自分の投稿のみ表示し、`onEdit` コールバックで `/edit/:id` へ遷移
- **api-client** に `addImages` / `deleteImage` / 完全な `updatePost`（UpdatePostDto）を追加

## Bug fix

- `useEffect` 依存配列に `api` を含めるとテストモックが毎回新しいオブジェクトを返すため無限再レンダリングが発生していた問題を `apiRef` + `useCallback` パターンで修正

## Test plan

- [ ] EditPost: 初期値セット・保存・削除・画像追加削除・remainingSlots=0 (9件 すべてパス)
- [ ] PostDetailSheet: 編集ボタン表示/非表示/クリック (3件 すべてパス)
- [ ] API テスト: 195件 すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)