### PR TITLE
fix: 初回接続時に切断バナーが誤表示される問題を修正

### DIFF
--- a/apps/web/src/lib/conversationSocket.ts
+++ b/apps/web/src/lib/conversationSocket.ts
@@ -1,5 +1,14 @@
 import { io, type Socket } from "socket.io-client";
 
 export function createConversationSocket(token: string): Socket {
-  return io("/conversations", { auth: { token } });
+  return io("/conversations", {
+    auth: { token },
+    transports: ["websocket", "polling"],
+    upgrade: false,
+    reconnection: true,
+    reconnectionAttempts: Infinity,
+    reconnectionDelay: 1000,
+    reconnectionDelayMax: 10000,
+    timeout: 20000,
+  });
 }

--- a/apps/web/src/pages/ConversationChat.test.tsx
+++ b/apps/web/src/pages/ConversationChat.test.tsx
@@ -289,6 +289,10 @@ describe("ConversationChat", () => {
 
       render(<ConversationChat />);
 
+      act(() => {
+        listeners["connect"]?.();
+      });
+
       expect(mockSocketEmit).toHaveBeenCalledWith("joinConversation", "conv-1");
     });
 
@@ -315,6 +319,9 @@ describe("ConversationChat", () => {
       render(<ConversationChat />);
 
       act(() => {
+        listeners["connect"]?.();
+      });
+      act(() => {
         listeners["disconnect"]?.();
       });
 
@@ -328,6 +335,9 @@ describe("ConversationChat", () => {
 
       render(<ConversationChat />);
 
+      act(() => {
+        listeners["connect"]?.();
+      });
       act(() => {
         listeners["disconnect"]?.();
       });
@@ -347,6 +357,9 @@ describe("ConversationChat", () => {
       render(<ConversationChat />);
 
       act(() => {
+        listeners["connect"]?.();
+      });
+      act(() => {
         listeners["disconnect"]?.();
       });
       act(() => {
@@ -361,6 +374,9 @@ describe("ConversationChat", () => {
 
       render(<ConversationChat />);
 
+      act(() => {
+        listeners["connect"]?.();
+      });
       act(() => {
         listeners["connect_error"]?.();
       });

--- a/apps/web/src/pages/ConversationChat.tsx
+++ b/apps/web/src/pages/ConversationChat.tsx
@@ -56,32 +56,38 @@ export default function ConversationChat() {
 
     client.markAsRead(id);
 
-    let isFirstConnect = true;
+    let wasConnected = false;
     const socket = createConversationSocket(token);
-    socket.emit("joinConversation", id);
 
     socket.on("newMessage", (msg: MessageResponseDto) => {
       setMessages((prev) => [...prev, msg]);
     });
 
-    socket.on("disconnect", () => {
-      setSocketDisconnected(true);
+    socket.on("disconnect", (reason) => {
+      if (reason === "io client disconnect") return;
+      if (wasConnected) {
+        setSocketDisconnected(true);
+      }
     });
 
     socket.on("connect", () => {
+      wasConnected = true;
       setSocketDisconnected(false);
       socket.emit("joinConversation", id);
-      if (!isFirstConnect) {
-        fetchMessagesRef.current?.();
-      }
-      isFirstConnect = false;
+      fetchMessagesRef.current?.();
     });
 
     socket.on("connect_error", () => {
-      setSocketDisconnected(true);
+      if (wasConnected) {
+        setSocketDisconnected(true);
+      }
     });
 
     return () => {
+      socket.off("newMessage");
+      socket.off("disconnect");
+      socket.off("connect");
+      socket.off("connect_error");
       socket.disconnect();
     };
   }, [id, token]);


### PR DESCRIPTION
## 概要

モバイル端末で会話画面を開いた際、初回接続前から「接続が切れました。再接続中…」の切断バナーが表示される問題を修正。

## 原因

1. 初回接続確立前に `connect_error` イベントが発火すると即座に切断バナーが表示されていた
2. `socket.emit("joinConversation")` がリスナー登録前に呼ばれており、タイミング依存の再接続ループを誘発しうる状態だった
3. クリーンアップ時の `socket.disconnect()` でも切断バナーが表示されていた

## 修正内容

### `apps/web/src/pages/ConversationChat.tsx`
- `wasConnected` フラグ導入：初回接続確立前は切断バナーを一切表示しない
- `disconnect` イベントで `reason === "io client disconnect"` の場合はバナー非表示
- 初回 `socket.emit("joinConversation")` を削除し、`connect` ハンドラ内に統一

### `apps/web/src/lib/conversationSocket.ts`
- `transports: ["websocket", "polling"]` で WebSocket 優先
- `upgrade: false` でポーリング→WebSocket アップグレード時の再接続イベントを抑制
- `reconnectionDelay: 1000`, `timeout: 20000` で再接続安定化