### PR TITLE
fix: pg_dump の接続エラーを修正（DATABASE_URL の引用符除去 + --dbname フラグ追加）

### DIFF
--- a/scripts/vps-backup.sh
+++ b/scripts/vps-backup.sh
@@ -17,7 +17,7 @@ DB_ONLY="${DB_ONLY:-false}"
 # 環境変数読み込み（DATABASE_URL のみ抽出）
 ENV_FILE="$PROJECT_DIR/apps/api/.env"
 if [[ -z "${DATABASE_URL:-}" ]] && [[ -f "$ENV_FILE" ]]; then
-  DATABASE_URL=$(grep '^DATABASE_URL=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+  DATABASE_URL=$(grep '^DATABASE_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed -e 's/^["'\'']//' -e 's/["'\'']$//')
   export DATABASE_URL
 fi
 
@@ -67,7 +67,7 @@ if [[ "$UPLOADS_ONLY" != true ]]; then
   else
     echo ""
     echo "📦 DB バックアップ中..."
-    pg_dump "$DATABASE_URL" | gzip > "$BACKUP_DIR/db_backup.sql.gz"
+    pg_dump --dbname="$DATABASE_URL" | gzip > "$BACKUP_DIR/db_backup.sql.gz"
     ls -lh "$BACKUP_DIR/db_backup.sql.gz"
   fi
 fi


### PR DESCRIPTION
## 概要
VPS デプロイ時のバックアップスクリプトで `pg_dump` が `role "deploy" does not exist` エラーになる問題を修正。

## 原因
1. `.env` から読み取った `DATABASE_URL` に引用符が残っていたため `pg_dump` が正しく解釈できなかった
2. `pg_dump` に URL を位置引数で渡すより `--dbname=` フラグで明示的に渡す方が堅牢

## 修正内容
- `.env` から値を抽出する際に前後の引用符 (`"` `'`) を `sed` で除去
- `pg_dump "$DATABASE_URL"` → `pg_dump --dbname="$DATABASE_URL"` に変更