### PR TITLE
fix: seedスクリプトで欠落していた utils/crypto モジュールを追加

### DIFF
--- a/apps/api/src/utils/crypto.ts
+++ b/apps/api/src/utils/crypto.ts
@@ -1,0 +1,44 @@
+import * as crypto from "crypto";
+
+export function normalizeEmail(email: string): string {
+  return email.toLowerCase().trim();
+}
+
+function deriveEncryptionKey(): Buffer {
+  const raw = process.env.ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error("ENCRYPTION_KEY is not set");
+  }
+  let buf = Buffer.from(raw, "base64");
+  if (buf.length === 32) return buf;
+  buf = Buffer.from(raw, "hex");
+  if (buf.length === 32) return buf;
+  buf = Buffer.from(raw, "utf8");
+  if (buf.length >= 32) return buf.slice(0, 32);
+  throw new Error("ENCRYPTION_KEY must decode to 32 bytes (base64/hex/utf8)");
+}
+
+export function encryptEmail(plain: string): string {
+  const key = deriveEncryptionKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const enc = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString("base64")}:${enc.toString("base64")}:${tag.toString("base64")}`;
+}
+
+export function hmacEmail(normalized: string): string {
+  const secret = process.env.HMAC_SECRET;
+  if (!secret) {
+    throw new Error("HMAC_SECRET is not set");
+  }
+  return crypto.createHmac("sha256", secret).update(normalized).digest("hex");
+}
+
+export function sha256Hex(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+export function generateSecureToken(): string {
+  return crypto.randomBytes(48).toString("hex");
+}


### PR DESCRIPTION
## 概要

CI の Schemathesis ジョブで seed 実行時に `Cannot find module '../src/utils/crypto'` エラーが発生していた問題を修正。

## 原因

`CryptoService` (`src/identity/crypto.service.ts`) へのリファクタリング時に、seed スクリプト (`prisma/seed.ts`, `prisma/seed-clean.ts`) の参照先モジュールが作成されていなかった。

## 対応

- `apps/api/src/utils/crypto.ts` を新規作成
- `normalizeEmail`, `encryptEmail`, `hmacEmail`, `sha256Hex`, `generateSecureToken` をスタンドアロン関数として実装
- `ENCRYPTION_KEY` / `HMAC_SECRET` は `process.env` から読み取り

## 確認

- 全テスト 206件 パス
- 型チェック パス