### PR TITLE
fix: issue#138 ENCRYPTION_KEYの導出をbase64単一化 + 起動時検証

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,8 +4,8 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nestjs_dev"
 # JWT
 JWT_SECRET="change-me-in-production"
 
-# Encryption (32 bytes base64/hex/utf8)
-ENCRYPTION_KEY="change-me-to-32-byte-base64-string"
+# Encryption (base64 エンコードされた 32 バイトのキー。生成方法: openssl rand -base64 32)
+ENCRYPTION_KEY=""
 HMAC_SECRET="change-me-hmac-in-production"
 
 # App

--- a/apps/api/src/identity/crypto.service.spec.ts
+++ b/apps/api/src/identity/crypto.service.spec.ts
@@ -116,4 +116,46 @@ describe("CryptoService", () => {
       expect(t1).not.toBe(t2);
     });
   });
+
+  describe("deriveEncryptionKey (ENCRYPTION_KEY バリデーション)", () => {
+    function makeConfigWithKey(key: string) {
+      return {
+        get: jest.fn((k: string) => (k === "ENCRYPTION_KEY" ? key : undefined)),
+        getOrThrow: jest.fn((k: string) => {
+          if (k === "ENCRYPTION_KEY") return key;
+          if (k === "HMAC_SECRET") return TEST_HMAC;
+          throw new Error(`Config key ${k} not found`);
+        }),
+      } as unknown as ConfigService;
+    }
+
+    it("32バイト未満のbase64キーはエラーになること", () => {
+      const shortKey = Buffer.alloc(16, 0xab).toString("base64");
+      const svc = new CryptoService(makeConfigWithKey(shortKey));
+      expect(() => svc.encryptEmail("test@example.com")).toThrow(/32 バイト/);
+    });
+
+    it("32バイト超のbase64キーはエラーになること", () => {
+      const longKey = Buffer.alloc(40, 0xab).toString("base64");
+      const svc = new CryptoService(makeConfigWithKey(longKey));
+      expect(() => svc.encryptEmail("test@example.com")).toThrow(/32 バイト/);
+    });
+
+    it("base64でない文字列（utf8平文）はエラーになること", () => {
+      const svc = new CryptoService(makeConfigWithKey("password"));
+      expect(() => svc.encryptEmail("test@example.com")).toThrow(/32 バイト/);
+    });
+
+    it("正しい32バイトbase64キーは正常に動作すること", () => {
+      const svc = new CryptoService(makeConfigWithKey(TEST_KEY_B64));
+      const enc = svc.encryptEmail("test@example.com");
+      expect(svc.decryptEmail(enc)).toBe("test@example.com");
+    });
+
+    it("onModuleInit で不正キーがあれば起動時にエラーになること", () => {
+      const shortKey = Buffer.alloc(10, 0xab).toString("base64");
+      const svc = new CryptoService(makeConfigWithKey(shortKey));
+      expect(() => svc.onModuleInit()).toThrow(/32 バイト/);
+    });
+  });
 });

--- a/apps/api/src/identity/crypto.service.ts
+++ b/apps/api/src/identity/crypto.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, OnModuleInit } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import * as crypto from "crypto";
 
 @Injectable()
-export class CryptoService {
+export class CryptoService implements OnModuleInit {
   constructor(private readonly config: ConfigService) {}
+
+  onModuleInit(): void {
+    this.deriveEncryptionKey();
+  }
 
   normalizeEmail(email: string): string {
     return email.toLowerCase().trim();
@@ -51,12 +55,13 @@ export class CryptoService {
 
   private deriveEncryptionKey(): Buffer {
     const raw = this.config.getOrThrow<string>("ENCRYPTION_KEY");
-    let buf = Buffer.from(raw, "base64");
-    if (buf.length === 32) return buf;
-    buf = Buffer.from(raw, "hex");
-    if (buf.length === 32) return buf;
-    buf = Buffer.from(raw, "utf8");
-    if (buf.length >= 32) return buf.slice(0, 32);
-    throw new Error("ENCRYPTION_KEY must decode to 32 bytes (base64/hex/utf8)");
+    const buf = Buffer.from(raw, "base64");
+    if (buf.length !== 32) {
+      throw new Error(
+        `ENCRYPTION_KEY は base64 エンコードされた 32 バイトのキーである必要があります（現在: ${buf.length} バイト）。` +
+          "生成方法: openssl rand -base64 32"
+      );
+    }
+    return buf;
   }
 }

--- a/apps/api/src/utils/crypto.ts
+++ b/apps/api/src/utils/crypto.ts
@@ -7,15 +7,16 @@ export function normalizeEmail(email: string): string {
 function deriveEncryptionKey(): Buffer {
   const raw = process.env.ENCRYPTION_KEY;
   if (!raw) {
-    throw new Error("ENCRYPTION_KEY is not set");
+    throw new Error("ENCRYPTION_KEY が設定されていません");
   }
-  let buf = Buffer.from(raw, "base64");
-  if (buf.length === 32) return buf;
-  buf = Buffer.from(raw, "hex");
-  if (buf.length === 32) return buf;
-  buf = Buffer.from(raw, "utf8");
-  if (buf.length >= 32) return buf.slice(0, 32);
-  throw new Error("ENCRYPTION_KEY must decode to 32 bytes (base64/hex/utf8)");
+  const buf = Buffer.from(raw, "base64");
+  if (buf.length !== 32) {
+    throw new Error(
+      `ENCRYPTION_KEY は base64 エンコードされた 32 バイトのキーである必要があります（現在: ${buf.length} バイト）。` +
+        "生成方法: openssl rand -base64 32"
+    );
+  }
+  return buf;
 }
 
 export function encryptEmail(plain: string): string {


### PR DESCRIPTION
## Summary
- `deriveEncryptionKey()` を `Buffer.from(raw, 'base64')` 一択に変更（base64/hex/utf8の試行錯誤を廃止）
- 32バイト以外のキーは `OnModuleInit` で起動時にエラーを投げて fail-fast
- `.env.example` に `openssl rand -base64 32` による生成方法を明記

## Test plan
- [ ] 32バイト未満のbase64キーでエラーになること
- [ ] 32バイト超のbase64キーでエラーになること
- [ ] utf8平文（例: "password"）でエラーになること
- [ ] 正しい32バイトbase64キーで暗号化・復号が正常動作すること
- [ ] `onModuleInit` で不正キーがあれば起動時にエラーになること

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)