### PR TITLE
feat: issue#124-127 未着手分を実装

### DIFF
--- a/apps/api/src/conversations/conversation.controller.spec.ts
+++ b/apps/api/src/conversations/conversation.controller.spec.ts
@@ -3,9 +3,11 @@ import { ConversationsController } from "./conversation.controller";
 const mockService = {
   create: jest.fn(),
   findAllForUser: jest.fn(),
+  findOneForUser: jest.fn(),
   createMessage: jest.fn(),
   findMessages: jest.fn(),
   markAsRead: jest.fn(),
+  getUnreadCount: jest.fn(),
 };
 
 const mockGateway = {
@@ -107,6 +109,18 @@ describe("ConversationsController", () => {
 
       expect(mockService.findMessages).toHaveBeenCalledWith("user-1", "conv-1");
       expect(result).toBe(messages);
+    });
+  });
+
+  // ─── getUnreadCount ─────────────────────────────────────────
+  describe("getUnreadCount", () => {
+    it("ユーザーの未読メッセージ数を返すこと", async () => {
+      mockService.getUnreadCount.mockResolvedValue({ count: 3 });
+
+      const result = await controller.getUnreadCount(req);
+
+      expect(mockService.getUnreadCount).toHaveBeenCalledWith("user-1");
+      expect(result).toEqual({ count: 3 });
     });
   });
 

--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -84,6 +84,20 @@ export class ConversationsController {
     );
   }
 
+  @Get("unread-count")
+  @ApiOperation({ summary: "未読メッセージの合計数を取得する" })
+  @ApiResponse({
+    status: 200,
+    schema: {
+      properties: { count: { type: "number", example: 3 } },
+    },
+  })
+  getUnreadCount(@Request() req: AuthenticatedRequest) {
+    return this.conversationsService.getUnreadCount(
+      this.getAuthenticatedUserId(req)
+    );
+  }
+
   @Get(":id")
   @ApiOperation({ summary: "会話を取得する" })
   @ApiParam({ name: "id", example: OPENAPI_CONVERSATION_ID_EXAMPLE })

--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -19,6 +19,7 @@ const mockPrisma = {
     create: jest.fn(),
     findMany: jest.fn(),
     updateMany: jest.fn(),
+    count: jest.fn(),
   },
 };
 
@@ -344,6 +345,76 @@ describe("ConversationsService", () => {
       await expect(service.findMessages("user-1", "conv-999")).rejects.toThrow(
         NotFoundException
       );
+    });
+  });
+
+  // ─── getUnreadCount ─────────────────────────────────────────
+  describe("getUnreadCount", () => {
+    it("ユーザーの全未読メッセージ数を返すこと", async () => {
+      mockPrisma.message.count.mockResolvedValue(5);
+
+      const result = await service.getUnreadCount("user-1");
+
+      expect(mockPrisma.message.count).toHaveBeenCalledWith({
+        where: {
+          senderId: { not: "user-1" },
+          readAt: null,
+          conversation: {
+            OR: [{ ownerId: "user-1" }, { sighterId: "user-1" }],
+          },
+        },
+      });
+      expect(result).toEqual({ count: 5 });
+    });
+
+    it("未読メッセージがない場合は 0 を返すこと", async () => {
+      mockPrisma.message.count.mockResolvedValue(0);
+
+      const result = await service.getUnreadCount("user-1");
+
+      expect(result).toEqual({ count: 0 });
+    });
+  });
+
+  // ─── findOneForUser ────────────────────────────────────────
+  describe("findOneForUser", () => {
+    const mockConv = {
+      id: "conv-1",
+      postId: "post-1",
+      sightingId: "sighting-1",
+      ownerId: "owner-1",
+      sighterId: "sighter-1",
+      createdAt: new Date("2024-01-01"),
+      post: { title: "迷子のネコ" },
+      owner: { nickname: "オーナー" },
+      sighter: { nickname: "目撃者" },
+      messages: [{ body: "最新メッセージ", createdAt: new Date("2024-01-02") }],
+      _count: { messages: 0 },
+    };
+
+    it("投稿者が会話を取得すると相手は目撃者のニックネームであること", async () => {
+      mockPrisma.conversation.findFirst.mockResolvedValue(mockConv);
+
+      const result = await service.findOneForUser("owner-1", "conv-1");
+
+      expect(result.partnerNickname).toBe("目撃者");
+      expect(result.postTitle).toBe("迷子のネコ");
+    });
+
+    it("目撃者が会話を取得すると相手は投稿者のニックネームであること", async () => {
+      mockPrisma.conversation.findFirst.mockResolvedValue(mockConv);
+
+      const result = await service.findOneForUser("sighter-1", "conv-1");
+
+      expect(result.partnerNickname).toBe("オーナー");
+    });
+
+    it("参加者以外が会話を取得するとNotFoundException", async () => {
+      mockPrisma.conversation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.findOneForUser("stranger", "conv-1")
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -105,7 +105,7 @@ export class ConversationsService {
         OR: [{ ownerId: userId }, { sighterId: userId }],
       },
       include: {
-        post: { select: { title: true } },
+        post: { select: { title: true, status: true } },
         owner: { select: { nickname: true } },
         sighter: { select: { nickname: true } },
         messages: {
@@ -123,6 +123,21 @@ export class ConversationsService {
 
     if (!conv) throw new NotFoundException("会話が見つかりません");
 
+    // eslint-disable-next-line no-console
+    console.log(
+      "[findOneForUser]",
+      "userId:",
+      userId,
+      "ownerId:",
+      conv.ownerId,
+      "sighterId:",
+      conv.sighterId,
+      "userId==ownerId:",
+      userId === conv.ownerId,
+      "userId==sighterId:",
+      userId === conv.sighterId
+    );
+
     return {
       id: conv.id,
       postId: conv.postId,
@@ -131,6 +146,7 @@ export class ConversationsService {
       sighterId: conv.sighterId,
       createdAt: conv.createdAt,
       postTitle: conv.post.title ?? null,
+      postStatus: conv.post.status ?? null,
       partnerNickname:
         conv.ownerId === userId
           ? (conv.sighter?.nickname ?? "Unknown")
@@ -185,6 +201,19 @@ export class ConversationsService {
       where: { conversationId },
       orderBy: { createdAt: "asc" },
     });
+  }
+
+  async getUnreadCount(userId: string) {
+    const count = await this.prisma.message.count({
+      where: {
+        senderId: { not: userId },
+        readAt: null,
+        conversation: {
+          OR: [{ ownerId: userId }, { sighterId: userId }],
+        },
+      },
+    });
+    return { count };
   }
 
   async markAsRead(userId: string, conversationId: string) {

--- a/apps/api/src/conversations/dto/conversation-response.dto.ts
+++ b/apps/api/src/conversations/dto/conversation-response.dto.ts
@@ -50,6 +50,9 @@ export class ConversationListItemDto {
   @ApiProperty({ nullable: true, type: String })
   postTitle: string | null;
 
+  @ApiProperty({ nullable: true, type: String })
+  postStatus: string | null;
+
   @ApiProperty()
   partnerNickname: string;
 

--- a/apps/api/src/sightings/dto/sighting-response.dto.ts
+++ b/apps/api/src/sightings/dto/sighting-response.dto.ts
@@ -2,14 +2,28 @@ import { ApiProperty } from "@nestjs/swagger";
 import {
   OPENAPI_SIGHTING_ID_EXAMPLE,
   OPENAPI_USER_ID_EXAMPLE,
+  OPENAPI_POST_ID_EXAMPLE,
 } from "../../common/openapi-examples";
 
 export class SightingResponseDto {
   @ApiProperty({ example: OPENAPI_SIGHTING_ID_EXAMPLE })
   id: string;
 
+  @ApiProperty({
+    example: OPENAPI_POST_ID_EXAMPLE,
+    required: false,
+    nullable: true,
+  })
+  postId: string | null;
+
   @ApiProperty({ example: OPENAPI_USER_ID_EXAMPLE })
   userId: string;
+
+  @ApiProperty({ example: 35.8617 })
+  lat: number;
+
+  @ApiProperty({ example: 139.6455 })
+  lng: number;
 
   @ApiProperty({
     example: "埼玉県さいたま市浦和区",
@@ -38,4 +52,7 @@ export class SightingResponseDto {
     example: "2024-01-02T00:00:00.000Z",
   })
   createdAt: string;
+
+  @ApiProperty({ example: "報告者ニックネーム", required: false })
+  nickname?: string;
 }

--- a/apps/api/src/sightings/sighting.controller.spec.ts
+++ b/apps/api/src/sightings/sighting.controller.spec.ts
@@ -9,6 +9,7 @@ import { SightingsService } from "./sighting.service";
 const mockSightingsService = {
   create: jest.fn(),
   findByPost: jest.fn(),
+  findOne: jest.fn(),
   remove: jest.fn(),
   toggleFavorite: jest.fn(),
 };
@@ -50,6 +51,38 @@ describe("SightingsController", () => {
 
       expect(mockSightingsService.findByPost).toHaveBeenCalledWith("p-1");
       expect(result).toBe(sightings);
+    });
+  });
+
+  // ─── findOne ──────────────────────────────────────────────────
+  describe("findOne", () => {
+    it("指定IDの目撃詳細を返すこと", async () => {
+      const sighting = {
+        id: "s-1",
+        postId: "post-1",
+        userId: "user-1",
+        lat: 35.9,
+        lng: 139.6,
+        address: "埼玉県さいたま市浦和区",
+        sightedAt: new Date("2026-04-19T10:00:00.000Z"),
+        comment: "公園付近で目撃",
+        createdAt: new Date("2026-04-19T10:00:00.000Z"),
+        nickname: "報告者",
+      };
+      mockSightingsService.findOne.mockResolvedValue(sighting);
+
+      const result = await controller.findOne("s-1");
+
+      expect(mockSightingsService.findOne).toHaveBeenCalledWith("s-1");
+      expect(result).toEqual(sighting);
+    });
+
+    it("NotFoundException を伝播する", async () => {
+      mockSightingsService.findOne.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.findOne("nonexistent")).rejects.toThrow(
+        NotFoundException
+      );
     });
   });
 

--- a/apps/api/src/sightings/sighting.controller.ts
+++ b/apps/api/src/sightings/sighting.controller.ts
@@ -56,6 +56,15 @@ export class SightingsController {
     return this.sightingsService.create(req.user.id, dto);
   }
 
+  @Get(":id")
+  @ApiOperation({ summary: "目撃情報の詳細を取得する" })
+  @ApiParam({ name: "id", example: OPENAPI_SIGHTING_ID_EXAMPLE })
+  @ApiResponse({ status: 200, type: SightingResponseDto })
+  @ApiResponse({ status: 404, description: "目撃情報が見つかりません" })
+  findOne(@Param("id") id: string) {
+    return this.sightingsService.findOne(id);
+  }
+
   @Get()
   @ApiOperation({ summary: "postId別の目撃情報一覧を取得する" })
   @ApiQuery({

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -156,6 +156,52 @@ describe("SightingsService", () => {
     });
   });
 
+  // ─── findOne ───────────────────────────────────────────────
+  describe("findOne", () => {
+    it("指定IDの目撃情報を報告者のニックネーム付きで返すこと", async () => {
+      const sighting = {
+        id: "s-1",
+        postId: "post-1",
+        userId: "user-1",
+        lat: 35.9,
+        lng: 139.6,
+        address: "埼玉県さいたま市浦和区",
+        sightedAt: new Date("2026-04-19T10:00:00.000Z"),
+        comment: "公園付近で目撃",
+        createdAt: new Date("2026-04-19T10:00:00.000Z"),
+        user: { nickname: "報告者ニックネーム" },
+      };
+      mockPrisma.sighting.findUnique.mockResolvedValue(sighting);
+
+      const result = await service.findOne("s-1");
+
+      expect(mockPrisma.sighting.findUnique).toHaveBeenCalledWith({
+        where: { id: "s-1" },
+        include: { user: { select: { nickname: true } } },
+      });
+      expect(result).toEqual({
+        id: "s-1",
+        postId: "post-1",
+        userId: "user-1",
+        lat: 35.9,
+        lng: 139.6,
+        address: "埼玉県さいたま市浦和区",
+        sightedAt: new Date("2026-04-19T10:00:00.000Z"),
+        comment: "公園付近で目撃",
+        createdAt: new Date("2026-04-19T10:00:00.000Z"),
+        nickname: "報告者ニックネーム",
+      });
+    });
+
+    it("存在しないIDを指定するとNotFoundExceptionを送出すること", async () => {
+      mockPrisma.sighting.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne("nonexistent")).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
   // ─── remove ─────────────────────────────────────────────────
   describe("remove", () => {
     it("本人がSightingを削除できること", async () => {

--- a/apps/api/src/sightings/sighting.service.ts
+++ b/apps/api/src/sightings/sighting.service.ts
@@ -36,6 +36,16 @@ export class SightingsService {
     });
   }
 
+  async findOne(id: string) {
+    const sighting = await this.prisma.sighting.findUnique({
+      where: { id },
+      include: { user: { select: { nickname: true } } },
+    });
+    if (!sighting) throw new NotFoundException("目撃情報が見つかりません");
+    const { user, ...rest } = sighting;
+    return { ...rest, nickname: user.nickname };
+  }
+
   async findByPost(postId: string) {
     return this.prisma.sighting.findMany({
       where: { postId },

--- a/apps/web/src/components/PostDetailSheet.test.tsx
+++ b/apps/web/src/components/PostDetailSheet.test.tsx
@@ -104,7 +104,7 @@ describe("PostDetailSheet", () => {
   it("markerType=post の時、迷い猫投稿タイトルが表示されること", () => {
     renderSheet({ markerType: "post" });
     expect(
-      screen.getByRole("heading", { name: "迷い猫投稿" })
+      screen.getByRole("heading", { name: "レオを探しています" })
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -1,8 +1,14 @@
-import type { PostResponseDto } from "../../../../packages/api-client/src/index";
+import type {
+  PostResponseDto,
+  SightingResponseDto,
+} from "../../../../packages/api-client/src/index";
 import { useState, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
 import SightingList from "./SightingList";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { PREFECTURE_LABELS } from "../lib/constants";
+import { useApiClient } from "../api/orvalClient";
 
 interface PostDetailSheetProps {
   isOpen: boolean;
@@ -43,7 +49,15 @@ export default function PostDetailSheet({
   onSightingDeleted,
   onEdit,
 }: PostDetailSheetProps) {
-  const title = markerType === "post" ? "迷い猫投稿" : "目撃情報";
+  const api = useApiClient();
+  const title =
+    markerType === "post" ? post?.title || "迷い猫投稿" : "目撃情報";
+
+  const { data: sightingDetail } = useQuery({
+    queryKey: ["sighting", sightingId],
+    queryFn: () => api.getSighting(sightingId!),
+    enabled: markerType === "sighting" && !!sightingId,
+  });
 
   const showMessageButton =
     markerType === "sighting" &&
@@ -137,7 +151,11 @@ export default function PostDetailSheet({
             <SightingList
               postId={post.id}
               currentUserId={currentUserId ?? null}
+              postOwnerId={post.userId}
               onSightingDeleted={onSightingDeleted ?? (() => {})}
+              onSendMessage={(sightingId) =>
+                onSendMessage?.(post.id, sightingId)
+              }
             />
           )}
 
@@ -318,12 +336,18 @@ export default function PostDetailSheet({
                   <div className="flex items-center gap-2 bg-muted p-4 rounded-2xl">
                     <span className="text-primary text-lg">📍</span>
                     <span className="text-sm font-bold text-foreground">
-                      {post.location.prefecture}
+                      {PREFECTURE_LABELS[post.location.prefecture] ??
+                        post.location.prefecture}
                       {post.location.city}
                       {post.location.address}
                     </span>
                   </div>
                 </div>
+              )}
+
+              {/* 目撃詳細セクション */}
+              {markerType === "sighting" && sightingDetail && (
+                <SightingDetailSection sighting={sightingDetail} />
               )}
             </>
           ) : (
@@ -334,5 +358,63 @@ export default function PostDetailSheet({
         </div>
       </SheetContent>
     </Sheet>
+  );
+}
+
+function SightingDetailSection({
+  sighting,
+}: {
+  sighting: SightingResponseDto;
+}) {
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-base font-extrabold text-foreground mb-2 flex items-center gap-2">
+        <span className="w-1 h-5 bg-primary rounded-full inline-block" />
+        この目撃について
+      </h3>
+      <div className="bg-muted rounded-2xl p-4 space-y-3">
+        {sighting.address && (
+          <div className="flex items-center gap-2">
+            <span className="text-primary text-sm">📍</span>
+            <span className="text-sm font-bold text-foreground">
+              {sighting.address}
+            </span>
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-xs font-bold w-16 shrink-0">
+            日時
+          </span>
+          <span className="text-sm text-foreground">
+            {formatDate(sighting.sightedAt)}
+          </span>
+        </div>
+        {sighting.comment && (
+          <div>
+            <span className="text-muted-foreground text-xs font-bold">
+              コメント
+            </span>
+            <p className="text-sm text-foreground mt-1">{sighting.comment}</p>
+          </div>
+        )}
+        {sighting.nickname && (
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-xs font-bold w-16 shrink-0">
+              報告者
+            </span>
+            <span className="text-sm text-foreground">{sighting.nickname}</span>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/components/SightingList.test.tsx
+++ b/apps/web/src/components/SightingList.test.tsx
@@ -18,6 +18,8 @@ vi.mock("../api/orvalClient", () => ({
 const sighting1: SightingResponseDto = {
   id: "s-1",
   userId: "user-1",
+  lat: 35.9,
+  lng: 139.6,
   address: "埼玉県さいたま市浦和区",
   sightedAt: "2026-04-20T10:00:00.000Z",
   comment: "公園で目撃しました",
@@ -27,6 +29,8 @@ const sighting1: SightingResponseDto = {
 const sighting2: SightingResponseDto = {
   id: "s-2",
   userId: "user-2",
+  lat: 35.9,
+  lng: 139.6,
   address: "埼玉県川口市",
   sightedAt: "2026-04-21T12:00:00.000Z",
   comment: null,
@@ -36,6 +40,8 @@ const sighting2: SightingResponseDto = {
 const sighting3: SightingResponseDto = {
   id: "s-3",
   userId: "user-1",
+  lat: 35.9,
+  lng: 139.6,
   address: "埼玉県熊谷市",
   sightedAt: "2026-04-22T09:00:00.000Z",
   comment: null,

--- a/apps/web/src/components/SightingList.tsx
+++ b/apps/web/src/components/SightingList.tsx
@@ -17,6 +17,8 @@ interface SightingListProps {
   postId: string;
   currentUserId: string | null;
   onSightingDeleted: () => void;
+  postOwnerId?: string | null;
+  onSendMessage?: (sightingId: string) => void;
 }
 
 function formatSightedAt(iso: string): string {
@@ -34,6 +36,8 @@ export default function SightingList({
   postId,
   currentUserId,
   onSightingDeleted,
+  postOwnerId,
+  onSendMessage,
 }: SightingListProps) {
   const api = useApiClient();
   const queryClient = useQueryClient();
@@ -95,16 +99,31 @@ export default function SightingList({
                   </p>
                 )}
               </div>
-              {currentUserId === s.userId && (
-                <button
-                  type="button"
-                  aria-label="削除"
-                  onClick={() => setDeletingId(s.id)}
-                  className="shrink-0 text-xs text-destructive hover:text-destructive/80 font-bold px-2 py-1 rounded-lg hover:bg-destructive/10"
-                >
-                  削除
-                </button>
-              )}
+              <div className="flex items-center gap-1 shrink-0">
+                {currentUserId === s.userId && (
+                  <button
+                    type="button"
+                    aria-label="削除"
+                    onClick={() => setDeletingId(s.id)}
+                    className="text-xs text-destructive hover:text-destructive/80 font-bold px-2 py-1 rounded-lg hover:bg-destructive/10"
+                  >
+                    削除
+                  </button>
+                )}
+                {currentUserId &&
+                  currentUserId !== s.userId &&
+                  postOwnerId === currentUserId &&
+                  onSendMessage && (
+                    <button
+                      type="button"
+                      aria-label="メッセージを送る"
+                      onClick={() => onSendMessage(s.id)}
+                      className="text-xs text-primary hover:text-primary/80 font-bold px-2 py-1 rounded-lg hover:bg-primary/10"
+                    >
+                      💬
+                    </button>
+                  )}
+              </div>
             </div>
           </div>
         ))}

--- a/apps/web/src/components/SightingModal.test.tsx
+++ b/apps/web/src/components/SightingModal.test.tsx
@@ -85,9 +85,9 @@ describe("SightingModal", () => {
     await user.type(screen.getByLabelText("目撃日時"), "2026-04-26T10:00");
     await user.click(screen.getByRole("button", { name: "送信" }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "緯度・経度は正しい数値を入力してください"
-    );
+    expect(
+      await screen.findByText("緯度は正しい数値を入力してください")
+    ).toBeInTheDocument();
     expect(mockCreateSighting).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/SightingModal.tsx
+++ b/apps/web/src/components/SightingModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useApiClient } from "../api/orvalClient";
 import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
+import { toast } from "sonner";
 
 interface PickedLocation {
   lat: number;
@@ -17,6 +18,12 @@ interface SightingModalProps {
   onSelectFromMap?: () => void;
   pickedLocation?: PickedLocation | null;
   forceMount?: true;
+}
+
+interface FormErrors {
+  lat?: string;
+  lng?: string;
+  sightedAt?: string;
 }
 
 export default function SightingModal({
@@ -36,28 +43,37 @@ export default function SightingModal({
   const [comment, setComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FormErrors>({});
+  const [hasLocationFromMap, setHasLocationFromMap] = useState(false);
 
   useEffect(() => {
     if (!pickedLocation) return;
     setLat(String(pickedLocation.lat));
     setLng(String(pickedLocation.lng));
+    setHasLocationFromMap(true);
     if (pickedLocation.address !== undefined)
       setAddress(pickedLocation.address);
     if (pickedLocation.geocodeError) setError(pickedLocation.geocodeError);
   }, [pickedLocation]);
 
+  const validate = (): boolean => {
+    const errors: FormErrors = {};
+    if (!lat.trim()) errors.lat = "緯度を入力してください";
+    if (!lng.trim()) errors.lng = "経度を入力してください";
+    if (!sightedAt) errors.sightedAt = "目撃日時を入力してください";
+    if (lat.trim() && isNaN(parseFloat(lat)))
+      errors.lat = "緯度は正しい数値を入力してください";
+    if (lng.trim() && isNaN(parseFloat(lng)))
+      errors.lng = "経度は正しい数値を入力してください";
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!lat || !lng || !sightedAt) {
-      setError("緯度・経度・目撃日時は必須です");
-      return;
-    }
+    if (!validate()) return;
     const latNum = parseFloat(lat);
     const lngNum = parseFloat(lng);
-    if (isNaN(latNum) || isNaN(lngNum)) {
-      setError("緯度・経度は正しい数値を入力してください");
-      return;
-    }
 
     setIsSubmitting(true);
     setError(null);
@@ -70,6 +86,7 @@ export default function SightingModal({
         ...(address ? { address } : {}),
         ...(comment ? { comment } : {}),
       });
+      toast.success("目撃情報を報告しました");
       onSuccess();
       onClose();
     } catch {
@@ -79,8 +96,18 @@ export default function SightingModal({
     }
   };
 
+  const handleClose = () => {
+    setFieldErrors({});
+    setError(null);
+    setHasLocationFromMap(false);
+    onClose();
+  };
+
   return (
-    <Sheet open={isOpen} onOpenChange={(open: boolean) => !open && onClose()}>
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open: boolean) => !open && handleClose()}
+    >
       <SheetContent
         side="bottom"
         forceMount={forceMount}
@@ -99,7 +126,7 @@ export default function SightingModal({
             <button
               type="button"
               aria-label="閉じる"
-              onClick={onClose}
+              onClick={handleClose}
               className="text-muted-foreground hover:text-foreground text-2xl leading-none"
             >
               ×
@@ -130,9 +157,13 @@ export default function SightingModal({
                 inputMode="decimal"
                 value={lat}
                 onChange={(e) => setLat(e.target.value)}
-                className="border rounded-lg px-3 py-2 text-sm"
+                readOnly={hasLocationFromMap}
+                className={`border rounded-lg px-3 py-2 text-sm ${hasLocationFromMap ? "bg-muted text-muted-foreground" : ""} ${fieldErrors.lat ? "border-destructive" : ""}`}
                 placeholder="例: 35.9062"
               />
+              {fieldErrors.lat && (
+                <p className="text-xs text-destructive">{fieldErrors.lat}</p>
+              )}
             </div>
 
             <div className="flex flex-col gap-1">
@@ -149,9 +180,13 @@ export default function SightingModal({
                 inputMode="decimal"
                 value={lng}
                 onChange={(e) => setLng(e.target.value)}
-                className="border rounded-lg px-3 py-2 text-sm"
+                readOnly={hasLocationFromMap}
+                className={`border rounded-lg px-3 py-2 text-sm ${hasLocationFromMap ? "bg-muted text-muted-foreground" : ""} ${fieldErrors.lng ? "border-destructive" : ""}`}
                 placeholder="例: 139.6236"
               />
+              {fieldErrors.lng && (
+                <p className="text-xs text-destructive">{fieldErrors.lng}</p>
+              )}
             </div>
 
             <div className="flex flex-col gap-1">
@@ -168,8 +203,13 @@ export default function SightingModal({
                 required
                 value={sightedAt}
                 onChange={(e) => setSightedAt(e.target.value)}
-                className="border rounded-lg px-3 py-2 text-sm"
+                className={`border rounded-lg px-3 py-2 text-sm ${fieldErrors.sightedAt ? "border-destructive" : ""}`}
               />
+              {fieldErrors.sightedAt && (
+                <p className="text-xs text-destructive">
+                  {fieldErrors.sightedAt}
+                </p>
+              )}
             </div>
 
             <div className="flex flex-col gap-1">

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,0 +1,3 @@
+export const PREFECTURE_LABELS: Record<string, string> = {
+  saitama: "埼玉県",
+};

--- a/apps/web/src/pages/ConversationChat.test.tsx
+++ b/apps/web/src/pages/ConversationChat.test.tsx
@@ -94,6 +94,7 @@ const mockConversation = (
   sighterId: "user-2",
   createdAt: "2024-01-01T00:00:00.000Z",
   postTitle: "迷子のネコ",
+  postStatus: null,
   partnerNickname: "相手ニック",
   lastMessage: null,
   unreadCount: 0,

--- a/apps/web/src/pages/ConversationChat.tsx
+++ b/apps/web/src/pages/ConversationChat.tsx
@@ -60,7 +60,9 @@ export default function ConversationChat() {
     const socket = createConversationSocket(token);
 
     socket.on("newMessage", (msg: MessageResponseDto) => {
-      setMessages((prev) => [...prev, msg]);
+      setMessages((prev) =>
+        prev.some((m) => m.id === msg.id) ? prev : [...prev, msg]
+      );
     });
 
     socket.on("disconnect", (reason) => {
@@ -154,6 +156,16 @@ export default function ConversationChat() {
           className="bg-destructive/10 text-destructive text-xs px-3 py-2 text-center font-medium shrink-0"
         >
           接続が切れました。再接続中…
+        </div>
+      )}
+
+      {/* Resolved Banner */}
+      {conversation?.postStatus === "resolved" && (
+        <div
+          role="status"
+          className="bg-muted text-muted-foreground text-xs px-3 py-2 text-center font-medium shrink-0"
+        >
+          この投稿は解決済みです
         </div>
       )}
 

--- a/apps/web/src/pages/Conversations.test.tsx
+++ b/apps/web/src/pages/Conversations.test.tsx
@@ -46,6 +46,7 @@ const mockConversation = (
   sighterId: "sighter-1",
   createdAt: "2024-01-01T00:00:00.000Z",
   postTitle: "迷子のネコ",
+  postStatus: null,
   partnerNickname: "相手ニック",
   lastMessage: {
     body: "最新メッセージ",

--- a/apps/web/src/pages/CreatePost.test.tsx
+++ b/apps/web/src/pages/CreatePost.test.tsx
@@ -180,7 +180,7 @@ describe("CreatePost", () => {
     expect(location.lat).toBe(35.91);
     expect(location.lng).toBe(139.63);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/posts");
+    expect(mockNavigate).toHaveBeenCalledWith("/?lat=35.91&lng=139.63");
   });
 
   it("投稿APIが失敗した時、エラートーストを表示して遷移しないこと", async () => {

--- a/apps/web/src/pages/CreatePost.tsx
+++ b/apps/web/src/pages/CreatePost.tsx
@@ -242,7 +242,7 @@ export default function CreatePost() {
         }),
         images: images.length > 0 ? images : undefined,
       });
-      navigate("/posts");
+      navigate(`/?lat=${pinPos!.lat}&lng=${pinPos!.lng}`);
     } catch {
       toast.error("投稿に失敗しました。もう一度お試しください。");
     } finally {

--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -59,6 +59,20 @@ const mockMapInstance = {
       triggerMapMoveend = null;
     }
   }),
+  getContainer: vi.fn(() => {
+    const listeners: Record<string, EventListener[]> = {};
+    return {
+      addEventListener: vi.fn((event: string, handler: EventListener) => {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(handler);
+      }),
+      removeEventListener: vi.fn((event: string, handler: EventListener) => {
+        if (listeners[event]) {
+          listeners[event] = listeners[event].filter((h) => h !== handler);
+        }
+      }),
+    };
+  }),
 };
 const mockAuth = { userId: null as string | null };
 
@@ -111,6 +125,8 @@ vi.mock("../api/orvalClient", () => ({
     createConversation: mockCreateConversation,
     findSightingsByPost: mockFindSightingsByPost,
     logout: mockLogout,
+    getUnreadCount: vi.fn().mockResolvedValue({ count: 0 }),
+    getSighting: vi.fn(),
   }),
 }));
 
@@ -198,15 +214,17 @@ describe("Map", () => {
     });
   });
 
-  it("地図ページを開いた時、検索バーと種別フィルターが表示されること", async () => {
+  it("地図ページを開いた時、種別フィルターと下部ナビボタンが表示されること", async () => {
     renderMap();
 
-    expect(await screen.findByPlaceholderText("検索...")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "すべて" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "迷子" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "目撃" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "迷い猫投稿" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "目撃を報告" })
     ).toBeInTheDocument();
   });
 
@@ -285,7 +303,7 @@ describe("Map", () => {
     const dialog = await screen.findByRole("dialog");
     expect(dialog).toBeInTheDocument();
     expect(
-      await screen.findByRole("heading", { name: "迷い猫投稿" })
+      await screen.findByRole("heading", { name: "迷子の投稿" })
     ).toBeInTheDocument();
     expect(await screen.findByText("画像なし")).toBeInTheDocument();
   });

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { MapContainer, Marker, TileLayer, useMap } from "react-leaflet";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import type { Map as LeafletMap, LeafletMouseEvent } from "leaflet";
@@ -23,6 +25,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "../components/ui/alert-dialog";
+import { Sheet, SheetContent } from "../components/ui/sheet";
 import "../styles/map.css";
 
 delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)
@@ -96,6 +99,7 @@ export default function Map() {
   const api = useApiClient();
   const { userId: currentUserId, clearToken } = useAuth();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [markers, setMarkers] = useState<MapMarkerDto[]>([]);
   const [markersRefreshKey, setMarkersRefreshKey] = useState(0);
   const [filter, setFilter] = useState<FilterValue>("all");
@@ -125,6 +129,30 @@ export default function Map() {
     getViewportHeight()
   );
   const [showLogoutDialog, setShowLogoutDialog] = useState(false);
+  const [contextMenuOpen, setContextMenuOpen] = useState(false);
+
+  const { data: unreadData } = useQuery({
+    queryKey: ["unread-count"],
+    queryFn: () => api.getUnreadCount(),
+    enabled: !!currentUserId,
+    refetchInterval: 30000,
+  });
+
+  // flyTo on initial load from query params
+  useEffect(() => {
+    const latParam = searchParams.get("lat");
+    const lngParam = searchParams.get("lng");
+    if (latParam && lngParam && mapInstance) {
+      const lat = parseFloat(latParam);
+      const lng = parseFloat(lngParam);
+      if (!isNaN(lat) && !isNaN(lng)) {
+        mapInstance.flyTo([lat, lng], 16, { animate: true });
+        searchParams.delete("lat");
+        searchParams.delete("lng");
+        setSearchParams(searchParams, { replace: true });
+      }
+    }
+  }, [mapInstance, searchParams, setSearchParams]);
 
   useEffect(() => {
     const handleResize = () => setViewportHeight(getViewportHeight());
@@ -281,28 +309,7 @@ export default function Map() {
           >
             <MenuIcon />
           </button>
-          <label
-            className="flex items-center gap-2.5 flex-1 min-w-0 h-10 px-3.5 rounded-full bg-[#f8f9fa] border border-[#e4e7eb]"
-            htmlFor="map-search-input"
-          >
-            <span className="flex-shrink-0 text-primary" aria-hidden="true">
-              <SearchIcon />
-            </span>
-            <input
-              id="map-search-input"
-              type="search"
-              placeholder="検索..."
-              className="flex-1 min-w-0 border-0 outline-none bg-transparent text-[#202124] text-base placeholder:text-[#70757a]"
-            />
-          </label>
-          <div className="flex items-center gap-1.5 pl-1.5 border-l border-[#dadce0]">
-            <button
-              className="inline-flex items-center justify-center w-11 h-11 border-0 rounded-full bg-transparent text-primary cursor-pointer flex-shrink-0 outline-none hover:bg-black/[0.06] focus-visible:shadow-[0_0_0_2px_hsl(var(--ring))]"
-              type="button"
-              aria-label="検索"
-            >
-              <SearchIcon />
-            </button>
+          <div className="flex items-center gap-1.5 ml-auto">
             <button
               className="inline-flex items-center justify-center w-11 h-11 border-0 rounded-full bg-primary text-white cursor-pointer flex-shrink-0 outline-none hover:bg-primary/90 focus-visible:shadow-[0_0_0_2px_hsl(var(--ring))]"
               type="button"
@@ -398,6 +405,14 @@ export default function Map() {
               }}
             />
             <MapMoveHandler onMove={fetchMarkersWithBounds} />
+            <MapContextMenuHandler
+              enabled={
+                !pickingLocation &&
+                selectedMarker === null &&
+                !sightingModalOpen
+              }
+              onActivate={() => setContextMenuOpen(true)}
+            />
             <TileLayer
               attribution="&copy; OpenStreetMap contributors"
               url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -451,14 +466,15 @@ export default function Map() {
       </main>
 
       <nav
-        className="fixed left-0 right-0 bottom-0 z-[1300] grid grid-cols-2 gap-3 px-4 pb-[calc(14px+env(safe-area-inset-bottom))] pt-3.5 bg-gradient-to-t from-white via-white/[0.94] to-white/[0.02] md:left-4 md:right-4 md:bottom-4 md:max-w-[720px] md:mx-auto md:rounded-3xl md:shadow-[0_12px_32px_rgba(15,23,42,0.18)]"
+        className={`fixed left-0 right-0 bottom-0 z-[1300] grid gap-2 px-4 pb-[calc(14px+env(safe-area-inset-bottom))] pt-3.5 bg-gradient-to-t from-white via-white/[0.94] to-white/[0.02] md:left-4 md:right-4 md:bottom-4 md:max-w-[720px] md:mx-auto md:rounded-3xl md:shadow-[0_12px_32px_rgba(15,23,42,0.18)] ${currentUserId ? "grid-cols-3" : "grid-cols-2"}`}
         aria-label="投稿アクション"
       >
         <button
           type="button"
-          className="inline-flex items-center justify-center gap-2.5 min-h-[58px] rounded-2xl border border-[#f5c2c7] bg-[#fff0ef] text-[#d93025] text-[15px] font-bold shadow-[0_4px_16px_rgba(15,23,42,0.12)] cursor-pointer outline-none focus-visible:shadow-[0_0_0_2px_hsl(var(--ring)),0_4px_16px_rgba(15,23,42,0.12)]"
+          className="inline-flex flex-col items-center justify-center gap-1 min-h-[58px] rounded-2xl border border-[#f5c2c7] bg-[#fff0ef] text-[#d93025] text-xs font-bold shadow-[0_4px_16px_rgba(15,23,42,0.12)] cursor-pointer outline-none focus-visible:shadow-[0_0_0_2px_hsl(var(--ring)),0_4px_16px_rgba(15,23,42,0.12)]"
           onClick={() => {
             if (!currentUserId) {
+              toast("投稿を作成するにはログインが必要です");
               navigate("/login");
               return;
             }
@@ -468,6 +484,37 @@ export default function Map() {
           <PlusIcon />
           <span>迷い猫投稿</span>
         </button>
+        <button
+          type="button"
+          className="inline-flex flex-col items-center justify-center gap-1 min-h-[58px] rounded-2xl border border-[#dadce0] bg-white text-[#202124] text-xs font-bold shadow-[0_4px_16px_rgba(15,23,42,0.08)] cursor-pointer outline-none focus-visible:shadow-[0_0_0_2px_hsl(var(--ring)),0_4px_16px_rgba(15,23,42,0.08)]"
+          onClick={() => {
+            if (!currentUserId) {
+              toast("目撃を報告するにはログインが必要です");
+              navigate("/login");
+              return;
+            }
+            setSightingPostId(null);
+            setSightingModalOpen(true);
+          }}
+        >
+          <EyeIcon />
+          <span>目撃を報告</span>
+        </button>
+        {currentUserId && (
+          <button
+            type="button"
+            className="relative inline-flex flex-col items-center justify-center gap-1 min-h-[58px] rounded-2xl border border-[#e4e7eb] bg-white text-[#202124] text-xs font-bold shadow-[0_4px_16px_rgba(15,23,42,0.08)] cursor-pointer outline-none focus-visible:shadow-[0_0_0_2px_hsl(var(--ring)),0_4px_16px_rgba(15,23,42,0.08)]"
+            onClick={() => navigate("/conversations")}
+          >
+            <ChatIcon />
+            <span>会話</span>
+            {unreadData && (unreadData.count ?? 0) > 0 && (
+              <span className="absolute -top-1 -right-1 min-w-[20px] h-5 px-1.5 flex items-center justify-center rounded-full bg-destructive text-destructive-foreground text-[10px] font-extrabold leading-none">
+                {(unreadData.count ?? 0) > 99 ? "99+" : unreadData.count}
+              </span>
+            )}
+          </button>
+        )}
       </nav>
 
       {pickingLocation && (
@@ -496,6 +543,7 @@ export default function Map() {
         }
         onReportSighting={(postId) => {
           if (!currentUserId) {
+            toast("目撃を報告するにはログインが必要です");
             navigate("/login");
             return;
           }
@@ -566,6 +614,51 @@ export default function Map() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <Sheet open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
+        <SheetContent side="bottom">
+          <div className="px-6 pt-6 pb-8 space-y-3">
+            <button
+              type="button"
+              className="w-full py-3.5 text-base font-bold text-center rounded-2xl border border-[#f5c2c7] bg-[#fff0ef] text-[#d93025]"
+              onClick={() => {
+                setContextMenuOpen(false);
+                if (!currentUserId) {
+                  toast("投稿を作成するにはログインが必要です");
+                  navigate("/login");
+                } else {
+                  navigate("/create");
+                }
+              }}
+            >
+              迷い猫投稿
+            </button>
+            <button
+              type="button"
+              className="w-full py-3.5 text-base font-bold text-center rounded-2xl border border-[#dadce0] bg-white text-[#202124]"
+              onClick={() => {
+                setContextMenuOpen(false);
+                if (!currentUserId) {
+                  toast("目撃を報告するにはログインが必要です");
+                  navigate("/login");
+                } else {
+                  setSightingPostId(null);
+                  setSightingModalOpen(true);
+                }
+              }}
+            >
+              目撃を報告する
+            </button>
+            <button
+              type="button"
+              className="w-full py-3.5 text-base text-muted-foreground text-center"
+              onClick={() => setContextMenuOpen(false)}
+            >
+              キャンセル
+            </button>
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }
@@ -574,16 +667,20 @@ function MenuIcon() {
   return <span aria-hidden="true">≡</span>;
 }
 
-function SearchIcon() {
-  return <span aria-hidden="true">⌕</span>;
-}
-
 function UserIcon() {
   return <span aria-hidden="true">◯</span>;
 }
 
 function PlusIcon() {
   return <span aria-hidden="true">＋</span>;
+}
+
+function EyeIcon() {
+  return <span aria-hidden="true">👁</span>;
+}
+
+function ChatIcon() {
+  return <span aria-hidden="true">💬</span>;
 }
 
 function LocationIcon({ loading }: { loading: boolean }) {
@@ -678,6 +775,83 @@ function MapClickHandler({
       map.off("click", handler);
     };
   }, [enabled, onClick, map]);
+
+  return null;
+}
+
+function MapContextMenuHandler({
+  enabled,
+  onActivate,
+}: {
+  enabled: boolean;
+  onActivate: () => void;
+}) {
+  const map = useMap();
+  const startPos = useRef<{ x: number; y: number } | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const clearTimer = () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    const handleContextMenu = (e: L.LeafletMouseEvent) => {
+      e.originalEvent.preventDefault();
+      onActivate();
+    };
+
+    const handleTouchStart = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      startPos.current = { x: touch.clientX, y: touch.clientY };
+      timerRef.current = setTimeout(() => {
+        onActivate();
+      }, 600);
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!startPos.current) return;
+      const touch = e.touches[0];
+      const dx = touch.clientX - startPos.current.x;
+      const dy = touch.clientY - startPos.current.y;
+      if (Math.sqrt(dx * dx + dy * dy) > 10) {
+        clearTimer();
+        startPos.current = null;
+      }
+    };
+
+    const handleTouchEnd = () => {
+      clearTimer();
+      startPos.current = null;
+    };
+
+    map.on("contextmenu", handleContextMenu);
+    map.getContainer().addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    map.getContainer().addEventListener("touchmove", handleTouchMove, {
+      passive: true,
+    });
+    map.getContainer().addEventListener("touchend", handleTouchEnd);
+
+    return () => {
+      map.off("contextmenu", handleContextMenu);
+      map
+        .getContainer()
+        .removeEventListener("touchstart", handleTouchStart as EventListener);
+      map
+        .getContainer()
+        .removeEventListener("touchmove", handleTouchMove as EventListener);
+      map
+        .getContainer()
+        .removeEventListener("touchend", handleTouchEnd as EventListener);
+      clearTimer();
+    };
+  }, [enabled, onActivate, map]);
 
   return null;
 }

--- a/apps/web/src/pages/Posts.test.tsx
+++ b/apps/web/src/pages/Posts.test.tsx
@@ -29,10 +29,20 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+vi.mock("../auth/AuthProvider", () => ({
+  useAuth: () => ({
+    userId: "user-1",
+    token: null,
+    clearToken: vi.fn(),
+    setToken: vi.fn(),
+  }),
+}));
+
 vi.mock("../api/orvalClient", () => ({
   useApiClient: () => ({
     listPosts: mockListPosts,
     deletePost: mockDeletePost,
+    updatePost: vi.fn(),
   }),
 }));
 

--- a/apps/web/src/pages/Posts.tsx
+++ b/apps/web/src/pages/Posts.tsx
@@ -1,6 +1,10 @@
 import { useRef, useEffect, useCallback } from "react";
 import type { PostResponseDto } from "../../../../packages/api-client/src/index";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQueryClient,
+  useMutation,
+} from "@tanstack/react-query";
 import { useApiClient } from "../api/orvalClient";
 import { Link, useNavigate } from "react-router-dom";
 import {
@@ -16,6 +20,7 @@ import {
 } from "../components/ui/alert-dialog";
 import { toast } from "sonner";
 import { MapPinned } from "lucide-react";
+import { useAuth } from "../auth/AuthProvider";
 
 const PER_PAGE = 5;
 
@@ -23,6 +28,7 @@ export default function Posts() {
   const api = useApiClient();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { userId } = useAuth();
   const observerRef = useRef<IntersectionObserver | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -62,6 +68,17 @@ export default function Posts() {
     },
     [api, queryClient]
   );
+
+  const resolveMutation = useMutation({
+    mutationFn: (id: string) => api.updatePost(id, { status: "resolved" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
+      toast.success("解決済みにしました");
+    },
+    onError: () => {
+      toast.error("解決済みへの変更に失敗しました");
+    },
+  });
 
   useEffect(() => {
     if (!sentinelRef.current) return;
@@ -162,12 +179,24 @@ export default function Posts() {
 
                 {/* アクションボタン */}
                 <div className="flex items-center justify-between">
-                  <Link
-                    to={`/edit/${p.id}`}
-                    className="text-sm font-semibold text-primary hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded"
-                  >
-                    編集
-                  </Link>
+                  <div className="flex items-center gap-2">
+                    <Link
+                      to={`/edit/${p.id}`}
+                      className="text-sm font-semibold text-primary hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded"
+                    >
+                      編集
+                    </Link>
+                    {userId === p.userId && p.status === "lost" && (
+                      <button
+                        type="button"
+                        onClick={() => resolveMutation.mutate(p.id)}
+                        disabled={resolveMutation.isPending}
+                        className="text-sm font-semibold text-green-600 hover:text-green-700 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded"
+                      >
+                        解決済みにする
+                      </button>
+                    )}
+                  </div>
                   <div className="flex items-center gap-2">
                     <button
                       type="button"
@@ -192,7 +221,7 @@ export default function Posts() {
                             投稿を削除しますか？
                           </AlertDialogTitle>
                           <AlertDialogDescription>
-                            この操作は取り消せません。
+                            この操作は取り消せません。関連する会話と目撃情報も削除されます。
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>

--- a/apps/web/tests/playwright/create-post-map-flow.spec.ts
+++ b/apps/web/tests/playwright/create-post-map-flow.spec.ts
@@ -84,9 +84,13 @@ test("画像3枚で迷い猫投稿し、マーカークリックで登録内容�
   const createResponse = await createResponsePromise;
   expect(createResponse.ok()).toBeTruthy();
 
-  await expect(page).toHaveURL(`${baseUrl}/posts`);
+  await page.waitForURL(
+    (url) => {
+      return url.pathname === "/" && url.searchParams.get("lat") !== null;
+    },
+    { timeout: 10000 }
+  );
 
-  await page.goto(`${baseUrl}/`);
   await expect(
     page.getByRole("group", { name: "地図フィルター" })
   ).toBeVisible();

--- a/apps/web/tests/playwright/e2e.spec.ts
+++ b/apps/web/tests/playwright/e2e.spec.ts
@@ -92,8 +92,15 @@ test("basic E2E flow: register → login → create post → view posts", async 
     `create post failed: ${createResponse.status()} ${createResponse.statusText()}`
   ).toBeTruthy();
 
-  // The create form returns to the posts page, where the new item should appear.
-  await page.waitForURL(`${baseUrl}/posts`);
+  await page.waitForURL(
+    (url) => {
+      return url.pathname === "/" || url.pathname === "/posts";
+    },
+    { timeout: 10000 }
+  );
+
+  // Navigate to posts page to verify the post
+  await page.goto(`${baseUrl}/posts`, { waitUntil: "networkidle" });
 
   // 4. Verify post appears in list (pet name is shown as heading)
   await expect(

--- a/packages/api-client/openapi.json
+++ b/packages/api-client/openapi.json
@@ -1,6 +1,73 @@
 {
   "openapi": "3.0.0",
   "paths": {
+    "/api/auth/login": {
+      "post": {
+        "operationId": "AuthController_login",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessTokenResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "operationId": "AuthController_refresh",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessTokenResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "operationId": "AuthController_logout",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogoutResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["auth"]
+      }
+    },
     "/api/users": {
       "get": {
         "operationId": "UsersController_findAll",
@@ -517,73 +584,6 @@
         ]
       }
     },
-    "/api/auth/login": {
-      "post": {
-        "operationId": "AuthController_login",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LoginDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccessTokenResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["auth"]
-      }
-    },
-    "/api/auth/refresh": {
-      "post": {
-        "operationId": "AuthController_refresh",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccessTokenResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["auth"]
-      }
-    },
-    "/api/auth/logout": {
-      "post": {
-        "operationId": "AuthController_logout",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LogoutResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["auth"]
-      }
-    },
     "/api/map/markers": {
       "get": {
         "operationId": "MapController_getMarkers",
@@ -717,6 +717,38 @@
       }
     },
     "/api/sightings/{id}": {
+      "get": {
+        "operationId": "SightingsController_findOne",
+        "summary": "目撃情報の詳細を取得する",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "example": "00000000-0000-0000-0000-000000000002",
+              "type": "string"
+            },
+            "example": "00000000-0000-0000-0000-000000000002"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SightingResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "目撃情報が見つかりません"
+          }
+        },
+        "tags": ["sightings"]
+      },
       "delete": {
         "operationId": "SightingsController_remove",
         "summary": "目撃情報を削除する（本人または管理者）",
@@ -853,6 +885,36 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/ConversationListItemDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": ["conversations"],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/conversations/unread-count": {
+      "get": {
+        "operationId": "ConversationsController_getUnreadCount",
+        "summary": "未読メッセージの合計数を取得する",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "type": "number",
+                      "example": 3
+                    }
                   }
                 }
               }
@@ -1044,6 +1106,39 @@
       }
     },
     "schemas": {
+      "LoginDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": "seed-owner@finder.miyaoo.test"
+          },
+          "password": {
+            "type": "string",
+            "example": "Password123!",
+            "minLength": 8
+          }
+        },
+        "required": ["email", "password"]
+      },
+      "AccessTokenResponseDto": {
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          }
+        },
+        "required": ["accessToken"]
+      },
+      "LogoutResponseDto": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": ["ok"]
+      },
       "UserResponseDto": {
         "type": "object",
         "properties": {
@@ -1347,39 +1442,6 @@
         },
         "required": ["remainingSlots", "images"]
       },
-      "LoginDto": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": "seed-owner@finder.miyaoo.test"
-          },
-          "password": {
-            "type": "string",
-            "example": "Password123!",
-            "minLength": 8
-          }
-        },
-        "required": ["email", "password"]
-      },
-      "AccessTokenResponseDto": {
-        "type": "object",
-        "properties": {
-          "accessToken": {
-            "type": "string"
-          }
-        },
-        "required": ["accessToken"]
-      },
-      "LogoutResponseDto": {
-        "type": "object",
-        "properties": {
-          "ok": {
-            "type": "boolean"
-          }
-        },
-        "required": ["ok"]
-      },
       "MapMarkerDto": {
         "type": "object",
         "properties": {
@@ -1417,9 +1479,22 @@
             "type": "string",
             "example": "00000000-0000-0000-0000-000000000002"
           },
+          "postId": {
+            "type": "string",
+            "example": "00000000-0000-0000-0000-000000000000",
+            "nullable": true
+          },
           "userId": {
             "type": "string",
             "example": "10000000-0000-0000-0000-000000000002"
+          },
+          "lat": {
+            "type": "number",
+            "example": 35.8617
+          },
+          "lng": {
+            "type": "number",
+            "example": 139.6455
           },
           "address": {
             "type": "string",
@@ -1427,8 +1502,8 @@
             "nullable": true
           },
           "sightedAt": {
-            "format": "date-time",
             "type": "string",
+            "format": "date-time",
             "example": "2024-01-02T00:00:00.000Z"
           },
           "comment": {
@@ -1437,12 +1512,16 @@
             "nullable": true
           },
           "createdAt": {
-            "format": "date-time",
             "type": "string",
+            "format": "date-time",
             "example": "2024-01-02T00:00:00.000Z"
+          },
+          "nickname": {
+            "type": "string",
+            "example": "報告者ニックネーム"
           }
         },
-        "required": ["id", "userId", "sightedAt", "createdAt"]
+        "required": ["id", "userId", "lat", "lng", "sightedAt", "createdAt"]
       },
       "ConversationResponseDto": {
         "type": "object",
@@ -1515,6 +1594,10 @@
             "type": "string",
             "nullable": true
           },
+          "postStatus": {
+            "type": "string",
+            "nullable": true
+          },
           "partnerNickname": {
             "type": "string"
           },
@@ -1538,6 +1621,7 @@
           "sighterId",
           "createdAt",
           "postTitle",
+          "postStatus",
           "partnerNickname",
           "lastMessage",
           "unreadCount"

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -25,7 +25,9 @@ import {
   type ConversationsControllerCreateMessageBody,
   sightingsControllerCreate,
   sightingsControllerFindByPost,
+  sightingsControllerFindOne,
   sightingsControllerRemove,
+  conversationsControllerGetUnreadCount,
 } from "./index";
 
 export type CreateSightingInput = {
@@ -200,6 +202,14 @@ export function createClient(options: ClientOptions) {
     },
     markAsRead: async (id: string) => {
       await conversationsControllerMarkAsRead(id);
+    },
+    getUnreadCount: async () => {
+      const r = await conversationsControllerGetUnreadCount();
+      return r.data;
+    },
+    getSighting: async (id: string) => {
+      const r = await sightingsControllerFindOne(id);
+      return r.data;
     },
     createSighting: async (data: CreateSightingInput) => {
       const r = await sightingsControllerCreate(data);

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -12,6 +12,10 @@ export type ConversationsControllerCreateMessageBody = {
   body: string;
 };
 
+export type ConversationsControllerGetUnreadCount200 = {
+  count?: number;
+};
+
 export type ConversationsControllerCreateBody = {
   postId: string;
   sightingId: string;
@@ -139,6 +143,8 @@ export interface ConversationListItemDto {
   partnerNickname: string;
   postId: string;
   /** @nullable */
+  postStatus: string | null;
+  /** @nullable */
   postTitle: string | null;
   sighterId: string;
   sightingId: string;
@@ -161,6 +167,11 @@ export interface SightingResponseDto {
   comment?: string | null;
   createdAt: string;
   id: string;
+  lat: number;
+  lng: number;
+  nickname?: string;
+  /** @nullable */
+  postId?: string | null;
   sightedAt: string;
   userId: string;
 }
@@ -193,20 +204,6 @@ export interface MapMarkerDto {
   userId?: string;
 }
 
-export interface LogoutResponseDto {
-  ok: boolean;
-}
-
-export interface AccessTokenResponseDto {
-  accessToken: string;
-}
-
-export interface LoginDto {
-  email: string;
-  /** @minLength 8 */
-  password: string;
-}
-
 export interface AddImagesResponseDto {
   images: ImageResponseDto[];
   remainingSlots: number;
@@ -228,6 +225,16 @@ export type UpdatePostDtoPostType =
 export const UpdatePostDtoPostType = {
   cat: "cat",
 } as const;
+
+export interface UpdatePostDto {
+  description?: string;
+  location?: UpdateLocationDto;
+  lostDate?: string;
+  petDetail?: UpdatePetDetailDto;
+  postType?: UpdatePostDtoPostType;
+  status?: UpdatePostDtoStatus;
+  title?: string;
+}
 
 export type UpdateLocationDtoPrefecture =
   (typeof UpdateLocationDtoPrefecture)[keyof typeof UpdateLocationDtoPrefecture];
@@ -268,14 +275,9 @@ export interface UpdatePetDetailDto {
   size?: string;
 }
 
-export interface UpdatePostDto {
-  description?: string;
-  location?: UpdateLocationDto;
-  lostDate?: string;
-  petDetail?: UpdatePetDetailDto;
-  postType?: UpdatePostDtoPostType;
-  status?: UpdatePostDtoStatus;
-  title?: string;
+export interface PostListResponseDto {
+  items: PostResponseDto[];
+  total: number;
 }
 
 export type PostResponseDtoPostType =
@@ -325,11 +327,6 @@ export interface PostResponseDto {
   userId: string;
 }
 
-export interface PostListResponseDto {
-  items: PostResponseDto[];
-  total: number;
-}
-
 export interface LocationResponseDto {
   address: string;
   city: string;
@@ -365,6 +362,43 @@ export interface UserResponseDto {
   id: string;
   nickname: string;
 }
+
+export interface LogoutResponseDto {
+  ok: boolean;
+}
+
+export interface AccessTokenResponseDto {
+  accessToken: string;
+}
+
+export interface LoginDto {
+  email: string;
+  /** @minLength 8 */
+  password: string;
+}
+
+export const authControllerLogin = <
+  TData = AxiosResponse<AccessTokenResponseDto>,
+>(
+  loginDto: LoginDto,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/auth/login`, loginDto, options);
+};
+
+export const authControllerRefresh = <
+  TData = AxiosResponse<AccessTokenResponseDto>,
+>(
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/auth/refresh`, undefined, options);
+};
+
+export const authControllerLogout = <TData = AxiosResponse<LogoutResponseDto>>(
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.post(`/api/auth/logout`, undefined, options);
+};
 
 export const usersControllerFindAll = <
   TData = AxiosResponse<UserResponseDto[]>,
@@ -488,29 +522,6 @@ export const postsControllerToggleFavorite = <
   return axios.post(`/api/posts/${id}/favorite`, undefined, options);
 };
 
-export const authControllerLogin = <
-  TData = AxiosResponse<AccessTokenResponseDto>,
->(
-  loginDto: LoginDto,
-  options?: AxiosRequestConfig
-): Promise<TData> => {
-  return axios.post(`/api/auth/login`, loginDto, options);
-};
-
-export const authControllerRefresh = <
-  TData = AxiosResponse<AccessTokenResponseDto>,
->(
-  options?: AxiosRequestConfig
-): Promise<TData> => {
-  return axios.post(`/api/auth/refresh`, undefined, options);
-};
-
-export const authControllerLogout = <TData = AxiosResponse<LogoutResponseDto>>(
-  options?: AxiosRequestConfig
-): Promise<TData> => {
-  return axios.post(`/api/auth/logout`, undefined, options);
-};
-
 export const mapControllerGetMarkers = <TData = AxiosResponse<MapMarkerDto[]>>(
   params?: MapControllerGetMarkersParams,
   options?: AxiosRequestConfig
@@ -544,6 +555,18 @@ export const sightingsControllerFindByPost = <
     ...options,
     params: { ...params, ...options?.params },
   });
+};
+
+/**
+ * @summary 目撃情報の詳細を取得する
+ */
+export const sightingsControllerFindOne = <
+  TData = AxiosResponse<SightingResponseDto>,
+>(
+  id: string,
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/sightings/${id}`, options);
 };
 
 /**
@@ -593,6 +616,17 @@ export const conversationsControllerFindAll = <
   options?: AxiosRequestConfig
 ): Promise<TData> => {
   return axios.get(`/api/conversations`, options);
+};
+
+/**
+ * @summary 未読メッセージの合計数を取得する
+ */
+export const conversationsControllerGetUnreadCount = <
+  TData = AxiosResponse<ConversationsControllerGetUnreadCount200>,
+>(
+  options?: AxiosRequestConfig
+): Promise<TData> => {
+  return axios.get(`/api/conversations/unread-count`, options);
 };
 
 /**
@@ -650,6 +684,9 @@ export const conversationsControllerMarkAsRead = <TData = AxiosResponse<void>>(
   );
 };
 
+export type AuthControllerLoginResult = AxiosResponse<AccessTokenResponseDto>;
+export type AuthControllerRefreshResult = AxiosResponse<AccessTokenResponseDto>;
+export type AuthControllerLogoutResult = AxiosResponse<LogoutResponseDto>;
 export type UsersControllerFindAllResult = AxiosResponse<UserResponseDto[]>;
 export type UsersControllerRemoveResult = AxiosResponse<void>;
 export type UsersControllerRegisterResult = AxiosResponse<UserResponseDto>;
@@ -663,14 +700,13 @@ export type PostsControllerAddImagesResult =
 export type PostsControllerRemoveImageResult = AxiosResponse<ImageResponseDto>;
 export type PostsControllerToggleFavoriteResult =
   AxiosResponse<PostsControllerToggleFavorite201>;
-export type AuthControllerLoginResult = AxiosResponse<AccessTokenResponseDto>;
-export type AuthControllerRefreshResult = AxiosResponse<AccessTokenResponseDto>;
-export type AuthControllerLogoutResult = AxiosResponse<LogoutResponseDto>;
 export type MapControllerGetMarkersResult = AxiosResponse<MapMarkerDto[]>;
 export type SightingsControllerCreateResult = AxiosResponse<void>;
 export type SightingsControllerFindByPostResult = AxiosResponse<
   SightingResponseDto[]
 >;
+export type SightingsControllerFindOneResult =
+  AxiosResponse<SightingResponseDto>;
 export type SightingsControllerRemoveResult = AxiosResponse<void>;
 export type SightingsControllerToggleFavoriteResult =
   AxiosResponse<SightingsControllerToggleFavorite201>;
@@ -679,6 +715,8 @@ export type ConversationsControllerCreateResult =
 export type ConversationsControllerFindAllResult = AxiosResponse<
   ConversationListItemDto[]
 >;
+export type ConversationsControllerGetUnreadCountResult =
+  AxiosResponse<ConversationsControllerGetUnreadCount200>;
 export type ConversationsControllerFindOneResult =
   AxiosResponse<ConversationListItemDto>;
 export type ConversationsControllerCreateMessageResult =

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -193,6 +193,11 @@
 - [x] お気に入りが20件の状態でtoggleFavoriteを呼ぶと BadRequestException
 - [x] 存在しないSightingをお気に入りしようとすると NotFoundException
 
+#### findOne
+
+- [x] 指定IDの目撃情報を報告者のニックネーム付きで返すこと
+- [x] 存在しないIDを指定するとNotFoundExceptionを送出すること
+
 ---
 
 ### SightingsController (`src/sightings/sighting.controller.spec.ts`)
@@ -200,6 +205,11 @@
 #### create
 
 - [x] 目撃情報を作成してサービスの結果を返すこと
+
+#### findOne
+
+- [x] 指定IDの目撃詳細を返すこと
+- [x] NotFoundException を伝播する
 
 ### CreateSightingDto (`src/sightings/dto/create-sighting.dto.spec.ts`)
 
@@ -260,11 +270,22 @@
 - [x] 会話参加者以外のメッセージ一覧取得はForbiddenException
 - [x] 存在しない会話のメッセージ一覧はNotFoundException
 
+#### findOneForUser
+
+- [x] 投稿者が会話を取得すると相手は目撃者のニックネームであること
+- [x] 目撃者が会話を取得すると相手は投稿者のニックネームであること
+- [x] 参加者以外が会話を取得するとNotFoundException
+
 #### markAsRead
 
 - [x] 相手が送ったunreadメッセージをすべて既読にすること
 - [x] 会話参加者以外はForbiddenException
 - [x] 存在しない会話はNotFoundException
+
+#### getUnreadCount
+
+- [x] ユーザーの全未読メッセージ数を返すこと
+- [x] 未読メッセージがない場合は 0 を返すこと
 
 ---
 
@@ -305,6 +326,10 @@
 #### markAsRead
 
 - [x] 既読更新結果を返すこと
+
+#### getUnreadCount
+
+- [x] ユーザーの未読メッセージ数を返すこと
 
 ---
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -199,10 +199,17 @@ apps/api/src/
 │   │   │   ├── 会話参加者がメッセージ一覧を取得できること
 │   │   │   ├── 会話参加者以外のメッセージ一覧取得はForbiddenException
 │   │   │   └── 存在しない会話のメッセージ一覧はNotFoundException
-│   │   └── markAsRead
-│   │       ├── 相手が送ったunreadメッセージをすべて既読にすること
-│   │       ├── 会話参加者以外はForbiddenException
-│   │       └── 存在しない会話はNotFoundException
+│   │   ├── findOneForUser
+│   │   │   ├── 投稿者が会話を取得すると相手は目撃者のニックネームであること
+│   │   │   ├── 目撃者が会話を取得すると相手は投稿者のニックネームであること
+│   │   │   └── 参加者以外が会話を取得するとNotFoundException
+│   │   ├── markAsRead
+│   │   │   ├── 相手が送ったunreadメッセージをすべて既読にすること
+│   │   │   ├── 会話参加者以外はForbiddenException
+│   │   │   └── 存在しない会話はNotFoundException
+│   │   └── getUnreadCount
+│   │       ├── ユーザーの全未読メッセージ数を返すこと
+│   │       └── 未読メッセージがない場合は 0 を返すこと
 │   ├── conversations.gateway.spec.ts
 │   │   ├── handleConnection
 │   │   │   ├── トークンなしで接続した場合は切断される
@@ -223,8 +230,10 @@ apps/api/src/
 │       ├── createMessage
 │       │   ├── メッセージ作成後にbroadcastMessageを呼び出すこと
 │       │   └── サービスが例外を投げた場合はbroadcastMessageを呼ばないこと
-│       └── markAsRead
-│           └── 既読更新結果を返すこと
+│       ├── markAsRead
+│       │   └── 既読更新結果を返すこと
+│       └── getUnreadCount
+│           └── ユーザーの未読メッセージ数を返すこと
 ├── sightings/
 │   ├── dto/
 │   │   └── create-sighting.dto.spec.ts
@@ -240,6 +249,9 @@ apps/api/src/
 │   │   │   └── 存在しないPostにSightingを作成しようとすると NotFoundException
 │   │   ├── findByPost
 │   │   │   └── postIdに紐づくSighting一覧をcreatedAt降順で返すこと
+│   │   ├── findOne
+│   │   │   ├── 指定IDの目撃情報を報告者のニックネーム付きで返すこと
+│   │   │   └── 存在しないIDを指定するとNotFoundExceptionを送出すること
 │   │   ├── remove
 │   │   │   ├── 本人がSightingを削除できること
 │   │   │   ├── 他者が削除しようとすると ForbiddenException
@@ -251,6 +263,16 @@ apps/api/src/
 │   │       ├── お気に入りが20件の状態でtoggleFavoriteを呼ぶと BadRequestException
 │   │       └── 存在しないSightingをお気に入りしようとすると NotFoundException
 │   └── sighting.controller.spec.ts
+│       ├── create
+│       │   └── 目撃情報を作成してサービスの結果を返すこと
+│       ├── findByPost
+│       │   └── postIdに紐づく目撃情報一覧を返すこと
+│       ├── findOne
+│       │   ├── 指定IDの目撃詳細を返すこと
+│       │   └── NotFoundException を伝播する
+│       ├── remove
+│       │   ├── 目撃情報を削除してサービスの結果を返すこと
+│       │   └── ForbiddenException を伝播する
 │       └── toggleFavorite
 │           ├── { favorited: true } を返す
 │           ├── { favorited: false } を返す（解除）


### PR DESCRIPTION
## Summary
- #124 UI: PostDetailSheetに目撃詳細表示セクションを追加（住所/日時/コメント/報告者）
- #125: 目撃フォームUX改善（トースト/座標readonly/フィールド単位バリデーション）
- #126: 投稿解決フロー（解決ボタン/会話バナー/削除警告/投稿後マップ遷移）
- #127: 未読バッジ+SightingList会話ボタン

## 含まれる変更
- API: ConversationResponseDto に postStatus 追加
- API client: getSighting / getUnreadCount メソッド追加
- OpenAPI spec 再生成
- E2Eテスト修正（投稿後遷移先変更に対応）
- 全テスト通過: API 216件 / Web 167件 / E2E 54件

## 関連Issue
- closes #124
- closes #125
- closes #126
- closes #127