### PR TITLE
feat: issue#76,77 Post詳細にSighting一覧表示と削除UIを実装

### DIFF
--- a/apps/api/src/sightings/dto/sighting-response.dto.ts
+++ b/apps/api/src/sightings/dto/sighting-response.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  OPENAPI_SIGHTING_ID_EXAMPLE,
+  OPENAPI_USER_ID_EXAMPLE,
+} from "../../common/openapi-examples";
+
+export class SightingResponseDto {
+  @ApiProperty({ example: OPENAPI_SIGHTING_ID_EXAMPLE })
+  id: string;
+
+  @ApiProperty({ example: OPENAPI_USER_ID_EXAMPLE })
+  userId: string;
+
+  @ApiProperty({
+    example: "埼玉県さいたま市浦和区",
+    required: false,
+    nullable: true,
+  })
+  address: string | null;
+
+  @ApiProperty({ example: "2024-01-02T00:00:00.000Z" })
+  sightedAt: Date;
+
+  @ApiProperty({
+    example: "公園付近で目撃しました",
+    required: false,
+    nullable: true,
+  })
+  comment: string | null;
+
+  @ApiProperty({ example: "2024-01-02T00:00:00.000Z" })
+  createdAt: Date;
+}

--- a/apps/api/src/sightings/dto/sighting-response.dto.ts
+++ b/apps/api/src/sightings/dto/sighting-response.dto.ts
@@ -18,8 +18,12 @@ export class SightingResponseDto {
   })
   address: string | null;
 
-  @ApiProperty({ example: "2024-01-02T00:00:00.000Z" })
-  sightedAt: Date;
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    example: "2024-01-02T00:00:00.000Z",
+  })
+  sightedAt: string;
 
   @ApiProperty({
     example: "公園付近で目撃しました",
@@ -28,6 +32,10 @@ export class SightingResponseDto {
   })
   comment: string | null;
 
-  @ApiProperty({ example: "2024-01-02T00:00:00.000Z" })
-  createdAt: Date;
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    example: "2024-01-02T00:00:00.000Z",
+  })
+  createdAt: string;
 }

--- a/apps/api/src/sightings/sighting.controller.ts
+++ b/apps/api/src/sightings/sighting.controller.ts
@@ -25,6 +25,7 @@ import {
   OPENAPI_SIGHTING_ID_EXAMPLE,
 } from "../common/openapi-examples";
 import { CreateSightingDto } from "./dto/create-sighting.dto";
+import { SightingResponseDto } from "./dto/sighting-response.dto";
 import { SightingsService } from "./sighting.service";
 
 @ApiTags("sightings")
@@ -61,6 +62,7 @@ export class SightingsController {
     required: true,
     example: OPENAPI_POST_ID_EXAMPLE,
   })
+  @ApiResponse({ status: 200, type: [SightingResponseDto] })
   findByPost(@Query("postId") postId: string) {
     return this.sightingsService.findByPost(postId);
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "npx playwright test --project=chromium --reporter=list"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",

--- a/apps/web/src/components/PostDetailSheet.test.tsx
+++ b/apps/web/src/components/PostDetailSheet.test.tsx
@@ -1,7 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
 import type { PostResponseDto } from "../../../../packages/api-client/src/index";
 import PostDetailSheet from "./PostDetailSheet";
+
+vi.mock("../api/orvalClient", () => ({
+  useApiClient: () => ({
+    findSightingsByPost: vi.fn().mockResolvedValue([]),
+  }),
+}));
 
 const basePost: PostResponseDto = {
   id: "post-1",
@@ -55,15 +63,20 @@ const postWithDetail: PostResponseDto = {
 function renderSheet(
   props: Partial<Parameters<typeof PostDetailSheet>[0]> = {}
 ) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <PostDetailSheet
-      isOpen={true}
-      onClose={() => {}}
-      post={basePost}
-      markerType="post"
-      isLoading={false}
-      {...props}
-    />
+    <QueryClientProvider client={queryClient}>
+      <PostDetailSheet
+        isOpen={true}
+        onClose={() => {}}
+        post={basePost}
+        markerType="post"
+        isLoading={false}
+        {...props}
+      />
+    </QueryClientProvider>
   );
 }
 

--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -1,5 +1,6 @@
 import type { PostResponseDto } from "../../../../packages/api-client/src/index";
 import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
+import SightingList from "./SightingList";
 
 interface PostDetailSheetProps {
   isOpen: boolean;
@@ -12,6 +13,7 @@ interface PostDetailSheetProps {
   sightingUserId?: string | null;
   onSendMessage?: (postId: string, sightingId: string) => void;
   onReportSighting?: (postId: string) => void;
+  onSightingDeleted?: () => void;
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -35,6 +37,7 @@ export default function PostDetailSheet({
   sightingUserId,
   onSendMessage,
   onReportSighting,
+  onSightingDeleted,
 }: PostDetailSheetProps) {
   const title = markerType === "post" ? "迷い猫投稿" : "目撃情報";
 
@@ -83,6 +86,14 @@ export default function PostDetailSheet({
                 目撃を報告する
               </button>
             </div>
+          )}
+
+          {markerType === "post" && post && !isLoading && (
+            <SightingList
+              postId={post.id}
+              currentUserId={currentUserId ?? null}
+              onSightingDeleted={onSightingDeleted ?? (() => {})}
+            />
           )}
 
           {showMessageButton && post && sightingId && (

--- a/apps/web/src/components/SightingList.test.tsx
+++ b/apps/web/src/components/SightingList.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+import SightingList from "./SightingList";
+import type { SightingResponseDto } from "../../../../packages/api-client/src/index";
+
+const mockFindSightingsByPost = vi.fn();
+const mockDeleteSighting = vi.fn();
+
+vi.mock("../api/orvalClient", () => ({
+  useApiClient: () => ({
+    findSightingsByPost: mockFindSightingsByPost,
+    deleteSighting: mockDeleteSighting,
+  }),
+}));
+
+const sighting1: SightingResponseDto = {
+  id: "s-1",
+  userId: "user-1",
+  address: "埼玉県さいたま市浦和区",
+  sightedAt: "2026-04-20T10:00:00.000Z",
+  comment: "公園で目撃しました",
+  createdAt: "2026-04-20T11:00:00.000Z",
+};
+
+const sighting2: SightingResponseDto = {
+  id: "s-2",
+  userId: "user-2",
+  address: "埼玉県川口市",
+  sightedAt: "2026-04-21T12:00:00.000Z",
+  comment: null,
+  createdAt: "2026-04-21T13:00:00.000Z",
+};
+
+function renderSightingList(
+  props: Partial<Parameters<typeof SightingList>[0]> = {}
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SightingList
+        postId="post-1"
+        currentUserId={null}
+        onSightingDeleted={() => {}}
+        {...props}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe("SightingList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ローディング中は読み込み中テキストが表示されること", () => {
+    mockFindSightingsByPost.mockReturnValue(new Promise(() => {}));
+    renderSightingList();
+    expect(screen.getByText("読み込み中…")).toBeInTheDocument();
+  });
+
+  it("Sightingが0件の時、空状態メッセージが表示されること", async () => {
+    mockFindSightingsByPost.mockResolvedValue([]);
+    renderSightingList();
+    await waitFor(() =>
+      expect(screen.getByText("まだ目撃情報はありません")).toBeInTheDocument()
+    );
+  });
+
+  it("Sighting一覧にsightedAt・address・commentが表示されること", async () => {
+    mockFindSightingsByPost.mockResolvedValue([sighting1]);
+    renderSightingList();
+    await waitFor(() =>
+      expect(screen.getByText("埼玉県さいたま市浦和区")).toBeInTheDocument()
+    );
+    expect(screen.getByText("公園で目撃しました")).toBeInTheDocument();
+  });
+
+  it("自分のSightingにのみ削除ボタンが表示されること", async () => {
+    mockFindSightingsByPost.mockResolvedValue([sighting1, sighting2]);
+    renderSightingList({ currentUserId: "user-1" });
+    await waitFor(() =>
+      expect(screen.getByText("埼玉県さいたま市浦和区")).toBeInTheDocument()
+    );
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    expect(deleteButtons).toHaveLength(1);
+  });
+
+  it("他人のSightingには削除ボタンが表示されないこと", async () => {
+    mockFindSightingsByPost.mockResolvedValue([sighting2]);
+    renderSightingList({ currentUserId: "user-1" });
+    await waitFor(() =>
+      expect(screen.getByText("埼玉県川口市")).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole("button", { name: "削除" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("削除ボタン押下でAlertDialogが表示されること", async () => {
+    const user = userEvent.setup();
+    mockFindSightingsByPost.mockResolvedValue([sighting1]);
+    renderSightingList({ currentUserId: "user-1" });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+
+  it("AlertDialog確認でdeleteSightingが呼ばれること", async () => {
+    const user = userEvent.setup();
+    mockFindSightingsByPost.mockResolvedValue([sighting1]);
+    mockDeleteSighting.mockResolvedValue(undefined);
+    renderSightingList({ currentUserId: "user-1" });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await waitFor(() => expect(mockDeleteSighting).toHaveBeenCalledWith("s-1"));
+  });
+
+  it("削除成功後にonSightingDeletedコールバックが呼ばれること", async () => {
+    const user = userEvent.setup();
+    const onSightingDeleted = vi.fn();
+    mockFindSightingsByPost.mockResolvedValue([sighting1]);
+    mockDeleteSighting.mockResolvedValue(undefined);
+    renderSightingList({ currentUserId: "user-1", onSightingDeleted });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await waitFor(() => expect(onSightingDeleted).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/src/components/SightingList.test.tsx
+++ b/apps/web/src/components/SightingList.test.tsx
@@ -33,6 +33,15 @@ const sighting2: SightingResponseDto = {
   createdAt: "2026-04-21T13:00:00.000Z",
 };
 
+const sighting3: SightingResponseDto = {
+  id: "s-3",
+  userId: "user-1",
+  address: "埼玉県熊谷市",
+  sightedAt: "2026-04-22T09:00:00.000Z",
+  comment: null,
+  createdAt: "2026-04-22T10:00:00.000Z",
+};
+
 function renderSightingList(
   props: Partial<Parameters<typeof SightingList>[0]> = {}
 ) {
@@ -136,5 +145,37 @@ describe("SightingList", () => {
     await user.click(screen.getByRole("button", { name: "削除" }));
     await user.click(screen.getByRole("button", { name: "削除する" }));
     await waitFor(() => expect(onSightingDeleted).toHaveBeenCalledTimes(1));
+  });
+
+  it("削除処理中は確認ダイアログの削除ボタンが無効化されること", async () => {
+    const user = userEvent.setup();
+    mockFindSightingsByPost.mockResolvedValue([sighting1, sighting3]);
+    mockDeleteSighting.mockReturnValue(new Promise(() => {}));
+    renderSightingList({ currentUserId: "user-1" });
+    const deleteButtons = await screen.findAllByRole("button", {
+      name: "削除",
+    });
+    expect(deleteButtons).toHaveLength(2);
+    await user.click(deleteButtons[0]);
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await user.click(deleteButtons[1]);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "削除する" })).toBeDisabled()
+    );
+  });
+
+  it("削除APIが失敗した時、エラーメッセージが表示されること", async () => {
+    const user = userEvent.setup();
+    mockFindSightingsByPost.mockResolvedValue([sighting1]);
+    mockDeleteSighting.mockRejectedValue(new Error("サーバーエラー"));
+    renderSightingList({ currentUserId: "user-1" });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole("button", { name: "削除" }));
+    await user.click(screen.getByRole("button", { name: "削除する" }));
+    await waitFor(() =>
+      expect(screen.getByText("削除に失敗しました")).toBeInTheDocument()
+    );
   });
 });

--- a/apps/web/src/components/SightingList.tsx
+++ b/apps/web/src/components/SightingList.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { SightingResponseDto } from "../../../../packages/api-client/src/index";
+import { useApiClient } from "../api/orvalClient";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+
+interface SightingListProps {
+  postId: string;
+  currentUserId: string | null;
+  onSightingDeleted: () => void;
+}
+
+function formatSightedAt(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function SightingList({
+  postId,
+  currentUserId,
+  onSightingDeleted,
+}: SightingListProps) {
+  const api = useApiClient();
+  const queryClient = useQueryClient();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const { data: sightings, isLoading } = useQuery({
+    queryKey: ["sightings", postId],
+    queryFn: () => api.findSightingsByPost(postId),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.deleteSighting(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sightings", postId] });
+      onSightingDeleted();
+      setDeletingId(null);
+    },
+  });
+
+  if (isLoading) {
+    return <p className="text-slate-500 text-sm mt-4">読み込み中…</p>;
+  }
+
+  if (!sightings || sightings.length === 0) {
+    return (
+      <p className="text-slate-400 text-sm mt-4">まだ目撃情報はありません</p>
+    );
+  }
+
+  return (
+    <>
+      <div className="mt-4 space-y-3">
+        {sightings.map((s: SightingResponseDto) => (
+          <div key={s.id} className="bg-slate-50 rounded-2xl p-4">
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-slate-400 mb-1">
+                  {formatSightedAt(s.sightedAt)}
+                </p>
+                {s.address && (
+                  <p className="text-sm font-bold text-slate-700 flex items-center gap-1">
+                    <span className="text-blue-500">📍</span>
+                    {s.address}
+                  </p>
+                )}
+                {s.comment && (
+                  <p className="text-sm text-slate-600 mt-1">{s.comment}</p>
+                )}
+              </div>
+              {currentUserId === s.userId && (
+                <button
+                  type="button"
+                  aria-label="削除"
+                  onClick={() => setDeletingId(s.id)}
+                  className="shrink-0 text-xs text-red-500 hover:text-red-700 font-bold px-2 py-1 rounded-lg hover:bg-red-50"
+                >
+                  削除
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <AlertDialog
+        open={deletingId !== null}
+        onOpenChange={(open: boolean) => !open && setDeletingId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>目撃情報を削除しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deletingId && deleteMutation.mutate(deletingId)}
+            >
+              削除する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/components/SightingList.tsx
+++ b/apps/web/src/components/SightingList.tsx
@@ -38,6 +38,7 @@ export default function SightingList({
   const api = useApiClient();
   const queryClient = useQueryClient();
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: sightings, isLoading } = useQuery({
     queryKey: ["sightings", postId],
@@ -50,6 +51,10 @@ export default function SightingList({
       queryClient.invalidateQueries({ queryKey: ["sightings", postId] });
       onSightingDeleted();
       setDeletingId(null);
+      setDeleteError(null);
+    },
+    onError: () => {
+      setDeleteError("削除に失敗しました");
     },
   });
 
@@ -65,6 +70,9 @@ export default function SightingList({
 
   return (
     <>
+      {deleteError && (
+        <p className="text-red-500 text-sm mt-2">{deleteError}</p>
+      )}
       <div className="mt-4 space-y-3">
         {sightings.map((s: SightingResponseDto) => (
           <div key={s.id} className="bg-slate-50 rounded-2xl p-4">
@@ -113,6 +121,7 @@ export default function SightingList({
             <AlertDialogCancel>キャンセル</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => deletingId && deleteMutation.mutate(deletingId)}
+              disabled={deleteMutation.isPending}
             >
               削除する
             </AlertDialogAction>

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,132 @@
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { cn } from "../../lib/utils";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn("fixed inset-0 z-50 bg-black/60", className)}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-white p-6 shadow-lg sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-slate-500", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      "mt-2 inline-flex h-10 items-center justify-center rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold hover:bg-slate-100 focus:outline-none sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockGetMapMarkers = vi.fn();
 const mockGetPost = vi.fn();
@@ -74,12 +75,15 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...mod, useNavigate: () => mockNavigate };
 });
 
+const mockFindSightingsByPost = vi.fn();
+
 vi.mock("../api/orvalClient", () => ({
   useApiClient: () => ({
     getMapMarkers: mockGetMapMarkers,
     getPost: mockGetPost,
     createSighting: mockCreateSighting,
     createConversation: mockCreateConversation,
+    findSightingsByPost: mockFindSightingsByPost,
   }),
 }));
 
@@ -130,10 +134,15 @@ import Map from "./Map";
 
 describe("Map", () => {
   function renderMap() {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     return render(
-      <MemoryRouter>
-        <Map />
-      </MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <Map />
+        </MemoryRouter>
+      </QueryClientProvider>
     );
   }
 
@@ -149,6 +158,7 @@ describe("Map", () => {
     mockGetPost.mockResolvedValue(samplePost);
     mockCreateSighting.mockResolvedValue(undefined);
     mockCreateConversation.mockResolvedValue({ id: "conv-1" });
+    mockFindSightingsByPost.mockResolvedValue([]);
     Object.defineProperty(window.navigator, "geolocation", {
       configurable: true,
       value: {

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -92,6 +92,7 @@ export default function Map() {
   const { userId: currentUserId } = useAuth();
   const navigate = useNavigate();
   const [markers, setMarkers] = useState<MapMarkerDto[]>([]);
+  const [markersRefreshKey, setMarkersRefreshKey] = useState(0);
   const [filter, setFilter] = useState<FilterValue>("all");
   const [mapInstance, setMapInstance] = useState<LeafletMap | null>(null);
   const [selectedMarker, setSelectedMarker] = useState<MapMarkerDto | null>(
@@ -136,7 +137,7 @@ export default function Map() {
         setError(null);
       })
       .catch(() => setError("マーカーデータの取得に失敗しました"));
-  }, [api]);
+  }, [api, markersRefreshKey]);
 
   const visibleMarkers = useMemo(() => {
     if (filter === "all") return markers;
@@ -419,6 +420,7 @@ export default function Map() {
             setError("メッセージの送信に失敗しました");
           }
         }}
+        onSightingDeleted={() => setMarkersRefreshKey((k) => k + 1)}
       />
 
       <SightingModal

--- a/package-lock.json
+++ b/package-lock.json
@@ -4946,6 +4946,7 @@
       "name": "apps-web",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
@@ -6973,6 +6974,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -700,7 +700,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SightingResponseDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": ["sightings"]
@@ -1383,6 +1393,9 @@
           "postId": {
             "type": "string"
           },
+          "userId": {
+            "type": "string"
+          },
           "lat": {
             "type": "number"
           },
@@ -1396,6 +1409,40 @@
           }
         },
         "required": ["type", "id", "lat", "lng", "status"]
+      },
+      "SightingResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "00000000-0000-0000-0000-000000000002"
+          },
+          "userId": {
+            "type": "string",
+            "example": "10000000-0000-0000-0000-000000000002"
+          },
+          "address": {
+            "type": "string",
+            "example": "埼玉県さいたま市浦和区",
+            "nullable": true
+          },
+          "sightedAt": {
+            "format": "date-time",
+            "type": "string",
+            "example": "2024-01-02T00:00:00.000Z"
+          },
+          "comment": {
+            "type": "string",
+            "example": "公園付近で目撃しました",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "example": "2024-01-02T00:00:00.000Z"
+          }
+        },
+        "required": ["id", "userId", "sightedAt", "createdAt"]
       },
       "ConversationResponseDto": {
         "type": "object",

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -21,6 +21,8 @@ import {
   conversationsControllerMarkAsRead,
   type ConversationsControllerCreateMessageBody,
   sightingsControllerCreate,
+  sightingsControllerFindByPost,
+  sightingsControllerRemove,
 } from "./index";
 
 export type CreateSightingInput = {
@@ -185,6 +187,13 @@ export function createClient(options: ClientOptions) {
     createSighting: async (data: CreateSightingInput) => {
       const r = await sightingsControllerCreate(data);
       return r.data;
+    },
+    findSightingsByPost: async (postId: string) => {
+      const r = await sightingsControllerFindByPost({ postId });
+      return r.data;
+    },
+    deleteSighting: async (id: string) => {
+      await sightingsControllerRemove(id);
     },
   };
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -154,6 +154,17 @@ export interface ConversationResponseDto {
   sightingId: string;
 }
 
+export interface SightingResponseDto {
+  /** @nullable */
+  address?: string | null;
+  /** @nullable */
+  comment?: string | null;
+  createdAt: string;
+  id: string;
+  sightedAt: string;
+  userId: string;
+}
+
 export type MapMarkerDtoType =
   (typeof MapMarkerDtoType)[keyof typeof MapMarkerDtoType];
 
@@ -177,9 +188,9 @@ export interface MapMarkerDto {
   lat: number;
   lng: number;
   postId?: string;
-  userId?: string;
   status: MapMarkerDtoStatus;
   type: MapMarkerDtoType;
+  userId?: string;
 }
 
 export interface LogoutResponseDto {
@@ -523,7 +534,9 @@ export const sightingsControllerCreate = <TData = AxiosResponse<void>>(
 /**
  * @summary postId別の目撃情報一覧を取得する
  */
-export const sightingsControllerFindByPost = <TData = AxiosResponse<void>>(
+export const sightingsControllerFindByPost = <
+  TData = AxiosResponse<SightingResponseDto[]>,
+>(
   params: SightingsControllerFindByPostParams,
   options?: AxiosRequestConfig
 ): Promise<TData> => {
@@ -655,7 +668,9 @@ export type AuthControllerRefreshResult = AxiosResponse<AccessTokenResponseDto>;
 export type AuthControllerLogoutResult = AxiosResponse<LogoutResponseDto>;
 export type MapControllerGetMarkersResult = AxiosResponse<MapMarkerDto[]>;
 export type SightingsControllerCreateResult = AxiosResponse<void>;
-export type SightingsControllerFindByPostResult = AxiosResponse<void>;
+export type SightingsControllerFindByPostResult = AxiosResponse<
+  SightingResponseDto[]
+>;
 export type SightingsControllerRemoveResult = AxiosResponse<void>;
 export type SightingsControllerToggleFavoriteResult =
   AxiosResponse<SightingsControllerToggleFavorite201>;

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -481,6 +481,14 @@
 - [x] PostDetailSheet で自分がPost投稿者の時、目撃を報告するボタンが非表示であること
 - [x] PostDetailSheet で markerType=sighting の時、目撃を報告するボタンが非表示であること
 - [x] PostDetailSheet でボタンを押した時、onReportSighting が postId で呼ばれること
+- [x] SightingList でローディング中は読み込み中テキストが表示されること
+- [x] SightingList で Sighting が 0 件の時、空状態メッセージが表示されること
+- [x] SightingList で Sighting 一覧に sightedAt・address・comment が表示されること
+- [x] SightingList で自分の Sighting にのみ削除ボタンが表示されること
+- [x] SightingList で他人の Sighting には削除ボタンが表示されないこと
+- [x] SightingList で削除ボタン押下で AlertDialog が表示されること
+- [x] SightingList で AlertDialog 確認で deleteSighting が呼ばれること
+- [x] SightingList で削除成功後に onSightingDeleted コールバックが呼ばれること
 - [x] SightingModal で isOpen=true の時、フォームが表示されること
 - [x] SightingModal で postId が渡された時、postId フィールドが非表示であること
 - [x] SightingModal で必須項目を入力して送信すると、createSighting が正しく呼ばれること

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -498,6 +498,8 @@
 - [x] SightingList で削除ボタン押下で AlertDialog が表示されること
 - [x] SightingList で AlertDialog 確認で deleteSighting が呼ばれること
 - [x] SightingList で削除成功後に onSightingDeleted コールバックが呼ばれること
+- [x] SightingList で削除処理中は確認ダイアログの削除ボタンが無効化されること
+- [x] SightingList で削除 API が失敗した時、エラーメッセージが表示されること
 - [x] SightingModal で isOpen=true の時、フォームが表示されること
 - [x] SightingModal で postId が渡された時、postId フィールドが非表示であること
 - [x] SightingModal で必須項目を入力して送信すると、createSighting が正しく呼ばれること

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -334,6 +334,16 @@ apps/web/src/
     │           ├── 自分がSighting投稿者でない時、ボタンが非表示であること
     │           ├── markerType=postの時、ボタンが非表示であること
     │           └── ボタンを押した時、onSendMessageが呼ばれること
+    ├── components/SightingList.test.tsx
+    │   └── SightingList
+    │       ├── ローディング中は読み込み中テキストが表示されること
+    │       ├── Sighting が 0 件の時、空状態メッセージが表示されること
+    │       ├── Sighting 一覧に sightedAt・address・comment が表示されること
+    │       ├── 自分の Sighting にのみ削除ボタンが表示されること
+    │       ├── 他人の Sighting には削除ボタンが表示されないこと
+    │       ├── 削除ボタン押下で AlertDialog が表示されること
+    │       ├── AlertDialog 確認で deleteSighting が呼ばれること
+    │       └── 削除成功後に onSightingDeleted コールバックが呼ばれること
     ├── components/SightingModal.test.tsx
     │   └── SightingModal
     │       ├── isOpen=true の時、フォームが表示されること

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -347,7 +347,9 @@ apps/web/src/
     │       ├── 他人の Sighting には削除ボタンが表示されないこと
     │       ├── 削除ボタン押下で AlertDialog が表示されること
     │       ├── AlertDialog 確認で deleteSighting が呼ばれること
-    │       └── 削除成功後に onSightingDeleted コールバックが呼ばれること
+    │       ├── 削除成功後に onSightingDeleted コールバックが呼ばれること
+    │       ├── 削除処理中は確認ダイアログの削除ボタンが無効化されること
+    │       └── 削除 API が失敗した時、エラーメッセージが表示されること
     ├── components/SightingModal.test.tsx
     │   └── SightingModal
     │       ├── isOpen=true の時、フォームが表示されること


### PR DESCRIPTION
## Summary

- `SightingResponseDto` を追加し `GET /sightings` のレスポンス型を明示 → api-client 再生成
- `SightingList` コンポーネント新規作成（TanStack Query でフェッチ、shadcn AlertDialog 削除確認）
- `PostDetailSheet` に `SightingList` を統合（`markerType=post` かつ `isLoading=false` の時のみ表示）
- `Map.tsx` に `markersRefreshKey` を追加し、Sighting 削除後に `getMapMarkers` を再フェッチ

## Test plan

- [x] `SightingList.test.tsx` — 8 テストケース（ローディング / 空状態 / 一覧表示 / 削除権限 / ダイアログ / コールバック）
- [x] `PostDetailSheet.test.tsx` — 既存 24 テスト全通過（`QueryClientProvider` / mock 追加）
- [x] `Map.test.tsx` — 既存テスト全通過（`findSightingsByPost` mock 追加）
- [x] API テスト 195 件通過
- [x] Web テスト 86 件通過
- [x] 型チェック通過（API / Web）

Closes #76
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)