### PR TITLE
fix: Prisma migrate deploy で schema が見つからない問題を修正

### DIFF
--- a/scripts/vps-deploy.sh
+++ b/scripts/vps-deploy.sh
@@ -85,7 +85,7 @@ npm ci
 echo ""
 echo "🔄 Step 4/10: Prisma generate & migrate deploy"
 npm run prisma:generate
-npx --prefix apps/api prisma migrate deploy
+(cd apps/api && npx prisma migrate deploy)
 
 # 5. API ビルド ----------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 概要
`npx --prefix` はバイナリの場所のみ指定し、カレントディレクトリは変わらないため、Prisma がルートディレクトリから schema.prisma を探して失敗していた。

## 修正
`npx --prefix apps/api prisma migrate deploy`
→ `(cd apps/api && npx prisma migrate deploy)`

サブシェルで `apps/api` に移動してから実行することで、Prisma が正しく `apps/api/prisma/schema.prisma` を認識できる。