### PR TITLE
chore: apps/web に test:run スクリプトを追加

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
+    "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "test:e2e": "npx playwright test --project=chromium --reporter=list"
   },


### PR DESCRIPTION
## Summary
- ルートの `npm run test:web` が `npm run test:run --workspace=apps/web` を呼び出すが、`apps/web/package.json` に `test:run` スクリプトが未定義だった
- `vitest run`（watchなし一回実行）を `test:run` として追加し、ルートからのテスト実行を完結させる

## Test plan
- [ ] `npm run test` をルートで実行してフロントエンド・バックエンド両方のテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)