### PR TITLE
feat: Post更新/画像追加にadmin権限チェック追加、Mapコンポーネント修正、AuthProviderの二重呼び出し防止

### DIFF
--- a/apps/api/src/posts/post.controller.spec.ts
+++ b/apps/api/src/posts/post.controller.spec.ts
@@ -191,9 +191,14 @@ describe("PostsController", () => {
         title: "New",
       } as any);
 
-      expect(mockPostsService.update).toHaveBeenCalledWith("post1", "user1", {
-        title: "New",
-      });
+      expect(mockPostsService.update).toHaveBeenCalledWith(
+        "post1",
+        "user1",
+        {
+          title: "New",
+        },
+        false
+      );
       expect(result).toEqual(updated);
     });
 
@@ -242,7 +247,8 @@ describe("PostsController", () => {
       expect(mockPostsService.update).toHaveBeenCalledWith(
         "post1",
         "user1",
-        dto
+        dto,
+        false
       );
       expect(result).toEqual(updated);
     });
@@ -268,7 +274,8 @@ describe("PostsController", () => {
       expect(mockPostsService.addImages).toHaveBeenCalledWith(
         "post1",
         "user1",
-        files
+        files,
+        false
       );
       expect(result).toEqual(response);
     });
@@ -287,7 +294,8 @@ describe("PostsController", () => {
       expect(mockPostsService.addImages).toHaveBeenCalledWith(
         "post1",
         "user1",
-        []
+        [],
+        false
       );
     });
 

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -160,7 +160,8 @@ export class PostsController {
     @Param("id") id: string,
     @Body() body: UpdatePostDto
   ) {
-    return this.posts.update(id, req.user.id, body);
+    const isAdmin = req.user?.role === "admin";
+    return this.posts.update(id, req.user.id, body, isAdmin);
   }
 
   @Delete(":id")
@@ -208,7 +209,8 @@ export class PostsController {
     @Param("id") id: string,
     @UploadedFiles() files: Express.Multer.File[]
   ) {
-    return this.posts.addImages(id, req.user.id, files ?? []);
+    const isAdmin = req.user?.role === "admin";
+    return this.posts.addImages(id, req.user.id, files ?? [], isAdmin);
   }
 
   @Delete(":id/images/:imageId")

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -263,14 +263,15 @@ export class PostsService {
   async addImages(
     postId: string,
     userId: string,
-    files: Express.Multer.File[]
+    files: Express.Multer.File[],
+    isAdmin = false
   ) {
     const post = await this.prisma.post.findUnique({
       where: { id: postId },
       include: { images: true },
     });
     if (!post) throw new NotFoundException("投稿が見つかりません");
-    if (post.userId !== userId)
+    if (post.userId !== userId && !isAdmin)
       throw new ForbiddenException("投稿のオーナーではありません");
 
     const user = await this.prisma.user.findUnique({
@@ -331,7 +332,12 @@ export class PostsService {
     return this.prisma.image.delete({ where: { id: imageId } });
   }
 
-  async update(id: string, userId: string, dto: UpdatePostDto) {
+  async update(
+    id: string,
+    userId: string,
+    dto: UpdatePostDto,
+    isAdmin = false
+  ) {
     const post = await this.prisma.post.findUnique({
       where: { id },
       include: { petDetail: true, location: true },
@@ -339,7 +345,7 @@ export class PostsService {
     if (!post) {
       throw new HttpException("投稿が見つかりません", HttpStatus.NOT_FOUND);
     }
-    if (post.userId !== userId) {
+    if (post.userId !== userId && !isAdmin) {
       throw new ForbiddenException("投稿のオーナーではありません");
     }
 

--- a/apps/web/src/auth/AuthProvider.tsx
+++ b/apps/web/src/auth/AuthProvider.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate } from "react-router-dom";
 import { authControllerRefresh } from "../../../../packages/api-client/src/index";
 
@@ -30,8 +36,11 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
   const [token, setTokenState] = useState<string | null>(null);
   const [isRestoring, setIsRestoring] = useState(true);
   const navigate = useNavigate();
+  const refreshCalledRef = useRef(false);
 
   useEffect(() => {
+    if (refreshCalledRef.current) return;
+    refreshCalledRef.current = true;
     authControllerRefresh()
       .then((res) => {
         const t =

--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -24,9 +24,33 @@ const { mockReverseGeocode } = vi.hoisted(() => ({
     >(),
 }));
 let triggerMapClick: ((lat: number, lng: number) => void) | null = null;
+let mapClickHandler:
+  | ((e: { latlng: { lat: number; lng: number } }) => void)
+  | null = null;
 const mockMapInstance = {
   flyTo: mockFlyTo,
   dragging: { enable: vi.fn(), disable: vi.fn() },
+  on: vi.fn(
+    (
+      _event: string,
+      handler: (e: { latlng: { lat: number; lng: number } }) => void
+    ) => {
+      mapClickHandler = handler;
+      triggerMapClick = (lat: number, lng: number) =>
+        handler({ latlng: { lat, lng } });
+    }
+  ),
+  off: vi.fn(
+    (
+      _event: string,
+      handler: (e: { latlng: { lat: number; lng: number } }) => void
+    ) => {
+      if (mapClickHandler === handler) {
+        mapClickHandler = null;
+        triggerMapClick = null;
+      }
+    }
+  ),
 };
 const mockAuth = { userId: null as string | null };
 
@@ -36,15 +60,6 @@ vi.mock("react-leaflet", () => ({
   ),
   TileLayer: () => <div data-testid="tile-layer" />,
   useMap: () => mockMapInstance,
-  useMapEvents: (handlers: {
-    click?: (e: { latlng: { lat: number; lng: number } }) => void;
-  }) => {
-    if (handlers.click) {
-      triggerMapClick = (lat: number, lng: number) =>
-        handlers.click?.({ latlng: { lat, lng } });
-    }
-    return mockMapInstance;
-  },
   Marker: ({
     children,
     title,
@@ -161,6 +176,7 @@ describe("Map", () => {
     mockReverseGeocode.mockReset();
     mockReverseGeocode.mockResolvedValue({ address: "埼玉県さいたま市" });
     triggerMapClick = null;
+    mapClickHandler = null;
     mockGetMapMarkers.mockResolvedValue([]);
     mockGetPost.mockResolvedValue(samplePost);
     mockCreateSighting.mockResolvedValue(undefined);
@@ -195,7 +211,9 @@ describe("Map", () => {
 
       await user.click(screen.getByRole("button", { name: "アカウント" }));
 
-      expect(screen.queryByText("ログアウトしますか？")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("ログアウトしますか？")
+      ).not.toBeInTheDocument();
       expect(mockLogout).not.toHaveBeenCalled();
       expect(mockClearToken).not.toHaveBeenCalled();
     });
@@ -208,8 +226,12 @@ describe("Map", () => {
 
       await user.click(screen.getByRole("button", { name: "アカウント" }));
 
-      expect(await screen.findByText("ログアウトしますか？")).toBeInTheDocument();
-      expect(screen.getByText("ログイン状態を解除します。")).toBeInTheDocument();
+      expect(
+        await screen.findByText("ログアウトしますか？")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("ログイン状態を解除します。")
+      ).toBeInTheDocument();
     });
 
     it("ダイアログでキャンセル押下時、ログアウト処理が実行されないこと", async () => {

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  MapContainer,
-  Marker,
-  TileLayer,
-  useMap,
-  useMapEvents,
-} from "react-leaflet";
+import { MapContainer, Marker, TileLayer, useMap } from "react-leaflet";
 import { useNavigate } from "react-router-dom";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
@@ -439,7 +433,6 @@ export default function Map() {
 
       <SightingModal
         isOpen={sightingModalOpen}
-        forceMount={pickingLocation ? true : undefined}
         onClose={() => {
           setSightingModalOpen(false);
           setSightingPostId(null);
@@ -448,6 +441,7 @@ export default function Map() {
         pickedLocation={pickedLocation}
         onSelectFromMap={() => {
           setSightingModalOpen(false);
+          setSelectedMarker(null);
           setPickingLocation(true);
           setPickedLocation(null);
         }}
@@ -556,10 +550,20 @@ function MapClickHandler({
   enabled: boolean;
   onClick: (lat: number, lng: number) => void;
 }) {
-  useMapEvents({
-    click(e: LeafletMouseEvent) {
-      if (enabled) onClick(e.latlng.lat, e.latlng.lng);
-    },
-  });
+  const map = useMap();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (e: LeafletMouseEvent) => {
+      onClick(e.latlng.lat, e.latlng.lng);
+    };
+
+    map.on("click", handler);
+    return () => {
+      map.off("click", handler);
+    };
+  }, [enabled, onClick, map]);
+
   return null;
 }

--- a/apps/web/src/styles/map.css
+++ b/apps/web/src/styles/map.css
@@ -208,6 +208,21 @@
   cursor: progress;
 }
 
+.map-picking-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1400;
+  padding: 10px 16px;
+  background: rgba(26, 115, 232, 0.96);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.2);
+}
+
 .map-current-location-button__icon {
   width: 19px;
   height: 19px;


### PR DESCRIPTION
## 概要

以下の修正を含みます。

### API (apps/api)
- POST /posts/:id (update) に admin 権限チェックを追加
- POST /posts/:id/images (addImages) に admin 権限チェックを追加
- 管理者は他ユーザーの投稿も編集・画像追加可能に

### Web (apps/web)
- **Map**: useMapEvents を useMap + useEffect に置き換え（React Leaflet v4 互換性対応）
- **Map**: .map-picking-banner CSS 追加、選択中バナーの表示に対応
- **AuthProvider**: useRef で refresh トークンの二重呼び出し防止（StrictMode 対応）

## 変更ファイル一覧
| ファイル | 変更内容 |
|---|---|
| apps/api/src/posts/post.controller.ts | update/addImages に isAdmin 引数追加 |
| apps/api/src/posts/post.service.ts | update/addImages に admin bypass 追加 |
| apps/api/src/posts/post.controller.spec.ts | テストに isAdmin引数追加 |
| apps/web/src/pages/Map.tsx | useMapEvents→useMap+useEffect 置き換え |
| apps/web/src/pages/Map.test.tsx | テストを新実装に合わせて修正 |
| apps/web/src/styles/map.css | .map-picking-banner 追加 |
| apps/web/src/auth/AuthProvider.tsx | useRef で refresh 二重呼び出し防止 |