### PR TITLE
fix: VPSスクリプトのセキュリティ指摘2点を修正

### DIFF
--- a/scripts/vps-backup.sh
+++ b/scripts/vps-backup.sh
@@ -12,10 +12,12 @@ RETAIN_DAYS="${RETAIN_DAYS:-7}"
 UPLOADS_ONLY="${UPLOADS_ONLY:-false}"
 DB_ONLY="${DB_ONLY:-false}"
 
-# 環境変数読み込み（DATABASE_URL）
-set -a
-[[ -f ~/finder-backend/apps/api/.env ]] && . ~/finder-backend/apps/api/.env
-set +a
+# 環境変数読み込み（DATABASE_URL のみ抽出）
+ENV_FILE=~/finder-backend/apps/api/.env
+if [[ -z "${DATABASE_URL:-}" ]] && [[ -f "$ENV_FILE" ]]; then
+  DATABASE_URL=$(grep '^DATABASE_URL=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+  export DATABASE_URL
+fi
 
 # オプション解析
 while [[ $# -gt 0 ]]; do

--- a/scripts/vps-health-check.sh
+++ b/scripts/vps-health-check.sh
@@ -59,7 +59,8 @@ done
 echo ""
 echo "🔄 [2/6] PM2 プロセス ($PM2_NAME)"
 if pm2 describe "$PM2_NAME" >/dev/null 2>&1; then
-  PM2_STATUS=$(pm2 jlist | python3 -c "import sys, json; d=json.load(sys.stdin); print(next((p['pm2_env']['status'] for p in d if p['name']=='$PM2_NAME'), 'unknown'))")
+  PM2_STATUS=$(pm2 describe "$PM2_NAME" 2>/dev/null | grep -E '^\s+status' | awk '{print $NF}' | head -1)
+  PM2_STATUS="${PM2_STATUS:-unknown}"
   if [[ "$PM2_STATUS" == "online" ]]; then
     echo "  $PM2_NAME  → OK ($PM2_STATUS)"
   else


### PR DESCRIPTION
## Summary

- `vps-backup.sh`: `.env` を `source` する代わりに `grep/cut` で `DATABASE_URL` のみ安全に抽出（シェルインジェクションリスクを排除）
- `vps-health-check.sh`: `python3` インライン文字列展開を廃止し `pm2 describe | grep | awk` に置き換え（`PM2_NAME` のメタ文字インジェクションリスクを排除）

## Test plan

- [ ] `vps-backup.sh` が `.env` から `DATABASE_URL` を正しく読み込めること
- [ ] `vps-backup.sh` が環境変数に `DATABASE_URL` が既にある場合はスキップすること
- [ ] `vps-health-check.sh` が PM2 ステータスを正しく取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)