### PR TITLE
feat: issue#139 RefreshTokenのDBハッシュ化（SHA-256）

### DIFF
--- a/apps/api/prisma/migrations/20260501000000_hash_refresh_token/migration.sql
+++ b/apps/api/prisma/migrations/20260501000000_hash_refresh_token/migration.sql
@@ -1,0 +1,5 @@
+-- RefreshTokenを全削除（平文トークンはハッシュに移行不可のため全ユーザー再ログイン必須）
+DELETE FROM "RefreshToken";
+
+-- カラム名変更: token -> tokenHash
+ALTER TABLE "RefreshToken" RENAME COLUMN "token" TO "tokenHash";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -187,7 +187,7 @@ model SightingFavorite {
 
 model RefreshToken {
   id        String   @id @default(cuid())
-  token     String   @unique
+  tokenHash String   @unique
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId    String
   createdAt DateTime @default(now())

--- a/apps/api/src/identity/identity.service.spec.ts
+++ b/apps/api/src/identity/identity.service.spec.ts
@@ -41,7 +41,7 @@ const mockCrypto = {
   encryptEmail: jest.fn().mockReturnValue("encrypted-email"),
   decryptEmail: jest.fn().mockReturnValue("user@example.com"),
   hmacEmail: jest.fn().mockReturnValue("hmac-hash"),
-  sha256Hex: jest.fn().mockReturnValue("sha256-hash"),
+  sha256Hex: jest.fn().mockReturnValue("token-hash"),
   generateSecureToken: jest.fn().mockReturnValue("a".repeat(96)),
 };
 
@@ -85,6 +85,20 @@ describe("IdentityService", () => {
       expect(result.setCookies[0].value).toBe("a".repeat(96));
       expect(result.setCookies[0].options.httpOnly).toBe(true);
       expect(result.setCookies[0].options.sameSite).toBe("lax");
+    });
+
+    it("DBにはtokenHashが保存され、平文トークンは保存されないこと", async () => {
+      const user = await makeUser();
+      mockPrisma.user.findUnique.mockResolvedValueOnce(user);
+      mockPrisma.refreshToken.create.mockResolvedValueOnce({});
+
+      const result = await service.login("user@example.com", "password123");
+      const plainToken = result.setCookies[0].value;
+
+      const createCall = mockPrisma.refreshToken.create.mock.calls[0][0];
+      expect(createCall.data.tokenHash).toBe("token-hash");
+      expect(createCall.data).not.toHaveProperty("token");
+      expect(createCall.data.tokenHash).not.toBe(plainToken);
     });
 
     it("パスワード不一致でUnauthorizedExceptionを投げること", async () => {
@@ -149,7 +163,7 @@ describe("IdentityService", () => {
     it("有効なトークンで新しいAuthResultを返すこと", async () => {
       const ts = new Date(Date.now() + 86400000);
       mockPrisma.refreshToken.findUnique.mockResolvedValueOnce({
-        token: "old-refresh-token",
+        tokenHash: "token-hash",
         userId: "user-1",
         expiresAt: ts,
         user: { emailEncrypted: "enc-email", role: "user" },
@@ -160,8 +174,27 @@ describe("IdentityService", () => {
 
       expect(result.accessToken).toBe("access-token-jwt");
       expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({
-        where: { token: "old-refresh-token" },
+        where: { tokenHash: "token-hash" },
       });
+    });
+
+    it("ローテーション: 新しいトークンのハッシュがDBに保存されること", async () => {
+      const ts = new Date(Date.now() + 86400000);
+      mockPrisma.refreshToken.findUnique.mockResolvedValueOnce({
+        tokenHash: "token-hash",
+        userId: "user-1",
+        expiresAt: ts,
+        user: { emailEncrypted: "enc-email", role: "user" },
+      });
+      mockPrisma.refreshToken.create.mockResolvedValueOnce({});
+
+      const result = await service.refresh("old-refresh-token");
+      const newPlainToken = result.setCookies[0].value;
+
+      const createCall = mockPrisma.refreshToken.create.mock.calls[0][0];
+      expect(createCall.data.tokenHash).toBe("token-hash");
+      expect(createCall.data).not.toHaveProperty("token");
+      expect(createCall.data.tokenHash).not.toBe(newPlainToken);
     });
 
     it("トークンが存在しない場合はUnauthorizedExceptionを投げること", async () => {
@@ -174,7 +207,7 @@ describe("IdentityService", () => {
 
     it("期限切れトークンはUnauthorizedExceptionを投げること", async () => {
       mockPrisma.refreshToken.findUnique.mockResolvedValueOnce({
-        token: "old-token",
+        tokenHash: "token-hash",
         userId: "user-1",
         expiresAt: new Date(Date.now() - 1000),
       });
@@ -183,16 +216,33 @@ describe("IdentityService", () => {
         UnauthorizedException
       );
     });
+
+    it("再利用検知: delete失敗時にUnauthorizedExceptionを投げること", async () => {
+      const ts = new Date(Date.now() + 86400000);
+      mockPrisma.refreshToken.findUnique.mockResolvedValueOnce({
+        tokenHash: "token-hash",
+        userId: "user-1",
+        expiresAt: ts,
+        user: { emailEncrypted: "enc-email", role: "user" },
+      });
+      mockPrisma.refreshToken.delete.mockRejectedValueOnce(
+        new Error("already deleted")
+      );
+
+      await expect(service.refresh("old-refresh-token")).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
   });
 
   describe("logout", () => {
-    it("リフレッシュトークンを削除すること", async () => {
+    it("リフレッシュトークンをハッシュで削除すること", async () => {
       mockPrisma.refreshToken.delete.mockResolvedValueOnce({});
 
       await service.logout("some-token");
 
       expect(mockPrisma.refreshToken.delete).toHaveBeenCalledWith({
-        where: { token: "some-token" },
+        where: { tokenHash: "token-hash" },
       });
     });
 

--- a/apps/api/src/identity/identity.service.ts
+++ b/apps/api/src/identity/identity.service.ts
@@ -70,9 +70,10 @@ export class IdentityService extends IIdentityService {
       throw new UnauthorizedException("認証情報が正しくありません");
     }
     const refreshToken = this.crypto.generateSecureToken();
+    const tokenHash = this.crypto.sha256Hex(refreshToken);
     await this.prisma.refreshToken.create({
       data: {
-        token: refreshToken,
+        tokenHash,
         userId: user.id,
         expiresAt: new Date(Date.now() + 60 * 60 * 24 * 30 * 1000),
       },
@@ -90,8 +91,9 @@ export class IdentityService extends IIdentityService {
   }
 
   async refresh(cookieToken: string): Promise<AuthResult> {
+    const tokenHash = this.crypto.sha256Hex(cookieToken);
     const rec = await this.prisma.refreshToken.findUnique({
-      where: { token: cookieToken },
+      where: { tokenHash },
       include: { user: { select: { emailEncrypted: true, role: true } } },
     });
     if (!rec || rec.expiresAt <= new Date()) {
@@ -99,15 +101,16 @@ export class IdentityService extends IIdentityService {
     }
     try {
       await this.prisma.refreshToken.delete({
-        where: { token: cookieToken },
+        where: { tokenHash },
       });
     } catch {
       throw new UnauthorizedException("無効なリフレッシュトークンです");
     }
     const newToken = this.crypto.generateSecureToken();
+    const newHash = this.crypto.sha256Hex(newToken);
     await this.prisma.refreshToken.create({
       data: {
-        token: newToken,
+        tokenHash: newHash,
         userId: rec.userId,
         expiresAt: new Date(Date.now() + 60 * 60 * 24 * 30 * 1000),
       },
@@ -125,9 +128,10 @@ export class IdentityService extends IIdentityService {
   }
 
   async logout(cookieToken: string): Promise<void> {
+    const tokenHash = this.crypto.sha256Hex(cookieToken);
     try {
       await this.prisma.refreshToken.delete({
-        where: { token: cookieToken },
+        where: { tokenHash },
       });
     } catch {
       // ignore


### PR DESCRIPTION
## Summary
- `RefreshToken.token` → `tokenHash` にカラム名変更（ハッシュ値のみ保存）
- Cookie には平文トークンを返し、DB には `sha256Hex(token)` のみ保存
- refresh/logout 時は Cookie の平文をハッシュ化してDB検索・削除
- マイグレーションで既存トークンを全削除（DB流出時の平文混在を防ぐため）

## ⚠️ 破壊的変更
マイグレーション実行時に全 RefreshToken を削除します。全ユーザーが再ログイン必要になります。

## Test plan
- [ ] ログイン後、DBに保存されるのは `tokenHash`（平文でないこと）
- [ ] 有効なトークンでリフレッシュが成功すること
- [ ] ローテーション後、新しいトークンのハッシュがDBに保存されること
- [ ] 再利用検知: delete失敗時に 401 を返すこと
- [ ] 期限切れトークンで 401 を返すこと
- [ ] ログアウト時にハッシュでDB削除されること

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)