### PR TITLE
chore: issue#142 SHA256 → HMAC emailHash 移行マイグレ + フォールバック削除

### DIFF
--- a/apps/api/scripts/migrate-email-hash.ts
+++ b/apps/api/scripts/migrate-email-hash.ts
@@ -1,0 +1,60 @@
+/**
+ * SHA256 emailHash → HMAC 移行スクリプト
+ *
+ * 使い方:
+ *   npx ts-node scripts/migrate-email-hash.ts           # 本番実行
+ *   npx ts-node scripts/migrate-email-hash.ts --dry-run # 確認のみ（DB変更なし）
+ *
+ * 事前準備:
+ *   1. DBのフルバックアップを取得すること
+ *      pg_dump $DATABASE_URL > backup_$(date +%Y%m%d_%H%M%S).sql
+ *   2. .env に ENCRYPTION_KEY と HMAC_SECRET が設定されていること
+ */
+
+import "reflect-metadata";
+import { config } from "dotenv";
+import * as path from "path";
+import { PrismaClient } from "@prisma/client";
+import { ConfigService } from "@nestjs/config";
+import { CryptoService } from "../src/identity/crypto.service";
+import { migrateEmailHashToHmac } from "../src/identity/email-hash-migration";
+
+config({ path: path.resolve(__dirname, "../.env") });
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+
+  if (dryRun) {
+    console.log("[dry-run] DBは更新されません。確認のみ実行します。");
+  }
+
+  const prisma = new PrismaClient();
+  const configService = new ConfigService();
+  const cryptoService = new CryptoService(configService);
+  cryptoService.onModuleInit();
+
+  try {
+    const result = await migrateEmailHashToHmac(prisma, cryptoService, {
+      dryRun,
+    });
+    console.log("マイグレーション完了:");
+    console.log(`  合計     : ${result.total}`);
+    console.log(`  更新済み : ${result.migrated}`);
+    console.log(`  スキップ : ${result.skipped}`);
+    console.log(`  エラー   : ${result.errors}`);
+
+    if (result.errors > 0) {
+      console.warn(
+        "一部ユーザーの移行に失敗しました。ログを確認してください。"
+      );
+      process.exit(1);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/api/src/identity/email-hash-migration.spec.ts
+++ b/apps/api/src/identity/email-hash-migration.spec.ts
@@ -1,0 +1,170 @@
+import { migrateEmailHashToHmac } from "./email-hash-migration";
+
+const mockCrypto = {
+  normalizeEmail: jest.fn((e: string) => e.toLowerCase().trim()),
+  decryptEmail: jest.fn(),
+  hmacEmail: jest.fn(),
+};
+
+function makePrisma(users: unknown[] = []) {
+  return {
+    user: {
+      findMany: jest.fn().mockResolvedValue(users),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+describe("migrateEmailHashToHmac", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("基本動作", () => {
+    it("ユーザーが0件の時、全カウントが0の結果を返すこと", async () => {
+      const prisma = makePrisma([]);
+
+      const result = await migrateEmailHashToHmac(
+        prisma as any,
+        mockCrypto as any
+      );
+
+      expect(result).toEqual({ total: 0, migrated: 0, skipped: 0, errors: 0 });
+    });
+  });
+
+  describe("HMACへの更新", () => {
+    it("SHA256ハッシュのユーザーがHMACに更新されること", async () => {
+      const sha256Hash = "a".repeat(64);
+      const hmacHash = "b".repeat(64);
+      const users = [
+        {
+          id: "user-1",
+          emailEncrypted: "enc-email",
+          emailHash: sha256Hash,
+        },
+      ];
+      const prisma = makePrisma(users);
+      mockCrypto.decryptEmail.mockReturnValue("user@example.com");
+      mockCrypto.hmacEmail.mockReturnValue(hmacHash);
+
+      const result = await migrateEmailHashToHmac(
+        prisma as any,
+        mockCrypto as any
+      );
+
+      expect(result.migrated).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: { emailHash: hmacHash },
+      });
+    });
+
+    it("既にHMACのユーザーはスキップされること（冪等）", async () => {
+      const hmacHash = "c".repeat(64);
+      const users = [
+        {
+          id: "user-2",
+          emailEncrypted: "enc-email",
+          emailHash: hmacHash,
+        },
+      ];
+      const prisma = makePrisma(users);
+      mockCrypto.decryptEmail.mockReturnValue("user@example.com");
+      mockCrypto.hmacEmail.mockReturnValue(hmacHash); // 同じハッシュ
+
+      const result = await migrateEmailHashToHmac(
+        prisma as any,
+        mockCrypto as any
+      );
+
+      expect(result.migrated).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dry-runモード", () => {
+    it("dry-runの時、DBを更新せず結果のみ返すこと", async () => {
+      const users = [
+        {
+          id: "user-1",
+          emailEncrypted: "enc-email",
+          emailHash: "sha256-hash",
+        },
+      ];
+      const prisma = makePrisma(users);
+      mockCrypto.decryptEmail.mockReturnValue("user@example.com");
+      mockCrypto.hmacEmail.mockReturnValue("hmac-hash");
+
+      const result = await migrateEmailHashToHmac(
+        prisma as any,
+        mockCrypto as any,
+        { dryRun: true }
+      );
+
+      expect(result.migrated).toBe(1);
+      expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("スキップケース", () => {
+    it("emailEncryptedがnullのユーザーはスキップされること", async () => {
+      const users = [
+        { id: "user-3", emailEncrypted: null, emailHash: "any-hash" },
+      ];
+      const prisma = makePrisma(users);
+
+      const result = await migrateEmailHashToHmac(
+        prisma as any,
+        mockCrypto as any
+      );
+
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toBe(0);
+      expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it("復号に失敗したユーザーはエラーカウントされること", async () => {
+      const users = [
+        { id: "user-4", emailEncrypted: "broken-enc", emailHash: "any-hash" },
+      ];
+      const prisma = makePrisma(users);
+      mockCrypto.decryptEmail.mockReturnValue(null); // 復号失敗
+
+      const result = await migrateEmailHashToHmac(
+        prisma as any,
+        mockCrypto as any
+      );
+
+      expect(result.errors).toBe(1);
+      expect(result.migrated).toBe(0);
+      expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("複数ユーザー混在", () => {
+    it("SHA256・HMAC済み・null混在の時、それぞれ正しくカウントされること", async () => {
+      const hmacHash = "hmac".repeat(16);
+      const users = [
+        { id: "u1", emailEncrypted: "enc1", emailHash: "sha256-hash" }, // 要更新
+        { id: "u2", emailEncrypted: "enc2", emailHash: hmacHash }, // スキップ
+        { id: "u3", emailEncrypted: null, emailHash: "any" }, // スキップ
+      ];
+      const prisma = makePrisma(users);
+      mockCrypto.decryptEmail.mockReturnValue("user@example.com");
+      mockCrypto.hmacEmail
+        .mockReturnValueOnce(hmacHash + "x") // u1: 異なるのでmigrate
+        .mockReturnValueOnce(hmacHash); // u2: 同じのでskip
+
+      const result = await migrateEmailHashToHmac(
+        prisma as any,
+        mockCrypto as any
+      );
+
+      expect(result.total).toBe(3);
+      expect(result.migrated).toBe(1);
+      expect(result.skipped).toBe(2);
+      expect(result.errors).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/identity/email-hash-migration.ts
+++ b/apps/api/src/identity/email-hash-migration.ts
@@ -1,0 +1,82 @@
+export interface MigrationResult {
+  total: number;
+  migrated: number;
+  skipped: number;
+  errors: number;
+}
+
+export interface MigrationOptions {
+  dryRun?: boolean;
+}
+
+interface MigrationCrypto {
+  normalizeEmail(email: string): string;
+  decryptEmail(encrypted: string): string | null;
+  hmacEmail(normalized: string): string;
+}
+
+interface MigrationPrisma {
+  user: {
+    findMany(args: { select: Record<string, boolean> }): Promise<
+      Array<{
+        id: string;
+        emailEncrypted: string | null;
+        emailHash: string | null;
+      }>
+    >;
+    update(args: {
+      where: { id: string };
+      data: { emailHash: string };
+    }): Promise<unknown>;
+  };
+}
+
+export async function migrateEmailHashToHmac(
+  prisma: MigrationPrisma,
+  crypto: MigrationCrypto,
+  options: MigrationOptions = {}
+): Promise<MigrationResult> {
+  const { dryRun = false } = options;
+  const result: MigrationResult = {
+    total: 0,
+    migrated: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const users = await prisma.user.findMany({
+    select: { id: true, emailEncrypted: true, emailHash: true },
+  });
+  result.total = users.length;
+
+  for (const user of users) {
+    if (!user.emailEncrypted) {
+      result.skipped++;
+      continue;
+    }
+
+    const plain = crypto.decryptEmail(user.emailEncrypted);
+    if (!plain) {
+      result.errors++;
+      continue;
+    }
+
+    const normalized = crypto.normalizeEmail(plain);
+    const hmac = crypto.hmacEmail(normalized);
+
+    if (user.emailHash === hmac) {
+      result.skipped++;
+      continue;
+    }
+
+    if (!dryRun) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { emailHash: hmac },
+      });
+    }
+    result.migrated++;
+  }
+
+  return result;
+}

--- a/apps/api/src/identity/identity.service.spec.ts
+++ b/apps/api/src/identity/identity.service.spec.ts
@@ -118,15 +118,13 @@ describe("IdentityService", () => {
       );
     });
 
-    it("SHA256フォールバック: HMACで見つからなければSHA256で再検索すること", async () => {
+    it("HMACのみで検索し、SHA256フォールバックを行わないこと", async () => {
       const user = await makeUser();
-      mockPrisma.user.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(user);
+      mockPrisma.user.findUnique.mockResolvedValueOnce(user);
 
       await service.login("user@example.com", "password123");
 
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(1);
     });
 
     it("production環境ではCookieのsecureとsameSiteが適切に設定されること", async () => {

--- a/apps/api/src/identity/identity.service.ts
+++ b/apps/api/src/identity/identity.service.ts
@@ -61,7 +61,7 @@ export class IdentityService extends IIdentityService {
   async login(email: string, password: string): Promise<AuthResult> {
     const normalized = this.crypto.normalizeEmail(email);
     const hmac = this.crypto.hmacEmail(normalized);
-    const user = await this.findUserByHash(hmac, normalized);
+    const user = await this.findUserByHash(hmac);
     if (!user) {
       throw new UnauthorizedException("認証情報が正しくありません");
     }
@@ -222,27 +222,16 @@ export class IdentityService extends IIdentityService {
     };
   }
 
-  private async findUserByHash(
-    hmac: string,
-    normalized: string
-  ): Promise<{
+  private async findUserByHash(hmac: string): Promise<{
     id: string;
     password: string;
     emailEncrypted: string;
     role: string;
   } | null> {
-    let user = await this.prisma.user.findUnique({
+    return this.prisma.user.findUnique({
       where: { emailHash: hmac },
       select: { id: true, password: true, emailEncrypted: true, role: true },
     });
-    if (!user) {
-      const sha = this.crypto.sha256Hex(normalized);
-      user = await this.prisma.user.findUnique({
-        where: { emailHash: sha },
-        select: { id: true, password: true, emailEncrypted: true, role: true },
-      });
-    }
-    return user;
   }
 
   private decryptSafely(encrypted: string | null): string | null {

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -368,9 +368,10 @@
 #### login
 
 - [x] 正しいメールとパスワードでAuthResultを返すこと
+- [x] DBにはtokenHashが保存され、平文トークンは保存されないこと
 - [x] パスワード不一致でUnauthorizedExceptionを投げること
 - [x] 存在しないメールアドレスでUnauthorizedExceptionを投げること
-- [x] SHA256フォールバック: HMACで見つからなければSHA256で再検索すること
+- [x] HMACのみで検索し、SHA256フォールバックを行わないこと
 - [x] production環境ではCookieのsecureとsameSiteが適切に設定されること
 
 #### refresh
@@ -397,6 +398,32 @@
 #### deleteUser
 
 - [x] ユーザーを削除しUserDtoを返すこと
+
+### emailHashマイグレーション (`src/identity/email-hash-migration.spec.ts`)
+
+#### 基本動作
+
+- [x] ユーザーが0件の時、全カウントが0の結果を返すこと
+
+#### HMACへの更新
+
+- [x] SHA256ハッシュのユーザーがHMACに更新されること
+- [x] 既にHMACのユーザーはスキップされること（冪等）
+
+#### dry-runモード
+
+- [x] dry-runの時、DBを更新せず結果のみ返すこと
+
+#### スキップケース
+
+- [x] emailEncryptedがnullのユーザーはスキップされること
+- [x] 復号に失敗したユーザーはエラーカウントされること
+
+#### 複数ユーザー混在
+
+- [x] SHA256・HMAC済み・null混在の時、それぞれ正しくカウントされること
+
+---
 
 ### CryptoService (`src/identity/crypto.service.spec.ts`)
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -18,13 +18,28 @@ apps/api/src/
 │       └── AppThrottlerGuard
 │           └── 制限超過時に日本語メッセージ付き ThrottlerException をスローすること
 ├── identity/
+│   ├── email-hash-migration.spec.ts
+│   │   └── migrateEmailHashToHmac
+│   │       ├── 基本動作
+│   │       │   └── ユーザーが0件の時、全カウントが0の結果を返すこと
+│   │       ├── HMACへの更新
+│   │       │   ├── SHA256ハッシュのユーザーがHMACに更新されること
+│   │       │   └── 既にHMACのユーザーはスキップされること（冪等）
+│   │       ├── dry-runモード
+│   │       │   └── dry-runの時、DBを更新せず結果のみ返すこと
+│   │       ├── スキップケース
+│   │       │   ├── emailEncryptedがnullのユーザーはスキップされること
+│   │       │   └── 復号に失敗したユーザーはエラーカウントされること
+│   │       └── 複数ユーザー混在
+│   │           └── SHA256・HMAC済み・null混在の時、それぞれ正しくカウントされること
 │   ├── identity.service.spec.ts
 │   │   └── IdentityService
 │   │       ├── login
 │   │       │   ├── 正しいメールとパスワードでAuthResultを返すこと
+│   │       │   ├── DBにはtokenHashが保存され、平文トークンは保存されないこと
 │   │       │   ├── パスワード不一致でUnauthorizedExceptionを投げること
 │   │       │   ├── 存在しないメールアドレスでUnauthorizedExceptionを投げること
-│   │       │   ├── SHA256フォールバック: HMACで見つからなければSHA256で再検索すること
+│   │       │   ├── HMACのみで検索し、SHA256フォールバックを行わないこと
 │   │       │   └── production環境ではCookieのsecureとsameSiteが適切に設定されること
 │   │       ├── refresh
 │   │       │   ├── 有効なトークンで新しいAuthResultを返すこと


### PR DESCRIPTION
## Summary

- `apps/api/src/identity/email-hash-migration.ts` — 全ユーザーの `emailHash` を SHA256 → HMAC に再計算する純粋関数を追加
  - 冪等（既にHMACなら再計算スキップ）
  - `--dry-run` モード対応（DB変更なし）
  - emailEncrypted が null / 復号失敗のユーザーは安全にスキップ
- `apps/api/scripts/migrate-email-hash.ts` — CLIエントリポイント（`npx ts-node scripts/migrate-email-hash.ts [--dry-run]`）
- `apps/api/src/identity/identity.service.ts` — `findUserByHash` の SHA256 フォールバック分岐を削除
- `apps/api/src/identity/identity.service.spec.ts` — フォールバックテストを「HMACのみで検索すること」に差し替え

## Test plan

- [x] `migrateEmailHashToHmac` ユニットテスト 7件パス（基本動作・更新・冪等・dry-run・スキップ・混在）
- [x] `IdentityService` ユニットテスト 18件パス
- [x] 全APIテスト 232件パス
- [x] 全Webテスト 167件パス

## 本番適用手順（HITL）

1. `pg_dump $DATABASE_URL > backup_$(date +%Y%m%d_%H%M%S).sql`
2. `npx ts-node scripts/migrate-email-hash.ts --dry-run` で確認
3. `npx ts-node scripts/migrate-email-hash.ts` で適用
4. エラーが 0 件であることを確認してからマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)