### PR TITLE
fix: any型除去・AuthenticatedRequest共通化・WebSocket認可・E2Eテスト修正

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,6 +1,14 @@
 import { AuthService } from "./auth.service";
 import * as bcrypt from "bcrypt";
 
+jest.mock("../utils/crypto", () => ({
+  decryptEmail: jest.fn().mockReturnValue("test@example.com"),
+  normalizeEmail: jest.fn((e: string) => e.toLowerCase()),
+  hmacEmail: jest.fn().mockReturnValue("hmac"),
+  encryptEmail: jest.fn().mockReturnValue("encrypted"),
+  sha256Hex: jest.fn().mockReturnValue("sha256"),
+}));
+
 const makeUser = (overrides = {}) => ({
   id: "user1",
   email: "test@example.com",
@@ -100,7 +108,8 @@ describe("AuthService", () => {
       mockPrisma.refreshToken.findUnique.mockResolvedValue({
         token: "old",
         userId: "user1",
-        user: { email: "test@example.com" },
+        expiresAt: new Date(Date.now() + 86400000),
+        user: { emailEncrypted: "encrypted", role: "user" },
       });
       mockPrisma.refreshToken.delete.mockResolvedValue({});
       mockPrisma.refreshToken.create.mockResolvedValue({});

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -30,7 +30,7 @@ export class AuthService {
   }
 
   async rotateRefreshToken(oldToken: string) {
-    const rec = await (this.prisma.refreshToken as any).findUnique({
+    const rec = await this.prisma.refreshToken.findUnique({
       where: { token: oldToken },
       include: { user: { select: { emailEncrypted: true, role: true } } },
     });
@@ -48,7 +48,7 @@ export class AuthService {
     });
     const email = rec.user.emailEncrypted
       ? decryptEmail(rec.user.emailEncrypted)
-      : (rec.user.email ?? null);
+      : null;
     return {
       newToken,
       userId: rec.userId,

--- a/apps/api/src/auth/interfaces/authenticated-request.interface.ts
+++ b/apps/api/src/auth/interfaces/authenticated-request.interface.ts
@@ -1,0 +1,11 @@
+import { Role } from "@prisma/client";
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  role: Role;
+}
+
+export interface AuthenticatedRequest {
+  user: AuthenticatedUser;
+}

--- a/apps/api/src/conversations/conversation.controller.spec.ts
+++ b/apps/api/src/conversations/conversation.controller.spec.ts
@@ -12,7 +12,9 @@ const mockGateway = {
   broadcastMessage: jest.fn(),
 };
 
-const req = { user: { id: "user-1" } };
+const req = {
+  user: { id: "user-1", email: "test@test.com", role: "user" as const },
+};
 
 describe("ConversationsController", () => {
   let controller: ConversationsController;

--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -7,7 +7,6 @@ import {
   Patch,
   Post,
   Request,
-  UnauthorizedException,
   UseGuards,
 } from "@nestjs/common";
 import {
@@ -33,13 +32,7 @@ import {
 import { MessageResponseDto } from "./dto/message-response.dto";
 import { ConversationsService } from "./conversation.service";
 import { ConversationsGateway } from "./conversations.gateway";
-
-type AuthenticatedRequest = {
-  user?: {
-    id?: string;
-    userId?: string;
-  };
-};
+import { AuthenticatedRequest } from "../auth/interfaces/authenticated-request.interface";
 
 @ApiTags("conversations")
 @Controller("conversations")
@@ -52,11 +45,7 @@ export class ConversationsController {
   ) {}
 
   private getAuthenticatedUserId(req: AuthenticatedRequest): string {
-    const userId = req.user?.id ?? req.user?.userId;
-    if (!userId) {
-      throw new UnauthorizedException("認証ユーザー情報が不正です");
-    }
-    return userId;
+    return req.user.id;
   }
 
   @Post()

--- a/apps/api/src/conversations/conversations.gateway.spec.ts
+++ b/apps/api/src/conversations/conversations.gateway.spec.ts
@@ -1,5 +1,7 @@
 import { JwtService } from "@nestjs/jwt";
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
 import { ConversationsGateway } from "./conversations.gateway";
+import { ConversationsService } from "./conversation.service";
 import { Socket } from "socket.io";
 
 function makeSocket(token?: string, authToken?: string): jest.Mocked<Socket> {
@@ -18,10 +20,14 @@ function makeSocket(token?: string, authToken?: string): jest.Mocked<Socket> {
 describe("ConversationsGateway", () => {
   let gateway: ConversationsGateway;
   let jwtService: jest.Mocked<JwtService>;
+  let conversationsService: jest.Mocked<ConversationsService>;
 
   beforeEach(() => {
     jwtService = { verify: jest.fn() } as unknown as jest.Mocked<JwtService>;
-    gateway = new ConversationsGateway(jwtService);
+    conversationsService = {
+      findOneForUser: jest.fn(),
+    } as unknown as jest.Mocked<ConversationsService>;
+    gateway = new ConversationsGateway(jwtService, conversationsService);
   });
 
   // ─── handleConnection ──────────────────────────────────────
@@ -58,19 +64,61 @@ describe("ConversationsGateway", () => {
     });
   });
 
-  // ─── handleJoin / handleLeave ──────────────────────────────
+  // ─── handleJoin ────────────────────────────────────────────
   describe("handleJoin", () => {
-    it("指定した会話ルームにjoinすること", () => {
+    it("userIdがない場合は切断されjoinしない", async () => {
       const client = makeSocket();
-      gateway.handleJoin("conv-1", client);
+      await gateway.handleJoin("conv-1", client);
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalled();
+    });
+
+    it("会話参加権限がない場合は切断されjoinしない", async () => {
+      conversationsService.findOneForUser.mockRejectedValue(
+        new ForbiddenException()
+      );
+      const client = makeSocket();
+      client.data.userId = "user-1";
+      await gateway.handleJoin("conv-1", client);
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalled();
+    });
+
+    it("会話が存在しない場合は切断されjoinしない", async () => {
+      conversationsService.findOneForUser.mockRejectedValue(
+        new NotFoundException()
+      );
+      const client = makeSocket();
+      client.data.userId = "user-1";
+      await gateway.handleJoin("conv-1", client);
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalled();
+    });
+
+    it("会話参加権限がある場合は指定した会話ルームにjoinすること", async () => {
+      conversationsService.findOneForUser.mockResolvedValue({} as never);
+      const client = makeSocket();
+      client.data.userId = "user-1";
+      await gateway.handleJoin("conv-1", client);
+      expect(client.disconnect).not.toHaveBeenCalled();
       expect(client.join).toHaveBeenCalledWith("conversation:conv-1");
     });
   });
 
+  // ─── handleLeave ───────────────────────────────────────────
   describe("handleLeave", () => {
-    it("指定した会話ルームからleaveすること", () => {
+    it("userIdがない場合は切断されleaveしない", () => {
       const client = makeSocket();
       gateway.handleLeave("conv-1", client);
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.leave).not.toHaveBeenCalled();
+    });
+
+    it("userIdがある場合は指定した会話ルームからleaveすること", () => {
+      const client = makeSocket();
+      client.data.userId = "user-1";
+      gateway.handleLeave("conv-1", client);
+      expect(client.disconnect).not.toHaveBeenCalled();
       expect(client.leave).toHaveBeenCalledWith("conversation:conv-1");
     });
   });

--- a/apps/api/src/conversations/conversations.gateway.ts
+++ b/apps/api/src/conversations/conversations.gateway.ts
@@ -11,6 +11,7 @@ import { Server, Socket } from "socket.io";
 import { JwtService } from "@nestjs/jwt";
 import { Message } from "@prisma/client";
 import { JwtPayload } from "../auth/interfaces/jwt-payload.interface";
+import { ConversationsService } from "./conversation.service";
 
 @WebSocketGateway({
   cors: { origin: process.env.WEB_ORIGIN || "http://localhost:5173" },
@@ -24,7 +25,10 @@ export class ConversationsGateway
 
   private readonly userSocketMap = new Map<string, string>();
 
-  constructor(private jwtService: JwtService) {}
+  constructor(
+    private jwtService: JwtService,
+    private conversationsService: ConversationsService
+  ) {}
 
   handleConnection(client: Socket) {
     const raw =
@@ -54,10 +58,21 @@ export class ConversationsGateway
   }
 
   @SubscribeMessage("joinConversation")
-  handleJoin(
+  async handleJoin(
     @MessageBody() conversationId: string,
     @ConnectedSocket() client: Socket
   ) {
+    const userId = client.data.userId as string | undefined;
+    if (!userId) {
+      client.disconnect();
+      return;
+    }
+    try {
+      await this.conversationsService.findOneForUser(userId, conversationId);
+    } catch {
+      client.disconnect();
+      return;
+    }
     client.join(`conversation:${conversationId}`);
   }
 
@@ -66,6 +81,11 @@ export class ConversationsGateway
     @MessageBody() conversationId: string,
     @ConnectedSocket() client: Socket
   ) {
+    const userId = client.data.userId as string | undefined;
+    if (!userId) {
+      client.disconnect();
+      return;
+    }
     client.leave(`conversation:${conversationId}`);
   }
 

--- a/apps/api/src/posts/post.controller.spec.ts
+++ b/apps/api/src/posts/post.controller.spec.ts
@@ -97,7 +97,9 @@ describe("PostsController", () => {
     it("dto と files をサービスに渡す", async () => {
       const post = makePost();
       mockPostsService.create.mockResolvedValue(post);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
       const dto = { title: "Title", description: "Content" };
 
       const result = await controller.create(req, dto as any, []);
@@ -109,7 +111,9 @@ describe("PostsController", () => {
     it("ファイル付きで作成できる", async () => {
       const post = makePost();
       mockPostsService.create.mockResolvedValue(post);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
       const dto = { title: "Title", description: "Content" };
       const files = [
         {
@@ -127,7 +131,9 @@ describe("PostsController", () => {
     it("files が undefined の時は空配列を渡す", async () => {
       const post = makePost();
       mockPostsService.create.mockResolvedValue(post);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await controller.create(
         req,
@@ -145,7 +151,9 @@ describe("PostsController", () => {
     it("petDetail と location を含む dto をサービスに渡す", async () => {
       const post = makePost();
       mockPostsService.create.mockResolvedValue(post);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
       const dto = {
         title: "Title",
         description: "Content",
@@ -175,7 +183,9 @@ describe("PostsController", () => {
     it("オーナーが更新できる", async () => {
       const updated = makePost({ title: "New" });
       mockPostsService.update.mockResolvedValue(updated);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       const result = await controller.update(req, "post1", {
         title: "New",
@@ -189,7 +199,9 @@ describe("PostsController", () => {
 
     it("オーナー以外は ForbiddenException を伝播する", async () => {
       mockPostsService.update.mockRejectedValue(new ForbiddenException());
-      const req = { user: { id: "other" } };
+      const req = {
+        user: { id: "other", email: "other@test.com", role: "user" as const },
+      };
 
       await expect(
         controller.update(req, "post1", { title: "X" } as any)
@@ -200,7 +212,9 @@ describe("PostsController", () => {
       mockPostsService.update.mockRejectedValue(
         new HttpException("Not found", 404)
       );
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await expect(
         controller.update(req, "no-such", {} as any)
@@ -210,7 +224,9 @@ describe("PostsController", () => {
     it("petDetail と location を含む dto をサービスに渡す", async () => {
       const updated = makePost();
       mockPostsService.update.mockResolvedValue(updated);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
       const dto = {
         petDetail: {
           name: "New",
@@ -242,7 +258,9 @@ describe("PostsController", () => {
         ],
       };
       mockPostsService.addImages.mockResolvedValue(response);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
       const files = [{ originalname: "a.png", buffer: Buffer.from("") } as any];
 
       const result = await controller.addImages(req, "post1", files);
@@ -260,7 +278,9 @@ describe("PostsController", () => {
         remainingSlots: 5,
         images: [],
       });
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await controller.addImages(req, "post1", undefined as any);
 
@@ -273,7 +293,9 @@ describe("PostsController", () => {
 
     it("オーナー以外は ForbiddenException を伝播する", async () => {
       mockPostsService.addImages.mockRejectedValue(new ForbiddenException());
-      const req = { user: { id: "other" } };
+      const req = {
+        user: { id: "other", email: "other@test.com", role: "user" as const },
+      };
 
       await expect(controller.addImages(req, "post1", [])).rejects.toThrow(
         ForbiddenException
@@ -282,7 +304,9 @@ describe("PostsController", () => {
 
     it("枚数超過は BadRequestException を伝播する", async () => {
       mockPostsService.addImages.mockRejectedValue(new BadRequestException());
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await expect(controller.addImages(req, "post1", [])).rejects.toThrow(
         BadRequestException
@@ -300,7 +324,9 @@ describe("PostsController", () => {
         createdAt: new Date(),
       };
       mockPostsService.removeImage.mockResolvedValue(image);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       const result = await controller.removeImage(req, "post1", "img1");
 
@@ -314,7 +340,9 @@ describe("PostsController", () => {
 
     it("オーナー以外は ForbiddenException を伝播する", async () => {
       mockPostsService.removeImage.mockRejectedValue(new ForbiddenException());
-      const req = { user: { id: "other" } };
+      const req = {
+        user: { id: "other", email: "other@test.com", role: "user" as const },
+      };
 
       await expect(
         controller.removeImage(req, "post1", "img1")
@@ -323,7 +351,9 @@ describe("PostsController", () => {
 
     it("存在しない画像は NotFoundException を伝播する", async () => {
       mockPostsService.removeImage.mockRejectedValue(new NotFoundException());
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await expect(
         controller.removeImage(req, "post1", "no-img")
@@ -335,7 +365,9 @@ describe("PostsController", () => {
   describe("toggleFavorite", () => {
     it("{ favorited: true } を返す", async () => {
       mockPostsService.toggleFavorite.mockResolvedValue({ favorited: true });
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       const result = await controller.toggleFavorite(req, "post1");
 
@@ -350,7 +382,9 @@ describe("PostsController", () => {
       mockPostsService.toggleFavorite.mockRejectedValue(
         new ForbiddenException()
       );
-      const req = { user: { id: "owner" } };
+      const req = {
+        user: { id: "owner", email: "owner@test.com", role: "user" as const },
+      };
 
       await expect(controller.toggleFavorite(req, "post1")).rejects.toThrow(
         ForbiddenException
@@ -361,7 +395,9 @@ describe("PostsController", () => {
       mockPostsService.toggleFavorite.mockRejectedValue(
         new BadRequestException()
       );
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await expect(controller.toggleFavorite(req, "post1")).rejects.toThrow(
         BadRequestException
@@ -409,7 +445,9 @@ describe("PostsController", () => {
     it("オーナーが削除できる", async () => {
       const post = makePost();
       mockPostsService.remove.mockResolvedValue(post);
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       const result = await controller.remove(req, "post1");
 
@@ -423,7 +461,9 @@ describe("PostsController", () => {
 
     it("オーナー以外は ForbiddenException を伝播する", async () => {
       mockPostsService.remove.mockRejectedValue(new ForbiddenException());
-      const req = { user: { id: "other" } };
+      const req = {
+        user: { id: "other", email: "other@test.com", role: "user" as const },
+      };
 
       await expect(controller.remove(req, "post1")).rejects.toThrow(
         ForbiddenException
@@ -434,7 +474,9 @@ describe("PostsController", () => {
       mockPostsService.remove.mockRejectedValue(
         new HttpException("Not found", 404)
       );
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await expect(controller.remove(req, "no-such")).rejects.toThrow(
         HttpException

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -33,6 +33,7 @@ import { CreatePostDto } from "./dto/create-post.dto";
 import { UpdatePostDto } from "./dto/update-post.dto";
 import { PostsService } from "./post.service";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { AuthenticatedRequest } from "../auth/interfaces/authenticated-request.interface";
 import { Plan } from "@prisma/client";
 import { PLAN_LIMITS } from "../common/plan-limits";
 import {
@@ -127,12 +128,11 @@ export class PostsController {
     },
   })
   async create(
-    @Req() req: any,
+    @Req() req: AuthenticatedRequest,
     @Body() dto: CreatePostDto,
     @UploadedFiles() files: Express.Multer.File[]
   ) {
-    const userId = req.user?.id ?? req.user?.userId;
-    return this.posts.create(userId, dto, files ?? []);
+    return this.posts.create(req.user.id, dto, files ?? []);
   }
 
   @Get()
@@ -156,12 +156,11 @@ export class PostsController {
   @ApiResponse({ status: 200, type: PostResponseDto })
   @ApiResponse({ status: 403, description: "Forbidden: not the post owner" })
   async update(
-    @Req() req: any,
+    @Req() req: AuthenticatedRequest,
     @Param("id") id: string,
     @Body() body: UpdatePostDto
   ) {
-    const userId = req.user?.id ?? req.user?.userId;
-    return this.posts.update(id, userId, body);
+    return this.posts.update(id, req.user.id, body);
   }
 
   @Delete(":id")
@@ -172,10 +171,8 @@ export class PostsController {
     status: 403,
     description: "Forbidden: not the post owner or admin",
   })
-  async remove(@Req() req: any, @Param("id") id: string) {
-    const userId = req.user?.id ?? req.user?.userId;
-    const isAdmin = req.user?.role === "admin";
-    return this.posts.remove(id, userId, isAdmin);
+  async remove(@Req() req: AuthenticatedRequest, @Param("id") id: string) {
+    return this.posts.remove(id, req.user.id, req.user.role === "admin");
   }
 
   @HttpPost(":id/images")
@@ -207,12 +204,11 @@ export class PostsController {
     },
   })
   async addImages(
-    @Req() req: any,
+    @Req() req: AuthenticatedRequest,
     @Param("id") id: string,
     @UploadedFiles() files: Express.Multer.File[]
   ) {
-    const userId = req.user?.id ?? req.user?.userId;
-    return this.posts.addImages(id, userId, files ?? []);
+    return this.posts.addImages(id, req.user.id, files ?? []);
   }
 
   @Delete(":id/images/:imageId")
@@ -226,12 +222,11 @@ export class PostsController {
   })
   @ApiResponse({ status: 404, description: "Image not found" })
   async removeImage(
-    @Req() req: any,
+    @Req() req: AuthenticatedRequest,
     @Param("id") id: string,
     @Param("imageId") imageId: string
   ) {
-    const userId = req.user?.id ?? req.user?.userId;
-    return this.posts.removeImage(id, imageId, userId);
+    return this.posts.removeImage(id, imageId, req.user.id);
   }
 
   @HttpPost(":id/favorite")
@@ -244,8 +239,10 @@ export class PostsController {
   @ApiResponse({ status: 400, description: "お気に入り上限超過" })
   @ApiResponse({ status: 403, description: "自分の投稿はお気に入り不可" })
   @ApiResponse({ status: 404, description: "Post not found" })
-  async toggleFavorite(@Req() req: any, @Param("id") id: string) {
-    const userId = req.user?.id ?? req.user?.userId;
-    return this.posts.toggleFavorite(userId, id);
+  async toggleFavorite(
+    @Req() req: AuthenticatedRequest,
+    @Param("id") id: string
+  ) {
+    return this.posts.toggleFavorite(req.user.id, id);
   }
 }

--- a/apps/api/src/sightings/sighting.controller.spec.ts
+++ b/apps/api/src/sightings/sighting.controller.spec.ts
@@ -28,10 +28,12 @@ describe("SightingsController", () => {
     it("目撃情報を作成してサービスの結果を返すこと", async () => {
       const sighting = { id: "s-1", postId: "p-1", userId: "user-1" };
       mockSightingsService.create.mockResolvedValue(sighting);
-      const req = { user: { userId: "user-1" } };
+      const req = {
+        user: { id: "user-1", email: "test@test.com", role: "user" as const },
+      };
       const dto = { postId: "p-1", lat: 35.0, lng: 139.0, note: "test" };
 
-      const result = await controller.create(req as any, dto as any);
+      const result = await controller.create(req, dto as any);
 
       expect(mockSightingsService.create).toHaveBeenCalledWith("user-1", dto);
       expect(result).toBe(sighting);
@@ -55,9 +57,11 @@ describe("SightingsController", () => {
   describe("remove", () => {
     it("目撃情報を削除してサービスの結果を返すこと", async () => {
       mockSightingsService.remove.mockResolvedValue({ id: "s-1" });
-      const req = { user: { userId: "user-1" } };
+      const req = {
+        user: { id: "user-1", email: "test@test.com", role: "user" as const },
+      };
 
-      const result = await controller.remove(req as any, "s-1");
+      const result = await controller.remove(req, "s-1");
 
       expect(mockSightingsService.remove).toHaveBeenCalledWith(
         "user-1",
@@ -69,9 +73,11 @@ describe("SightingsController", () => {
 
     it("ForbiddenException を伝播する", async () => {
       mockSightingsService.remove.mockRejectedValue(new ForbiddenException());
-      const req = { user: { userId: "user-1" } };
+      const req = {
+        user: { id: "user-1", email: "test@test.com", role: "user" as const },
+      };
 
-      await expect(controller.remove(req as any, "s-1")).rejects.toThrow(
+      await expect(controller.remove(req, "s-1")).rejects.toThrow(
         ForbiddenException
       );
     });
@@ -83,7 +89,9 @@ describe("SightingsController", () => {
       mockSightingsService.toggleFavorite.mockResolvedValue({
         favorited: true,
       });
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       const result = await controller.toggleFavorite(req as any, "s-1");
 
@@ -98,7 +106,9 @@ describe("SightingsController", () => {
       mockSightingsService.toggleFavorite.mockResolvedValue({
         favorited: false,
       });
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       const result = await controller.toggleFavorite(req as any, "s-1");
 
@@ -109,7 +119,9 @@ describe("SightingsController", () => {
       mockSightingsService.toggleFavorite.mockRejectedValue(
         new BadRequestException()
       );
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await expect(
         controller.toggleFavorite(req as any, "s-1")
@@ -120,7 +132,9 @@ describe("SightingsController", () => {
       mockSightingsService.toggleFavorite.mockRejectedValue(
         new NotFoundException()
       );
-      const req = { user: { id: "user1" } };
+      const req = {
+        user: { id: "user1", email: "test@test.com", role: "user" as const },
+      };
 
       await expect(
         controller.toggleFavorite(req as any, "s-1")

--- a/apps/api/src/sightings/sighting.controller.ts
+++ b/apps/api/src/sightings/sighting.controller.ts
@@ -21,6 +21,7 @@ import {
   ApiParam,
 } from "@nestjs/swagger";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { AuthenticatedRequest } from "../auth/interfaces/authenticated-request.interface";
 import {
   OPENAPI_POST_ID_EXAMPLE,
   OPENAPI_SIGHTING_ID_EXAMPLE,
@@ -51,9 +52,8 @@ export class SightingsController {
       },
     },
   })
-  create(@Request() req: any, @Body() dto: CreateSightingDto) {
-    const userId = req.user?.id ?? req.user?.userId;
-    return this.sightingsService.create(userId, dto);
+  create(@Request() req: AuthenticatedRequest, @Body() dto: CreateSightingDto) {
+    return this.sightingsService.create(req.user.id, dto);
   }
 
   @Get()
@@ -76,10 +76,12 @@ export class SightingsController {
   @ApiOperation({ summary: "目撃情報を削除する（本人または管理者）" })
   @ApiParam({ name: "id", example: OPENAPI_SIGHTING_ID_EXAMPLE })
   @ApiResponse({ status: 204 })
-  remove(@Request() req: any, @Param("id") id: string) {
-    const userId = req.user?.id ?? req.user?.userId;
-    const isAdmin = req.user?.role === "admin";
-    return this.sightingsService.remove(userId, id, isAdmin);
+  remove(@Request() req: AuthenticatedRequest, @Param("id") id: string) {
+    return this.sightingsService.remove(
+      req.user.id,
+      id,
+      req.user.role === "admin"
+    );
   }
 
   @Post(":id/favorite")
@@ -93,8 +95,10 @@ export class SightingsController {
   })
   @ApiResponse({ status: 400, description: "お気に入り上限超過" })
   @ApiResponse({ status: 404, description: "Sighting not found" })
-  async toggleFavorite(@Request() req: any, @Param("id") id: string) {
-    const userId = req.user?.id ?? req.user?.userId;
-    return this.sightingsService.toggleFavorite(userId, id);
+  async toggleFavorite(
+    @Request() req: AuthenticatedRequest,
+    @Param("id") id: string
+  ) {
+    return this.sightingsService.toggleFavorite(req.user.id, id);
   }
 }

--- a/apps/api/src/users/user.controller.spec.ts
+++ b/apps/api/src/users/user.controller.spec.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, ConflictException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ConflictException,
+  HttpException,
+  HttpStatus,
+} from "@nestjs/common";
 import { UsersController } from "./user.controller";
 import { RegisterDto } from "./dto/register.dto";
 
@@ -6,6 +11,7 @@ describe("UsersController", () => {
   let controller: UsersController;
   const mockUsersService = {
     createUser: jest.fn(),
+    deleteUser: jest.fn(),
   };
 
   beforeEach(() => {
@@ -83,5 +89,47 @@ describe("UsersController", () => {
       "password123",
       "Alice"
     );
+  });
+
+  // ─── remove ─────────────────────────────────────────────────
+  describe("remove", () => {
+    it("管理者がユーザーを削除できる", async () => {
+      const deleted = {
+        id: "user1",
+        nickname: "Alice",
+        role: "user",
+        createdAt: new Date(),
+      };
+      mockUsersService.deleteUser.mockResolvedValue(deleted);
+
+      const result = await controller.remove("user1");
+
+      expect(mockUsersService.deleteUser).toHaveBeenCalledWith("user1");
+      expect(result).toBe(deleted);
+    });
+
+    it("存在しないユーザーIDはP2025エラーを404に変換する", async () => {
+      mockUsersService.deleteUser.mockRejectedValue({ code: "P2025" });
+
+      await expect(controller.remove("nonexistent")).rejects.toThrow(
+        HttpException
+      );
+
+      try {
+        await controller.remove("nonexistent");
+      } catch (e) {
+        expect(e).toBeInstanceOf(HttpException);
+        expect((e as HttpException).getStatus()).toBe(HttpStatus.NOT_FOUND);
+        const body = (e as HttpException).getResponse() as { error: string };
+        expect(body.error).toBe("ユーザーが見つかりません");
+      }
+    });
+
+    it("P2025以外のエラーは再スローされる", async () => {
+      const dbError = new Error("DB接続エラー");
+      mockUsersService.deleteUser.mockRejectedValue(dbError);
+
+      await expect(controller.remove("user1")).rejects.toThrow(dbError);
+    });
   });
 });

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -24,7 +24,7 @@ export class UsersService {
     const emailEncrypted = encryptEmail(normalized);
 
     try {
-      const user = await (this.prisma.user as any).create({
+      const user = await this.prisma.user.create({
         data: {
           emailEncrypted,
           emailHash,
@@ -62,11 +62,11 @@ export class UsersService {
     const hmac = hmacEmail(normalized);
     const sha = sha256Hex(normalized);
     // Try HMAC first, fallback to SHA256 (transitional for existing rows)
-    let user = await (this.prisma.user as any).findUnique({
+    let user = await this.prisma.user.findUnique({
       where: { emailHash: hmac },
     });
     if (!user) {
-      user = await (this.prisma.user as any).findUnique({
+      user = await this.prisma.user.findUnique({
         where: { emailHash: sha },
       });
     }
@@ -82,7 +82,7 @@ export class UsersService {
   }
 
   async findById(id: string) {
-    const user = await (this.prisma.user as any).findUnique({ where: { id } });
+    const user = await this.prisma.user.findUnique({ where: { id } });
     if (!user) return null;
     let emailDec = null;
     try {
@@ -96,7 +96,7 @@ export class UsersService {
   // TanStack Start: export const getUsers = createServerFn(async () => db.user.findMany())
   // NestJS:  この1行が「サーバー関数の中身」に相当する
   async findAll() {
-    const users = await (this.prisma.user as any).findMany({
+    const users = await this.prisma.user.findMany({
       select: {
         id: true,
         emailEncrypted: true,

--- a/apps/web/tests/playwright/e2e.spec.ts
+++ b/apps/web/tests/playwright/e2e.spec.ts
@@ -93,7 +93,9 @@ test("basic E2E flow: register → login → create post → view posts", async 
   await page.waitForURL(`${baseUrl}/posts`);
 
   // 4. Verify post appears in list (pet name is shown as heading)
-  await expect(page.getByRole("heading", { name: "ミケ" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "ミケ" }).first()
+  ).toBeVisible();
 
   // 5. Logout from map page
   await page.goto(`${baseUrl}/`);

--- a/scripts/vps-backup.sh
+++ b/scripts/vps-backup.sh
@@ -12,10 +12,12 @@ RETAIN_DAYS="${RETAIN_DAYS:-7}"
 UPLOADS_ONLY="${UPLOADS_ONLY:-false}"
 DB_ONLY="${DB_ONLY:-false}"
 
-# 環境変数読み込み（DATABASE_URL）
-set -a
-[[ -f ~/finder-backend/apps/api/.env ]] && . ~/finder-backend/apps/api/.env
-set +a
+# 環境変数読み込み（DATABASE_URL のみ抽出）
+ENV_FILE=~/finder-backend/apps/api/.env
+if [[ -z "${DATABASE_URL:-}" ]] && [[ -f "$ENV_FILE" ]]; then
+  DATABASE_URL=$(grep '^DATABASE_URL=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+  export DATABASE_URL
+fi
 
 # オプション解析
 while [[ $# -gt 0 ]]; do

--- a/scripts/vps-health-check.sh
+++ b/scripts/vps-health-check.sh
@@ -59,7 +59,8 @@ done
 echo ""
 echo "🔄 [2/6] PM2 プロセス ($PM2_NAME)"
 if pm2 describe "$PM2_NAME" >/dev/null 2>&1; then
-  PM2_STATUS=$(pm2 jlist | python3 -c "import sys, json; d=json.load(sys.stdin); print(next((p['pm2_env']['status'] for p in d if p['name']=='$PM2_NAME'), 'unknown'))")
+  PM2_STATUS=$(pm2 describe "$PM2_NAME" 2>/dev/null | grep -E '^\s+status' | awk '{print $NF}' | head -1)
+  PM2_STATUS="${PM2_STATUS:-unknown}"
   if [[ "$PM2_STATUS" == "online" ]]; then
     echo "  $PM2_NAME  → OK ($PM2_STATUS)"
   else

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -279,11 +279,15 @@
 
 #### handleJoin
 
-- [x] 指定した会話ルームにjoinすること
+- [x] userIdがない場合は切断されjoinしない
+- [x] 会話参加権限がない場合は切断されjoinしない
+- [x] 会話が存在しない場合は切断されjoinしない
+- [x] 会話参加権限がある場合は指定した会話ルームにjoinすること
 
 #### handleLeave
 
-- [x] 指定した会話ルームからleaveすること
+- [x] userIdがない場合は切断されleaveしない
+- [x] userIdがある場合は指定した会話ルームからleaveすること
 
 #### broadcastMessage
 
@@ -355,6 +359,12 @@
 - [x] ConflictException はそのまま伝播する
 - [x] nickname があれば service に渡す
 - [x] nickname がなくても name を後方互換で使う
+
+#### remove
+
+- [x] 管理者がユーザーを削除できる
+- [x] 存在しないユーザーIDはP2025エラーを404に変換する
+- [x] P2025以外のエラーは再スローされる
 
 ### Dredd 契約テスト
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -168,9 +168,13 @@ apps/api/src/
 │   │   │   ├── 有効なトークンで接続した場合はsocket.data.userIdが設定される
 │   │   │   └── Authorizationヘッダー（Bearer形式）でも認証できる
 │   │   ├── handleJoin
-│   │   │   └── 指定した会話ルームにjoinすること
+│   │   │   ├── userIdがない場合は切断されjoinしない
+│   │   │   ├── 会話参加権限がない場合は切断されjoinしない
+│   │   │   ├── 会話が存在しない場合は切断されjoinしない
+│   │   │   └── 会話参加権限がある場合は指定した会話ルームにjoinすること
 │   │   ├── handleLeave
-│   │   │   └── 指定した会話ルームからleaveすること
+│   │   │   ├── userIdがない場合は切断されleaveしない
+│   │   │   └── userIdがある場合は指定した会話ルームからleaveすること
 │   │   └── broadcastMessage
 │   │       └── 最小化されたペイロードのみemitする（readAtを含まない）
 │   └── conversation.controller.spec.ts
@@ -216,7 +220,11 @@ apps/api/src/
     │       ├── nickname と name がないと BadRequestException を返す
     │       ├── ConflictException はそのまま伝播する
     │       ├── nickname があれば service に渡す
-    │       └── nickname がなくても name を後方互換で使う
+    │       ├── nickname がなくても name を後方互換で使う
+    │       └── remove
+    │           ├── 管理者がユーザーを削除できる
+    │           ├── 存在しないユーザーIDはP2025エラーを404に変換する
+    │           └── P2025以外のエラーは再スローされる
     ├── dto/
     │   └── register.dto.spec.ts
     │       └── RegisterDto


### PR DESCRIPTION
## Summary

- Prisma呼び出しの `(prisma.model as any)` を正規型に統一し、型安全性を向上
- `AuthenticatedRequest` インターフェースを `auth/interfaces/` に切り出し、各コントローラ・ゲートウェイで共用
- `ConversationsGateway` の `joinConversation` / `leaveConversation` に `userId` 認証チェックを追加（未認証クライアントを切断）
- E2Eテスト: `getByRole('heading')` の strict mode 違反を `.first()` で解消

## Test plan

- [x] `npm run test` — Jest 202件全パス（型チェック・lintも通過）
- [x] `npm run test:e2e` — Playwright 2件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)