### PR TITLE
chore: コードレビュー指摘対応（全7項目）

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -3,7 +3,10 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nestjs_dev"
 
 # JWT
 JWT_SECRET="change-me-in-production"
-JWT_REFRESH_SECRET="change-me-refresh-in-production"
+
+# Encryption (32 bytes base64/hex/utf8)
+ENCRYPTION_KEY="change-me-to-32-byte-base64-string"
+HMAC_SECRET="change-me-hmac-in-production"
 
 # App
 NODE_ENV="development"

--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -26,6 +26,7 @@ module.exports = [
   },
   {
     files: [path.join(apiDir, "src/**/*.ts").replace(/\\/g, "/")],
+    ignores: ["**/*.spec.ts"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -41,6 +42,23 @@ module.exports = [
       "@typescript-eslint/interface-name-prefix": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
+  {
+    files: [path.join(apiDir, "src/**/*.spec.ts").replace(/\\/g, "/")],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: path.join(apiDir, "tsconfig.json"),
+        tsconfigRootDir: apiDir,
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": typescriptEslint,
+    },
+    rules: {
       "@typescript-eslint/no-explicit-any": "off",
     },
   },

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
-import { PrismaService } from "./prisma.service";
+import { PrismaModule } from "./prisma.module";
 import { IdentityModule } from "./identity/identity.module";
 import { PostsModule } from "./posts/post.module";
 import { MapModule } from "./map/map.module";
@@ -10,12 +10,12 @@ import { ConversationsModule } from "./conversations/conversation.module";
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    PrismaModule,
     IdentityModule,
     PostsModule,
     MapModule,
     SightingsModule,
     ConversationsModule,
   ],
-  providers: [PrismaService],
 })
 export class AppModule {}

--- a/apps/api/src/common/openapi-document.ts
+++ b/apps/api/src/common/openapi-document.ts
@@ -1,19 +1,35 @@
-export function applyParameterExamples(document: any) {
-  for (const pathItem of Object.values(document.paths ?? {})) {
+interface OpenApiOperation {
+  parameters?: unknown;
+}
+
+interface OpenApiParameter {
+  example?: unknown;
+  schema?: {
+    example?: unknown;
+    default?: unknown;
+  };
+}
+
+export function applyParameterExamples(document: object) {
+  const doc = document as { paths?: Record<string, Record<string, object>> };
+  const paths = doc.paths;
+  for (const pathItem of Object.values(paths ?? {})) {
     if (!pathItem || typeof pathItem !== "object") {
       continue;
     }
 
-    for (const operation of Object.values(pathItem as Record<string, any>)) {
+    for (const operation of Object.values(pathItem)) {
       if (!operation || typeof operation !== "object") {
         continue;
       }
 
-      if (!Array.isArray(operation.parameters)) {
+      const op = operation as OpenApiOperation;
+      if (!Array.isArray(op.parameters)) {
         continue;
       }
 
-      for (const parameter of operation.parameters) {
+      for (const item of op.parameters) {
+        const parameter = item as OpenApiParameter;
         if (!parameter || typeof parameter !== "object") {
           continue;
         }

--- a/apps/api/src/conversations/conversation.module.ts
+++ b/apps/api/src/conversations/conversation.module.ts
@@ -1,7 +1,6 @@
 import { Module } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { JwtModule } from "@nestjs/jwt";
-import { PrismaService } from "../prisma.service";
 import { ConversationsController } from "./conversation.controller";
 import { ConversationsService } from "./conversation.service";
 import { ConversationsGateway } from "./conversations.gateway";
@@ -18,6 +17,6 @@ import { IdentityModule } from "../identity/identity.module";
     }),
   ],
   controllers: [ConversationsController],
-  providers: [ConversationsService, ConversationsGateway, PrismaService],
+  providers: [ConversationsService, ConversationsGateway],
 })
 export class ConversationsModule {}

--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -26,7 +26,6 @@ describe("ConversationsService", () => {
   let service: ConversationsService;
 
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     service = new ConversationsService(mockPrisma as any);
     jest.clearAllMocks();
   });

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -24,7 +24,9 @@ export class ConversationsService {
     });
     if (!sighting) throw new NotFoundException("目撃情報が見つかりません");
     if (sighting.postId == null || sighting.postId !== dto.postId) {
-      throw new NotFoundException("目撃情報が見つかりません");
+      throw new NotFoundException(
+        "指定された投稿に紐づく目撃情報ではありません"
+      );
     }
 
     if (post.userId !== userId && sighting.userId !== userId) {

--- a/apps/api/src/conversations/conversations.gateway.ts
+++ b/apps/api/src/conversations/conversations.gateway.ts
@@ -23,6 +23,9 @@ export class ConversationsGateway
   @WebSocketServer()
   server: Server;
 
+  // userId → socketId の1対1マッピング。
+  // 同一ユーザーが複数タブ/ブラウザで接続した場合は後勝ちとなる。
+  // 意図的な単一接続制約であり、複数接続が必要な場合は Map<string, Set<string>> に変更する。
   private readonly userSocketMap = new Map<string, string>();
 
   constructor(

--- a/apps/api/src/identity/identity.module.ts
+++ b/apps/api/src/identity/identity.module.ts
@@ -9,7 +9,6 @@ import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { RolesGuard } from "../auth/roles.guard";
 import { AuthController } from "../auth/auth.controller";
 import { UsersController } from "../users/user.controller";
-import { PrismaService } from "../prisma.service";
 
 @Module({
   imports: [
@@ -25,7 +24,6 @@ import { PrismaService } from "../prisma.service";
   ],
   controllers: [AuthController, UsersController],
   providers: [
-    PrismaService,
     CryptoService,
     { provide: IIdentityService, useClass: IdentityService },
     JwtStrategy,

--- a/apps/api/src/map/map.module.ts
+++ b/apps/api/src/map/map.module.ts
@@ -1,10 +1,9 @@
 import { Module } from "@nestjs/common";
-import { PrismaService } from "../prisma.service";
 import { MapController } from "./map.controller";
 import { MapService } from "./map.service";
 
 @Module({
   controllers: [MapController],
-  providers: [MapService, PrismaService],
+  providers: [MapService],
 })
 export class MapModule {}

--- a/apps/api/src/map/map.service.spec.ts
+++ b/apps/api/src/map/map.service.spec.ts
@@ -13,7 +13,6 @@ describe("MapService", () => {
   let service: MapService;
 
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     service = new MapService(mockPrisma as any);
     jest.clearAllMocks();
   });

--- a/apps/api/src/posts/post.controller.spec.ts
+++ b/apps/api/src/posts/post.controller.spec.ts
@@ -417,20 +417,24 @@ describe("PostsController", () => {
   describe("imageFileFilter", () => {
     it("fileがnullの時、cb(null, false)を呼ぶこと", () => {
       const cb = jest.fn();
-      imageFileFilter({}, null, cb);
+      imageFileFilter({} as Express.Request, null, cb);
       expect(cb).toHaveBeenCalledWith(null, false);
     });
 
     it("originalnameがない時、cb(null, false)を呼ぶこと", () => {
       const cb = jest.fn();
-      imageFileFilter({}, { mimetype: "image/png" } as any, cb);
+      imageFileFilter(
+        {} as Express.Request,
+        { mimetype: "image/png" } as any,
+        cb
+      );
       expect(cb).toHaveBeenCalledWith(null, false);
     });
 
     it("許可されたMIMEタイプの時、cb(null, true)を呼ぶこと", () => {
       const cb = jest.fn();
       imageFileFilter(
-        {},
+        {} as Express.Request,
         { originalname: "photo.png", mimetype: "image/png" } as any,
         cb
       );
@@ -440,7 +444,7 @@ describe("PostsController", () => {
     it("許可されていないMIMEタイプの時、BadRequestExceptionを渡すこと", () => {
       const cb = jest.fn();
       imageFileFilter(
-        {},
+        {} as Express.Request,
         { originalname: "doc.pdf", mimetype: "application/pdf" } as any,
         cb
       );

--- a/apps/api/src/posts/post.controller.ts
+++ b/apps/api/src/posts/post.controller.ts
@@ -50,7 +50,11 @@ const ALLOWED_MIME_TYPES = [
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const MAX_IMAGES_PER_POST = PLAN_LIMITS[Plan.premium].imageUploadLimit;
 
-export function imageFileFilter(_req: any, file: Express.Multer.File, cb: any) {
+export function imageFileFilter(
+  _req: Express.Request,
+  file: Express.Multer.File,
+  cb: (error: Error | null, acceptFile: boolean) => void
+) {
   if (!file || !file.originalname || !file.mimetype) {
     return cb(null, false);
   }
@@ -138,8 +142,8 @@ export class PostsController {
   @Get()
   @ApiResponse({ status: 200, type: PostListResponseDto })
   async list(@Query("page") page = "1", @Query("perPage") perPage = "10") {
-    const p = parseInt(page as any, 10) || 1;
-    const pp = parseInt(perPage as any, 10) || 10;
+    const p = parseInt(page, 10) || 1;
+    const pp = parseInt(perPage, 10) || 10;
     return this.posts.findAll(p, pp);
   }
 

--- a/apps/api/src/posts/post.module.ts
+++ b/apps/api/src/posts/post.module.ts
@@ -1,12 +1,11 @@
 import { Module } from "@nestjs/common";
 import { PostsService } from "./post.service";
 import { PostsController } from "./post.controller";
-import { PrismaService } from "../prisma.service";
 import { IdentityModule } from "../identity/identity.module";
 
 @Module({
   imports: [IdentityModule],
-  providers: [PostsService, PrismaService],
+  providers: [PostsService],
   controllers: [PostsController],
 })
 export class PostsModule {}

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -735,7 +735,7 @@ describe("PostsService", () => {
         lostDate: "2026-04-21",
       });
 
-      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(3);
       expect(mockPrisma.$transaction).toHaveBeenCalledWith(
         expect.any(Function),
         expect.objectContaining({

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -97,134 +97,153 @@ export class PostsService {
     }
     const lostDate = new Date(dto.lostDate);
 
+    // Phase 1: Create post + relations in transaction (retry on Serializable conflict)
+    let createdPost: { id: string };
     for (let attempt = 0; attempt < MAX_TRANSACTION_RETRIES; attempt += 1) {
-      const savedUrls: string[] = [];
-
       try {
-        return await this.prisma
-          .$transaction(
-            async (tx) => {
-              const user = await tx.user.findUnique({
-                where: { id: userId },
-                select: { plan: true },
-              });
+        createdPost = await this.prisma.$transaction(
+          async (tx) => {
+            const user = await tx.user.findUnique({
+              where: { id: userId },
+              select: { plan: true },
+            });
 
-              if (!user) {
-                throw new NotFoundException("ユーザーが見つかりません");
-              }
+            if (!user) {
+              throw new NotFoundException("ユーザーが見つかりません");
+            }
 
-              const imageUploadLimit = getImageUploadLimit(user.plan);
-              if (files.length > imageUploadLimit) {
-                throw new ForbiddenException(
-                  `このプランでは画像は最大${imageUploadLimit}枚までです`
-                );
-              }
+            const imageUploadLimit = getImageUploadLimit(user.plan);
+            if (files.length > imageUploadLimit) {
+              throw new ForbiddenException(
+                `このプランでは画像は最大${imageUploadLimit}枚までです`
+              );
+            }
 
-              const monthlyPostLimit = getMonthlyPostLimit(user.plan);
-              if (monthlyPostLimit !== null) {
-                const { start, end } = getMonthRange();
-                const postCount = await tx.post.count({
-                  where: {
-                    userId,
-                    createdAt: {
-                      gte: start,
-                      lt: end,
-                    },
-                  },
-                });
-
-                if (postCount >= monthlyPostLimit) {
-                  throw new ForbiddenException(
-                    "無料プランの月間投稿数上限に達しています"
-                  );
-                }
-              }
-
-              const post = await tx.post.create({
-                data: {
-                  title: dto.title,
-                  description: dto.description,
+            const monthlyPostLimit = getMonthlyPostLimit(user.plan);
+            if (monthlyPostLimit !== null) {
+              const { start, end } = getMonthRange();
+              const postCount = await tx.post.count({
+                where: {
                   userId,
-                  postType: dto.postType ?? PostType.cat,
-                  lostDate,
+                  createdAt: {
+                    gte: start,
+                    lt: end,
+                  },
                 },
               });
 
-              if (dto.petDetail) {
-                const pd = dto.petDetail;
-                await tx.petDetail.create({
-                  data: {
-                    postId: post.id,
-                    name: pd.name,
-                    color: pd.color,
-                    age: pd.age,
-                    features: pd.features,
-                    ...(pd.gender !== undefined && {
-                      gender: pd.gender as Gender,
-                    }),
-                    ...(pd.breed !== undefined && { breed: pd.breed }),
-                    ...(pd.size !== undefined && { size: pd.size }),
-                    ...(pd.collar !== undefined && { collar: pd.collar }),
-                    ...(pd.microchip !== undefined && {
-                      microchip: pd.microchip,
-                    }),
-                    ...(pd.neutered !== undefined && { neutered: pd.neutered }),
-                  },
-                });
+              if (postCount >= monthlyPostLimit) {
+                throw new ForbiddenException(
+                  "無料プランの月間投稿数上限に達しています"
+                );
               }
-
-              if (dto.location) {
-                const loc = dto.location;
-                await tx.location.create({
-                  data: {
-                    postId: post.id,
-                    prefecture: loc.prefecture as Prefecture,
-                    city: loc.city,
-                    address: loc.address,
-                    lat: loc.lat,
-                    lng: loc.lng,
-                  },
-                });
-              }
-
-              for (const file of files) {
-                const url = await this.saveFile(post.id, file);
-                savedUrls.push(url);
-                await tx.image.create({ data: { postId: post.id, url } });
-              }
-
-              return tx.post.findUnique({
-                where: { id: post.id },
-                include: { petDetail: true, location: true, images: true },
-              });
-            },
-            {
-              isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
             }
-          )
-          .then((result) => ({
-            ...result!,
-            images: (result!.images ?? []).map((img) => ({
-              ...img,
-              url: this.prefixImageUrl(img.url),
-            })),
-          }));
-      } catch (e) {
-        for (const url of savedUrls) {
-          try {
-            this.deleteFile(url);
-          } catch {}
-        }
 
+            const post = await tx.post.create({
+              data: {
+                title: dto.title,
+                description: dto.description,
+                userId,
+                postType: dto.postType ?? PostType.cat,
+                lostDate,
+              },
+            });
+
+            if (dto.petDetail) {
+              const pd = dto.petDetail;
+              await tx.petDetail.create({
+                data: {
+                  postId: post.id,
+                  name: pd.name,
+                  color: pd.color,
+                  age: pd.age,
+                  features: pd.features,
+                  ...(pd.gender !== undefined && {
+                    gender: pd.gender as Gender,
+                  }),
+                  ...(pd.breed !== undefined && { breed: pd.breed }),
+                  ...(pd.size !== undefined && { size: pd.size }),
+                  ...(pd.collar !== undefined && { collar: pd.collar }),
+                  ...(pd.microchip !== undefined && {
+                    microchip: pd.microchip,
+                  }),
+                  ...(pd.neutered !== undefined && { neutered: pd.neutered }),
+                },
+              });
+            }
+
+            if (dto.location) {
+              const loc = dto.location;
+              await tx.location.create({
+                data: {
+                  postId: post.id,
+                  prefecture: loc.prefecture as Prefecture,
+                  city: loc.city,
+                  address: loc.address,
+                  lat: loc.lat,
+                  lng: loc.lng,
+                },
+              });
+            }
+
+            return { id: post.id };
+          },
+          {
+            isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+          }
+        );
+        break;
+      } catch (e) {
         if (isTransactionConflict(e) && attempt < MAX_TRANSACTION_RETRIES - 1) {
           continue;
         }
-
         throw e;
       }
     }
 
-    throw new Error("投稿作成の再試行に失敗しました");
+    if (!createdPost!) {
+      throw new Error("投稿作成の再試行に失敗しました");
+    }
+
+    // Phase 2: Save files and create image records (outside transaction)
+    const savedUrls: string[] = [];
+    try {
+      for (const file of files) {
+        const url = await this.saveFile(createdPost.id, file);
+        savedUrls.push(url);
+      }
+
+      const newImages = await this.prisma.$transaction(async (tx) => {
+        return Promise.all(
+          savedUrls.map((url) =>
+            tx.image.create({ data: { postId: createdPost.id, url } })
+          )
+        );
+      });
+
+      const fullPost = await this.prisma.post.findUnique({
+        where: { id: createdPost.id },
+        include: { petDetail: true, location: true, images: true },
+      });
+
+      return {
+        ...fullPost!,
+        images: (fullPost!.images ?? []).map((img) => ({
+          ...img,
+          url: this.prefixImageUrl(img.url),
+        })),
+      };
+    } catch (e) {
+      for (const url of savedUrls) {
+        try {
+          this.deleteFile(url);
+        } catch {}
+      }
+      try {
+        await this.prisma.post.delete({ where: { id: createdPost.id } });
+      } catch {}
+      throw e;
+    }
   }
 
   async findAll(page = 1, perPage = 10) {

--- a/apps/api/src/prisma.module.ts
+++ b/apps/api/src/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from "@nestjs/common";
+import { PrismaService } from "./prisma.service";
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/apps/api/src/sightings/dto/create-sighting.dto.ts
+++ b/apps/api/src/sightings/dto/create-sighting.dto.ts
@@ -19,6 +19,7 @@ export class CreateSightingDto {
   @ApiProperty({ required: false, example: "Saitama City, Urawa-ku" })
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   address?: string;
   @ApiProperty({ example: "2024-01-02T00:00:00.000Z" })
   @IsDateString()
@@ -26,5 +27,6 @@ export class CreateSightingDto {
   @ApiProperty({ required: false, example: "Seed sighting" })
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   comment?: string;
 }

--- a/apps/api/src/sightings/sighting.module.ts
+++ b/apps/api/src/sightings/sighting.module.ts
@@ -1,10 +1,9 @@
 import { Module } from "@nestjs/common";
-import { PrismaService } from "../prisma.service";
 import { SightingsController } from "./sighting.controller";
 import { SightingsService } from "./sighting.service";
 
 @Module({
   controllers: [SightingsController],
-  providers: [SightingsService, PrismaService],
+  providers: [SightingsService],
 })
 export class SightingsModule {}

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -26,7 +26,6 @@ describe("SightingsService", () => {
   let service: SightingsService;
 
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     service = new SightingsService(mockPrisma as any);
     jest.clearAllMocks();
     mockPrisma.$transaction.mockImplementation(

--- a/apps/api/src/users/user.controller.ts
+++ b/apps/api/src/users/user.controller.ts
@@ -56,8 +56,9 @@ export class UsersController {
   async remove(@Param("id") id: string) {
     try {
       return await this.identity.deleteUser(id);
-    } catch (e: any) {
-      if (e?.code === "P2025") {
+    } catch (e: unknown) {
+      const err = e as { code?: string };
+      if (err?.code === "P2025") {
         throw new HttpException(
           { error: "ユーザーが見つかりません" },
           HttpStatus.NOT_FOUND
@@ -114,7 +115,7 @@ export class UsersController {
         nickname: user.nickname,
         createdAt: user.createdAt,
       };
-    } catch (e: any) {
+    } catch (e: unknown) {
       if (e instanceof HttpException) {
         throw e;
       }


### PR DESCRIPTION
## Summary

コードレビュー(2026-04-29)の指摘対応。全7項目を修正。

### 変更内容

| # | 項目 | 重要度 | 変更 |
|---|------|--------|------|
| 1 | `.env.example` 環境変数追加 | 高 | `ENCRYPTION_KEY`/`HMAC_SECRET` 追加、未使用 `JWT_REFRESH_SECRET` 削除 |
| 2 | `PrismaService` 重複解消 | 高 | `PrismaModule` (`@Global()`) を作成し6モジュールから重複 provider を削除 |
| 3 | `any` 禁止 lint 統一 | 高 | `no-explicit-any` → `error`、ソースコードの `any` 使用箇所6件を修正 |
| 4 | `CreateSightingDto` 検証強化 | 中 | `address`/`comment` に `@IsNotEmpty()` 追加 |
| 5 | エラーメッセージ区別化 | 低 | 2つ目の `NotFoundException` を「指定された投稿に紐づく目撃情報ではありません」に変更 |
| 6 | `saveFile` トランザクション外へ | 中 | `create()` を2フェーズに分離し、ファイル保存を Serializable トランザクション外に移動 |
| 7 | `userSocketMap` ドキュメント化 | 中 | 単一接続制約が意図的であることをコメント明記 |

### 検証結果

- lint: 0 errors
- typecheck (api/web): 0 errors
- test: 206 passed