### PR TITLE
fix: VPS デプロイ時の npx prisma 解決エラーを修正

### DIFF
--- a/scripts/vps-deploy.sh
+++ b/scripts/vps-deploy.sh
@@ -85,7 +85,7 @@ npm ci
 echo ""
 echo "🔄 Step 4/10: Prisma generate & migrate deploy"
 npm run prisma:generate
-npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma
+npx --prefix apps/api prisma migrate deploy
 
 # 5. API ビルド ----------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 概要
VPS デプロイ Step 4/10 で `sh: 1: prisma: not found` になる問題を修正。

## 原因
ルートディレクトリで `npx prisma` を実行しても `prisma` が `apps/api/node_modules` にしかないため解決できない。

## 修正
`npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma`
→ `npx --prefix apps/api prisma migrate deploy`