### PR TITLE
feat: issue#140 WebSocket接続維持中のJWT期限再検証

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md
+
+Kilo エージェント用プロジェクトガイダンス。CLAUDE.md と内容は共通だが、並列タスク競合回避ルールの参照先が異なる。
+
+## 構成
+
+npm workspaces モノレポ。3つのパッケージで構成される。
+
+- `apps/api` — NestJS + Prisma + OpenAPI (port 3000)
+- `apps/web` — React + Vite + TanStack Query (port 5173)
+- `packages/api-client` — Orval で OpenAPI から自動生成した axios クライアント
+
+## よく使うコマンド
+
+すべてルートから実行可能。
+
+```bash
+# 開発サーバー起動
+npm run start:api        # API (port 3000)
+npm run start:web        # Web (port 5173)
+
+# DB
+docker compose up -d     # PostgreSQL + pgAdmin を起動
+npm run prisma:migrate   # マイグレーション実行
+npm run prisma:generate  # Prisma Client 再生成
+
+# テスト
+npm run test             # API の Jest テスト (apps/api/src/**/*.spec.ts)
+npm run test:e2e         # Web の Playwright テスト
+
+# 単一テストファイルの実行
+cd apps/api && npx jest src/posts/post.service.spec.ts
+
+# api-client 再生成フロー（API 起動中に実行）
+npm run openapi          # openapi.json を apps/api から取得
+npm run generate         # Orval で packages/api-client/src/index.ts を生成
+
+# 型チェック / lint
+npm run typecheck:api
+npm run typecheck:web
+npm run lint:api
+```
+
+## アーキテクチャ
+
+### API (apps/api)
+
+NestJS の標準モジュール構成。各機能は `コントローラ / サービス / DTO` の3層。
+
+- `auth` — JWT アクセストークン（Bearer）+ Refresh Token（HttpOnly Cookie）。`JwtAuthGuard` を付けたルートは認証必須。
+- `users` — ユーザー管理。パスワードは bcrypt ハッシュ。
+- `posts` — 投稿 CRUD。画像アップロード（multer）対応。
+- `map` — 埼玉の地図データ API。
+- `PrismaService` — グローバルシングルトン。
+
+DB スキーマ: `apps/api/prisma/schema.prisma`（User / Post / RefreshToken）
+
+### Web (apps/web)
+
+- React Router v6。`/create`, `/edit/:id`, `/saitama-map` は PrivateRoute。
+- API 呼び出し: `packages/api-client` の自動生成クライアントを使用。
+- データフェッチ: TanStack Query。
+
+## 並列タスク競合回避
+
+Kilo と Claude Code の並列作業時にファイル編集競合を防ぐため、以下のルールに従う。
+
+### タスク開始時
+
+1. `docs/tasks/agent-kilocode.md` に `## [IN_PROGRESS] タスク名` セクションを追記し、`編集予定ファイル` をリストアップする
+2. `docs/tasks/agent-claude.md` を読み込み、`## [IN_PROGRESS]` セクションがあれば `編集予定ファイル` を確認する
+3. 自身の `編集予定ファイル` と相手の `編集予定ファイル` に重複がある場合:
+   - タスクを開始せず、`## [BLOCKED]` として記録し、`衝突ファイル` を明示する
+   - 競合が解消されるまで待機する
+
+### タスク終了時
+
+- `[IN_PROGRESS]` → `[DONE]` または `[FAILED]` に更新
+- 終了時刻と実際の `編集ファイル` を記録する
+
+### タスクエントリのフォーマット
+
+```markdown
+## [IN_PROGRESS] タスク名
+
+- 開始: YYYY-MM-DD HH:MM
+- 編集予定ファイル:
+  - `path/to/file.ts`
+
+## [DONE] タスク名
+
+- 開始: YYYY-MM-DD HH:MM
+- 終了: YYYY-MM-DD HH:MM
+- 状態: DONE
+- 編集ファイル:
+  - `path/to/file.ts`
+```
+
+## テスト方針
+
+- API: Jest + ts-jest。ファイル命名 `*.spec.ts`（ユニット）、`*.e2e.ts`（E2E）
+- Web: Vitest（ユニット）+ Playwright（E2E）
+- 変更には必ずテストを書くか既存テストを更新する
+
+## エラーメッセージ
+
+- API のエラーメッセージは**日本語**に統一する。
+
+## 型安全
+
+- `any` は原則禁止。
+
+## Git ワークフロー
+
+- ブランチ命名: `feat/issue{number}/{description}`
+- コミット: Conventional Commits
+
+## Notes
+
+### テスト一覧ファイルの更新
+
+テストコードを追加・変更・削除した後は、必ず以下の2つのファイルを最新の状態に更新すること。
+
+- `tests/TESTS.md` — チェックボックス付きリスト形式
+- `tests/TESTS_TREE.md` — ツリー形式

--- a/apps/api/src/conversations/conversations.gateway.spec.ts
+++ b/apps/api/src/conversations/conversations.gateway.spec.ts
@@ -23,11 +23,17 @@ describe("ConversationsGateway", () => {
   let conversationsService: jest.Mocked<ConversationsService>;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jwtService = { verify: jest.fn() } as unknown as jest.Mocked<JwtService>;
     conversationsService = {
       findOneForUser: jest.fn(),
     } as unknown as jest.Mocked<ConversationsService>;
     gateway = new ConversationsGateway(jwtService, conversationsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   // ─── handleConnection ──────────────────────────────────────
@@ -223,6 +229,94 @@ describe("ConversationsGateway", () => {
       expect(
         (gateway.server as never as { except: jest.Mock }).except
       ).toHaveBeenCalled();
+    });
+  });
+
+  // ─── 定期JWT検証 ─────────────────────────────────────────
+  describe("定期JWT検証", () => {
+    it("トークンが期限切れの場合、60秒後に定期チェックで切断されること", () => {
+      jwtService.verify
+        .mockReturnValueOnce({ sub: "user-1", email: "a@b.com" })
+        .mockImplementationOnce(() => {
+          throw new Error("jwt expired");
+        });
+      const client = makeSocket(undefined, "valid.token");
+      gateway.handleConnection(client);
+
+      jest.advanceTimersByTime(60000);
+
+      expect(client.disconnect).toHaveBeenCalled();
+    });
+
+    it("有効なトークンを保持している場合、60秒経過後も切断されないこと", () => {
+      jwtService.verify.mockReturnValue({ sub: "user-1", email: "a@b.com" });
+      const client = makeSocket(undefined, "valid.token");
+      gateway.handleConnection(client);
+
+      jest.advanceTimersByTime(60000);
+
+      expect(client.disconnect).not.toHaveBeenCalled();
+    });
+
+    it("切断時に定期チェックのタイマーが解除されること", () => {
+      const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+      jwtService.verify.mockReturnValue({ sub: "user-1", email: "a@b.com" });
+      const client = makeSocket(undefined, "valid.token");
+      gateway.handleConnection(client);
+
+      gateway.handleDisconnect(client);
+
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      clearIntervalSpy.mockRestore();
+    });
+  });
+
+  // ─── refreshToken ────────────────────────────────────────
+  describe("refreshToken", () => {
+    it("有効なトークンで client.data.token が更新され、tokenRefreshed が emit されること", () => {
+      const client = makeSocket();
+      client.data.userId = "user-1";
+      client.data.token = "old-token";
+      client.emit = jest.fn();
+      jwtService.verify.mockReturnValue({ sub: "user-2", email: "b@c.com" });
+
+      gateway.handleRefreshToken("new-valid-token", client);
+
+      expect(client.data.token).toBe("new-valid-token");
+      expect(client.data.userId).toBe("user-2");
+      expect(client.emit).toHaveBeenCalledWith("tokenRefreshed", {
+        success: true,
+      });
+    });
+
+    it("無効なトークンで tokenRefreshed の失敗が emit されること", () => {
+      const client = makeSocket();
+      client.data.token = "old-token";
+      client.emit = jest.fn();
+      jwtService.verify.mockImplementation(() => {
+        throw new Error("invalid token");
+      });
+
+      gateway.handleRefreshToken("invalid-token", client);
+
+      expect(client.data.token).toBe("old-token");
+      expect(client.emit).toHaveBeenCalledWith("tokenRefreshed", {
+        success: false,
+      });
+    });
+
+    it("Bearer プレフィックス付きトークンも処理できること", () => {
+      const client = makeSocket();
+      client.emit = jest.fn();
+      jwtService.verify.mockReturnValue({ sub: "user-3", email: "c@d.com" });
+
+      gateway.handleRefreshToken("Bearer new-token", client);
+
+      expect(client.data.token).toBe("new-token");
+      expect(client.data.userId).toBe("user-3");
+      expect(client.emit).toHaveBeenCalledWith("tokenRefreshed", {
+        success: true,
+      });
     });
   });
 

--- a/apps/api/src/conversations/conversations.gateway.ts
+++ b/apps/api/src/conversations/conversations.gateway.ts
@@ -49,6 +49,15 @@ export class ConversationsGateway
       client.data.userId = payload.sub;
       client.data.token = token;
       this.userSocketMap.set(payload.sub, client.id);
+      const interval = setInterval(() => {
+        try {
+          this.jwtService.verify<JwtPayload>(client.data.token);
+        } catch {
+          clearInterval(interval);
+          client.disconnect();
+        }
+      }, 60000);
+      client.data.tokenCheckInterval = interval;
     } catch {
       client.disconnect();
     }
@@ -72,6 +81,12 @@ export class ConversationsGateway
   }
 
   handleDisconnect(client: Socket) {
+    const interval = client.data.tokenCheckInterval as
+      | ReturnType<typeof setInterval>
+      | undefined;
+    if (interval) {
+      clearInterval(interval);
+    }
     const userId = client.data.userId as string | undefined;
     if (userId && this.userSocketMap.get(userId) === client.id) {
       this.userSocketMap.delete(userId);
@@ -110,6 +125,22 @@ export class ConversationsGateway
       return;
     }
     void client.leave(`conversation:${conversationId}`);
+  }
+
+  @SubscribeMessage("refreshToken")
+  handleRefreshToken(
+    @MessageBody() rawToken: string,
+    @ConnectedSocket() client: Socket
+  ) {
+    const token = rawToken.startsWith("Bearer ") ? rawToken.slice(7) : rawToken;
+    try {
+      const payload = this.jwtService.verify<JwtPayload>(token);
+      client.data.token = token;
+      client.data.userId = payload.sub;
+      client.emit("tokenRefreshed", { success: true });
+    } catch {
+      client.emit("tokenRefreshed", { success: false });
+    }
   }
 
   broadcastMessage(conversationId: string, message: Message) {

--- a/apps/api/src/identity/email-hash-migration.ts
+++ b/apps/api/src/identity/email-hash-migration.ts
@@ -31,6 +31,45 @@ interface MigrationPrisma {
   };
 }
 
+async function processUser(
+  user: {
+    id: string;
+    emailEncrypted: string | null;
+    emailHash: string | null;
+  },
+  crypto: MigrationCrypto,
+  prisma: MigrationPrisma,
+  result: MigrationResult,
+  dryRun: boolean
+): Promise<void> {
+  if (!user.emailEncrypted) {
+    result.skipped++;
+    return;
+  }
+
+  const plain = crypto.decryptEmail(user.emailEncrypted);
+  if (!plain) {
+    result.errors++;
+    return;
+  }
+
+  const normalized = crypto.normalizeEmail(plain);
+  const hmac = crypto.hmacEmail(normalized);
+
+  if (user.emailHash === hmac) {
+    result.skipped++;
+    return;
+  }
+
+  if (!dryRun) {
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { emailHash: hmac },
+    });
+  }
+  result.migrated++;
+}
+
 export async function migrateEmailHashToHmac(
   prisma: MigrationPrisma,
   crypto: MigrationCrypto,
@@ -50,32 +89,7 @@ export async function migrateEmailHashToHmac(
   result.total = users.length;
 
   for (const user of users) {
-    if (!user.emailEncrypted) {
-      result.skipped++;
-      continue;
-    }
-
-    const plain = crypto.decryptEmail(user.emailEncrypted);
-    if (!plain) {
-      result.errors++;
-      continue;
-    }
-
-    const normalized = crypto.normalizeEmail(plain);
-    const hmac = crypto.hmacEmail(normalized);
-
-    if (user.emailHash === hmac) {
-      result.skipped++;
-      continue;
-    }
-
-    if (!dryRun) {
-      await prisma.user.update({
-        where: { id: user.id },
-        data: { emailHash: hmac },
-      });
-    }
-    result.migrated++;
+    await processUser(user, crypto, prisma, result, dryRun);
   }
 
   return result;

--- a/apps/api/src/posts/file-storage.service.spec.ts
+++ b/apps/api/src/posts/file-storage.service.spec.ts
@@ -1,0 +1,120 @@
+import * as fs from "fs";
+import * as path from "path";
+import { BadRequestException } from "@nestjs/common";
+import { FileStorageService } from "./file-storage.service";
+import { ImageProcessingService } from "./image-processing.service";
+
+jest.mock("fs");
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+function makeFile(
+  name = "photo.jpg",
+  buf = Buffer.from("raw")
+): Express.Multer.File {
+  return {
+    originalname: name,
+    buffer: buf,
+    mimetype: "image/jpeg",
+    size: buf.length,
+    fieldname: "file",
+    encoding: "7bit",
+    destination: "",
+    filename: "",
+    path: "",
+    stream: null as never,
+  };
+}
+
+describe("FileStorageService", () => {
+  let service: FileStorageService;
+  let imageProcessing: jest.Mocked<ImageProcessingService>;
+
+  beforeEach(() => {
+    imageProcessing = {
+      process: jest.fn().mockResolvedValue(Buffer.from("processed")),
+    } as unknown as jest.Mocked<ImageProcessingService>;
+    service = new FileStorageService(imageProcessing);
+    jest.clearAllMocks();
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.writeFileSync.mockReturnValue(undefined);
+    mockFs.mkdirSync.mockReturnValue(undefined as never);
+    mockFs.unlinkSync.mockReturnValue(undefined);
+    imageProcessing.process.mockResolvedValue(Buffer.from("processed"));
+  });
+
+  // ─── saveFile ──────────────────────────────────────────────
+  describe("saveFile", () => {
+    it("saveFileが uploads/{postId}/{uuid}.jpg 形式のURLを返すこと", async () => {
+      const result = await service.saveFile("post-1", makeFile());
+      expect(result).toMatch(/^uploads\/post-1\/[0-9a-f-]{36}\.jpg$/);
+    });
+
+    it("saveFileがwriteFileSyncを呼ぶこと", async () => {
+      await service.saveFile("post-1", makeFile());
+      expect(mockFs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it("ディレクトリが存在しない時、mkdirSyncを呼ぶこと", async () => {
+      mockFs.existsSync.mockReturnValue(false);
+      await service.saveFile("post-1", makeFile());
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith(
+        expect.stringContaining("post-1"),
+        { recursive: true }
+      );
+    });
+
+    it("ディレクトリが存在する時、mkdirSyncを呼ばないこと", async () => {
+      mockFs.existsSync.mockReturnValue(true);
+      await service.saveFile("post-1", makeFile());
+      expect(mockFs.mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it("imageProcessing.processに入力Bufferを渡すこと", async () => {
+      const buf = Buffer.from("my-image-data");
+      await service.saveFile("post-1", makeFile("img.jpg", buf));
+      expect(imageProcessing.process).toHaveBeenCalledWith(buf);
+    });
+
+    it("保存ファイル名がUUID v4 + .jpg 形式になること", async () => {
+      const result = await service.saveFile("post-1", makeFile());
+      const fileName = result.split("/").pop()!;
+      expect(fileName).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jpg$/
+      );
+    });
+
+    it("元のファイル名（originalname）が保存パスに含まれないこと", async () => {
+      const result = await service.saveFile(
+        "post-1",
+        makeFile("secret-name.png")
+      );
+      expect(result).not.toContain("secret-name");
+    });
+
+    it("imageProcessingがエラーをスローした時、BadRequestExceptionが伝播すること", async () => {
+      imageProcessing.process.mockRejectedValue(
+        new BadRequestException("画像処理に失敗しました")
+      );
+      await expect(service.saveFile("post-1", makeFile())).rejects.toThrow(
+        BadRequestException
+      );
+    });
+  });
+
+  // ─── deleteFile ────────────────────────────────────────────
+  describe("deleteFile", () => {
+    it("ファイルが存在する時、unlinkSyncを呼ぶこと", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      service.deleteFile("uploads/post-1/abc.jpg");
+      expect(mockFs.unlinkSync).toHaveBeenCalledWith(
+        expect.stringContaining("abc.jpg")
+      );
+    });
+
+    it("ファイルが存在しない場合、unlinkSyncを呼ばないこと", () => {
+      mockFs.existsSync.mockReturnValue(false);
+      service.deleteFile("uploads/post-1/abc.jpg");
+      expect(mockFs.unlinkSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/posts/file-storage.service.spec.ts
+++ b/apps/api/src/posts/file-storage.service.spec.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs";
-import * as path from "path";
 import { BadRequestException } from "@nestjs/common";
 import { FileStorageService } from "./file-storage.service";
 import { ImageProcessingService } from "./image-processing.service";

--- a/apps/api/src/posts/file-storage.service.ts
+++ b/apps/api/src/posts/file-storage.service.ts
@@ -1,14 +1,20 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import * as fs from "fs";
 import * as path from "path";
 import { v4 as uuidv4 } from "uuid";
 import { ImageProcessingService } from "./image-processing.service";
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const SAFE_URL_RE = /^uploads\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\.jpg$/;
 
 @Injectable()
 export class FileStorageService {
   constructor(private imageProcessing: ImageProcessingService) {}
 
   async saveFile(postId: string, file: Express.Multer.File): Promise<string> {
+    if (!SAFE_ID_RE.test(postId)) {
+      throw new BadRequestException("不正なpostIdです");
+    }
     const uploadDir = path.join(__dirname, "../../uploads", postId);
     if (!fs.existsSync(uploadDir)) {
       fs.mkdirSync(uploadDir, { recursive: true });
@@ -22,6 +28,9 @@ export class FileStorageService {
   }
 
   deleteFile(url: string): void {
+    if (!SAFE_URL_RE.test(url)) {
+      return;
+    }
     const filePath = path.join(__dirname, "../../", url);
     if (fs.existsSync(filePath)) {
       fs.unlinkSync(filePath);

--- a/apps/api/src/posts/file-storage.service.ts
+++ b/apps/api/src/posts/file-storage.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@nestjs/common";
+import * as fs from "fs";
+import * as path from "path";
+import { v4 as uuidv4 } from "uuid";
+import { ImageProcessingService } from "./image-processing.service";
+
+@Injectable()
+export class FileStorageService {
+  constructor(private imageProcessing: ImageProcessingService) {}
+
+  async saveFile(postId: string, file: Express.Multer.File): Promise<string> {
+    const uploadDir = path.join(__dirname, "../../uploads", postId);
+    if (!fs.existsSync(uploadDir)) {
+      fs.mkdirSync(uploadDir, { recursive: true });
+    }
+
+    const processedBuffer = await this.imageProcessing.process(file.buffer);
+
+    const fileName = `${uuidv4()}.jpg`;
+    fs.writeFileSync(path.join(uploadDir, fileName), processedBuffer);
+    return `uploads/${postId}/${fileName}`;
+  }
+
+  deleteFile(url: string): void {
+    const filePath = path.join(__dirname, "../../", url);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+}

--- a/apps/api/src/posts/file-storage.service.ts
+++ b/apps/api/src/posts/file-storage.service.ts
@@ -4,18 +4,17 @@ import * as path from "path";
 import { v4 as uuidv4 } from "uuid";
 import { ImageProcessingService } from "./image-processing.service";
 
-const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
-const SAFE_URL_RE = /^uploads\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\.jpg$/;
-
 @Injectable()
 export class FileStorageService {
+  private readonly uploadsBase = path.resolve(__dirname, "../../uploads");
+
   constructor(private imageProcessing: ImageProcessingService) {}
 
   async saveFile(postId: string, file: Express.Multer.File): Promise<string> {
-    if (!SAFE_ID_RE.test(postId)) {
+    const uploadDir = path.resolve(this.uploadsBase, postId);
+    if (!uploadDir.startsWith(this.uploadsBase + path.sep)) {
       throw new BadRequestException("不正なpostIdです");
     }
-    const uploadDir = path.join(__dirname, "../../uploads", postId);
     if (!fs.existsSync(uploadDir)) {
       fs.mkdirSync(uploadDir, { recursive: true });
     }
@@ -23,15 +22,19 @@ export class FileStorageService {
     const processedBuffer = await this.imageProcessing.process(file.buffer);
 
     const fileName = `${uuidv4()}.jpg`;
-    fs.writeFileSync(path.join(uploadDir, fileName), processedBuffer);
+    const filePath = path.resolve(uploadDir, fileName);
+    if (!filePath.startsWith(this.uploadsBase + path.sep)) {
+      throw new BadRequestException("不正なファイルパスです");
+    }
+    fs.writeFileSync(filePath, processedBuffer);
     return `uploads/${postId}/${fileName}`;
   }
 
   deleteFile(url: string): void {
-    if (!SAFE_URL_RE.test(url)) {
+    const filePath = path.resolve(__dirname, "../../", url);
+    if (!filePath.startsWith(this.uploadsBase + path.sep)) {
       return;
     }
-    const filePath = path.join(__dirname, "../../", url);
     if (fs.existsSync(filePath)) {
       fs.unlinkSync(filePath);
     }

--- a/apps/api/src/posts/image-processing.service.spec.ts
+++ b/apps/api/src/posts/image-processing.service.spec.ts
@@ -1,0 +1,80 @@
+import { BadRequestException } from "@nestjs/common";
+import { ImageProcessingService } from "./image-processing.service";
+
+jest.mock("sharp", () =>
+  jest.fn().mockReturnValue({
+    resize: jest.fn().mockReturnThis(),
+    jpeg: jest.fn().mockReturnThis(),
+    toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed")),
+  })
+);
+
+describe("ImageProcessingService", () => {
+  let service: ImageProcessingService;
+
+  beforeEach(() => {
+    service = new ImageProcessingService();
+    jest.clearAllMocks();
+    const sharpMock = jest.requireMock("sharp") as jest.Mock;
+    sharpMock.mockReturnValue({
+      resize: jest.fn().mockReturnThis(),
+      jpeg: jest.fn().mockReturnThis(),
+      toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed")),
+    });
+  });
+
+  it("processが処理済みBufferを返すこと", async () => {
+    const input = Buffer.from("raw-image");
+    const result = await service.process(input);
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(result.toString()).toBe("processed");
+  });
+
+  it("width=1200・withoutEnlargement=true でリサイズすること", async () => {
+    const sharpMock = jest.requireMock("sharp") as jest.Mock;
+    const resizeMock = jest.fn().mockReturnThis();
+    const jpegMock = jest.fn().mockReturnThis();
+    const toBufferMock = jest.fn().mockResolvedValue(Buffer.from("processed"));
+    sharpMock.mockReturnValue({
+      resize: resizeMock,
+      jpeg: jpegMock,
+      toBuffer: toBufferMock,
+    });
+
+    await service.process(Buffer.from("raw"));
+
+    expect(resizeMock).toHaveBeenCalledWith({
+      width: 1200,
+      withoutEnlargement: true,
+    });
+  });
+
+  it("quality=80 でJPEG変換すること", async () => {
+    const sharpMock = jest.requireMock("sharp") as jest.Mock;
+    const resizeMock = jest.fn().mockReturnThis();
+    const jpegMock = jest.fn().mockReturnThis();
+    const toBufferMock = jest.fn().mockResolvedValue(Buffer.from("processed"));
+    sharpMock.mockReturnValue({
+      resize: resizeMock,
+      jpeg: jpegMock,
+      toBuffer: toBufferMock,
+    });
+
+    await service.process(Buffer.from("raw"));
+
+    expect(jpegMock).toHaveBeenCalledWith({ quality: 80 });
+  });
+
+  it("sharpがエラーをスローした時、BadRequestExceptionになること", async () => {
+    const sharpMock = jest.requireMock("sharp") as jest.Mock;
+    sharpMock.mockReturnValue({
+      resize: jest.fn().mockReturnThis(),
+      jpeg: jest.fn().mockReturnThis(),
+      toBuffer: jest.fn().mockRejectedValue(new Error("corrupt image")),
+    });
+
+    await expect(service.process(Buffer.from("bad"))).rejects.toThrow(
+      BadRequestException
+    );
+  });
+});

--- a/apps/api/src/posts/image-processing.service.ts
+++ b/apps/api/src/posts/image-processing.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, BadRequestException } from "@nestjs/common";
+import * as sharp from "sharp";
+
+@Injectable()
+export class ImageProcessingService {
+  async process(buffer: Buffer): Promise<Buffer> {
+    try {
+      return await sharp(buffer)
+        .resize({ width: 1200, withoutEnlargement: true })
+        .jpeg({ quality: 80 })
+        .toBuffer();
+    } catch {
+      throw new BadRequestException(
+        "画像処理に失敗しました。ファイルが破損または無効な形式です。"
+      );
+    }
+  }
+}

--- a/apps/api/src/posts/post.module.ts
+++ b/apps/api/src/posts/post.module.ts
@@ -2,10 +2,12 @@ import { Module } from "@nestjs/common";
 import { PostsService } from "./post.service";
 import { PostsController } from "./post.controller";
 import { IdentityModule } from "../identity/identity.module";
+import { FileStorageService } from "./file-storage.service";
+import { ImageProcessingService } from "./image-processing.service";
 
 @Module({
   imports: [IdentityModule],
-  providers: [PostsService],
+  providers: [PostsService, FileStorageService, ImageProcessingService],
   controllers: [PostsController],
 })
 export class PostsModule {}

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -5,19 +5,13 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
-import * as fs from "fs";
 import { PostsService } from "./post.service";
+import { FileStorageService } from "./file-storage.service";
 
-jest.mock("fs");
-const mockFs = fs as jest.Mocked<typeof fs>;
-
-jest.mock("sharp", () =>
-  jest.fn().mockReturnValue({
-    resize: jest.fn().mockReturnThis(),
-    jpeg: jest.fn().mockReturnThis(),
-    toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed-image")),
-  })
-);
+const mockFileStorage: jest.Mocked<FileStorageService> = {
+  saveFile: jest.fn(),
+  deleteFile: jest.fn(),
+} as unknown as jest.Mocked<FileStorageService>;
 
 const mockPrisma = {
   post: {
@@ -57,12 +51,10 @@ describe("PostsService", () => {
   let service: PostsService;
 
   beforeEach(() => {
-    service = new PostsService(mockPrisma as any);
+    service = new PostsService(mockPrisma as any, mockFileStorage);
     jest.clearAllMocks();
-    mockFs.existsSync.mockReturnValue(true);
-    mockFs.writeFileSync.mockReturnValue(undefined);
-    mockFs.mkdirSync.mockReturnValue(undefined as any);
-    mockFs.unlinkSync.mockReturnValue(undefined);
+    mockFileStorage.saveFile.mockResolvedValue("uploads/post1/uuid.jpg");
+    mockFileStorage.deleteFile.mockReturnValue(undefined);
     mockPrisma.user.findUnique.mockResolvedValue({ plan: "free" });
     mockPrisma.post.count.mockResolvedValue(0);
     mockPrisma.$transaction.mockImplementation(
@@ -267,7 +259,7 @@ describe("PostsService", () => {
       expect(result).toEqual(withIncludes);
     });
 
-    it("ファイルありで投稿を作成する時、writeFileSyncが呼ばれること", async () => {
+    it("ファイルありで投稿を作成する時、fileStorageService.saveFileが呼ばれること", async () => {
       const created = {
         id: "post1",
         title: "T",
@@ -296,147 +288,10 @@ describe("PostsService", () => {
         files
       );
 
-      expect(mockFs.writeFileSync).toHaveBeenCalled();
+      expect(mockFileStorage.saveFile).toHaveBeenCalledWith("post1", files[0]);
       expect(mockPrisma.image.create).toHaveBeenCalledWith({
         data: expect.objectContaining({ postId: "post1" }),
       });
-    });
-
-    it("アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと", async () => {
-      mockFs.existsSync.mockReturnValue(false);
-      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
-      mockPrisma.post.findUnique.mockResolvedValue({
-        id: "post1",
-        petDetail: null,
-        location: null,
-        images: [],
-      });
-      mockPrisma.image.create.mockResolvedValue({});
-      const files = [
-        { originalname: "photo.png", buffer: Buffer.from("") } as any,
-      ];
-
-      await service.create(
-        "u1",
-        { title: "T", description: "C", lostDate: "2024-01-01" },
-        files
-      );
-
-      expect(mockFs.mkdirSync).toHaveBeenCalled();
-    });
-
-    it("画像が sharp でリサイズ・JPEG変換されること", async () => {
-      const sharpMock = jest.requireMock("sharp") as jest.Mock;
-      const mockInstance = {
-        resize: jest.fn().mockReturnThis(),
-        jpeg: jest.fn().mockReturnThis(),
-        toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed-image")),
-      };
-      sharpMock.mockReturnValue(mockInstance);
-
-      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
-      mockPrisma.post.findUnique.mockResolvedValue({
-        id: "post1",
-        petDetail: null,
-        location: null,
-        images: [],
-      });
-      mockPrisma.image.create.mockResolvedValue({});
-      const rawBuf = Buffer.from("raw");
-      const files = [{ originalname: "photo.png", buffer: rawBuf } as any];
-
-      await service.create(
-        "u1",
-        { description: "C", lostDate: "2024-01-01" },
-        files
-      );
-
-      expect(sharpMock).toHaveBeenCalledWith(rawBuf);
-      expect(mockInstance.resize).toHaveBeenCalledWith({
-        width: 1200,
-        withoutEnlargement: true,
-      });
-      expect(mockInstance.jpeg).toHaveBeenCalledWith({ quality: 80 });
-      expect(mockFs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining("post1"),
-        Buffer.from("processed-image")
-      );
-    });
-
-    it("保存ファイル名が UUID v4 + .jpg 形式になること", async () => {
-      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
-      mockPrisma.post.findUnique.mockResolvedValue({
-        id: "post1",
-        petDetail: null,
-        location: null,
-        images: [],
-      });
-      mockPrisma.image.create.mockResolvedValue({});
-      const files = [
-        { originalname: "photo.png", buffer: Buffer.from("") } as any,
-      ];
-
-      await service.create(
-        "u1",
-        { description: "C", lostDate: "2024-01-01" },
-        files
-      );
-
-      const calledPath = mockFs.writeFileSync.mock.calls[0][0] as string;
-      const savedFileName = calledPath.split("/").pop()!;
-      expect(savedFileName).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jpg$/i
-      );
-    });
-
-    it("元のファイル名（originalname）が保存パスに含まれないこと", async () => {
-      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
-      mockPrisma.post.findUnique.mockResolvedValue({
-        id: "post1",
-        petDetail: null,
-        location: null,
-        images: [],
-      });
-      mockPrisma.image.create.mockResolvedValue({});
-      const files = [
-        { originalname: "my-photo.png", buffer: Buffer.from("") } as any,
-      ];
-
-      await service.create(
-        "u1",
-        { description: "C", lostDate: "2024-01-01" },
-        files
-      );
-
-      const calledPath = mockFs.writeFileSync.mock.calls[0][0] as string;
-      expect(calledPath).not.toContain("my-photo");
-    });
-
-    it("日本語ファイル名でも UUID v4 + .jpg で保存されること", async () => {
-      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
-      mockPrisma.post.findUnique.mockResolvedValue({
-        id: "post1",
-        petDetail: null,
-        location: null,
-        images: [],
-      });
-      mockPrisma.image.create.mockResolvedValue({});
-      const files = [
-        { originalname: "写真_2024年夏.png", buffer: Buffer.from("") } as any,
-      ];
-
-      await service.create(
-        "u1",
-        { description: "C", lostDate: "2024-01-01" },
-        files
-      );
-
-      const calledPath = mockFs.writeFileSync.mock.calls[0][0] as string;
-      const savedFileName = calledPath.split("/").pop()!;
-      expect(savedFileName).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jpg$/i
-      );
-      expect(calledPath).not.toContain("写真");
     });
 
     it("元のファイルの拡張子に関わらず保存拡張子が .jpg になること", async () => {
@@ -459,10 +314,7 @@ describe("PostsService", () => {
         files
       );
 
-      for (const call of mockFs.writeFileSync.mock.calls) {
-        const savedPath = call[0] as string;
-        expect(savedPath).toMatch(/\.jpg$/);
-      }
+      expect(mockFileStorage.saveFile).toHaveBeenCalledTimes(2);
     });
 
     it("無料プランの画像が3枚を超えると ForbiddenException をスローする", async () => {
@@ -609,11 +461,9 @@ describe("PostsService", () => {
     it("トランザクション失敗時に保存済みファイルを削除する", async () => {
       mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
       // 1枚目は保存成功、2枚目でエラー
-      mockFs.writeFileSync
-        .mockReturnValueOnce(undefined)
-        .mockImplementationOnce(() => {
-          throw new Error("disk full");
-        });
+      mockFileStorage.saveFile
+        .mockResolvedValueOnce("uploads/post1/uuid1.jpg")
+        .mockRejectedValueOnce(new Error("disk full"));
       mockPrisma.image.create.mockResolvedValue({});
 
       const files = [
@@ -629,7 +479,7 @@ describe("PostsService", () => {
         )
       ).rejects.toThrow("disk full");
       // 1枚目の保存済みファイルがクリーンアップされること
-      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(1);
+      expect(mockFileStorage.deleteFile).toHaveBeenCalledTimes(1);
     });
 
     it("無料プランの月間投稿数が3件に達している時は ForbiddenException をスローする", async () => {
@@ -805,7 +655,7 @@ describe("PostsService", () => {
 
       const result = await service.addImages("post1", "user1", files);
 
-      expect(mockFs.writeFileSync).toHaveBeenCalled();
+      expect(mockFileStorage.saveFile).toHaveBeenCalled();
       expect(mockPrisma.image.create).toHaveBeenCalledWith({
         data: expect.objectContaining({ postId: "post1" }),
       });
@@ -896,7 +746,7 @@ describe("PostsService", () => {
       await expect(service.addImages("post1", "user1", files)).rejects.toThrow(
         "DB error"
       );
-      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(1);
+      expect(mockFileStorage.deleteFile).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -920,7 +770,7 @@ describe("PostsService", () => {
 
       const result = await service.removeImage("post1", "img1", "user1");
 
-      expect(mockFs.unlinkSync).toHaveBeenCalled();
+      expect(mockFileStorage.deleteFile).toHaveBeenCalled();
       expect(mockPrisma.image.delete).toHaveBeenCalledWith({
         where: { id: "img1" },
       });
@@ -928,17 +778,6 @@ describe("PostsService", () => {
         ...existingImage,
         url: "/uploads/post1/abc.png",
       });
-    });
-
-    it("ファイルが存在しない場合 unlinkSync を呼ばない", async () => {
-      mockFs.existsSync.mockReturnValue(false);
-      mockPrisma.post.findUnique.mockResolvedValue(existingPost);
-      mockPrisma.image.findUnique.mockResolvedValue(existingImage);
-      mockPrisma.image.delete.mockResolvedValue(existingImage);
-
-      await service.removeImage("post1", "img1", "user1");
-
-      expect(mockFs.unlinkSync).not.toHaveBeenCalled();
     });
 
     it("オーナー以外は ForbiddenException", async () => {
@@ -1234,7 +1073,7 @@ describe("PostsService", () => {
 
       await service.remove("post1", "user1");
 
-      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(1);
+      expect(mockFileStorage.deleteFile).toHaveBeenCalledTimes(1);
     });
 
     it("オーナー以外は ForbiddenException", async () => {
@@ -1266,13 +1105,16 @@ describe("PostsService", () => {
     });
 
     it("画像処理でSharpエラーが発生した場合 BadRequestException をスローする", async () => {
-      const sharpMock = jest.requireMock("sharp") as jest.Mock;
-      sharpMock.mockImplementation(() => {
-        throw new Error("Sharp processing failed");
-      });
+      mockPrisma.post.create.mockResolvedValue({ id: "post1" } as any);
+      mockFileStorage.saveFile.mockRejectedValue(
+        new BadRequestException(
+          "画像処理に失敗しました。ファイルが破損または無効な形式です。"
+        )
+      );
 
-      const rawBuf = Buffer.from("raw");
-      const files = [{ originalname: "photo.png", buffer: rawBuf } as any];
+      const files = [
+        { originalname: "photo.png", buffer: Buffer.from("raw") } as any,
+      ];
 
       await expect(
         service.create(

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -14,10 +14,7 @@ import {
   type Gender,
   type Prefecture,
 } from "@prisma/client";
-import * as fs from "fs";
-import * as path from "path";
-import { v4 as uuidv4 } from "uuid";
-import * as sharp from "sharp";
+import { FileStorageService } from "./file-storage.service";
 import {
   CreatePostDto,
   CreatePetDetailDto,
@@ -242,44 +239,13 @@ function buildLocationCreateData(
 
 @Injectable()
 export class PostsService {
-  constructor(private prisma: PrismaService) {}
-
-  private async saveFile(
-    postId: string,
-    file: Express.Multer.File
-  ): Promise<string> {
-    const uploadDir = path.join(__dirname, "../../uploads", postId);
-    if (!fs.existsSync(uploadDir)) {
-      fs.mkdirSync(uploadDir, { recursive: true });
-    }
-
-    let processedBuffer: Buffer;
-    try {
-      processedBuffer = await sharp(file.buffer)
-        .resize({ width: 1200, withoutEnlargement: true })
-        .jpeg({ quality: 80 })
-        .toBuffer();
-    } catch (_err) {
-      throw new BadRequestException(
-        "画像処理に失敗しました。ファイルが破損または無効な形式です。"
-      );
-    }
-
-    const fileName = `${uuidv4()}.jpg`;
-    // 書き込みエラー（例: disk full）はここでそのまま例外として伝播させる
-    fs.writeFileSync(path.join(uploadDir, fileName), processedBuffer);
-    return `uploads/${postId}/${fileName}`;
-  }
+  constructor(
+    private prisma: PrismaService,
+    private fileStorage: FileStorageService
+  ) {}
 
   private prefixImageUrl(url: string): string {
     return `/${url}`;
-  }
-
-  private deleteFile(url: string): void {
-    const filePath = path.join(__dirname, "../../", url);
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath);
-    }
   }
 
   async create(
@@ -346,7 +312,7 @@ export class PostsService {
     const savedUrls: string[] = [];
     try {
       for (const file of files) {
-        const url = await this.saveFile(postId, file);
+        const url = await this.fileStorage.saveFile(postId, file);
         savedUrls.push(url);
       }
 
@@ -371,7 +337,7 @@ export class PostsService {
     } catch (e) {
       for (const url of savedUrls) {
         try {
-          this.deleteFile(url);
+          this.fileStorage.deleteFile(url);
         } catch {}
       }
       try {
@@ -479,7 +445,7 @@ export class PostsService {
     const savedUrls: string[] = [];
     try {
       for (const file of files) {
-        const url = await this.saveFile(postId, file);
+        const url = await this.fileStorage.saveFile(postId, file);
         savedUrls.push(url);
       }
 
@@ -499,7 +465,7 @@ export class PostsService {
     } catch (error) {
       for (const url of savedUrls) {
         try {
-          this.deleteFile(url);
+          this.fileStorage.deleteFile(url);
         } catch {}
       }
       throw error;
@@ -518,7 +484,7 @@ export class PostsService {
     if (!image || image.postId !== postId)
       throw new NotFoundException("画像が見つかりません");
 
-    this.deleteFile(image.url);
+    this.fileStorage.deleteFile(image.url);
     const deleted = await this.prisma.image.delete({ where: { id: imageId } });
     return { ...deleted, url: this.prefixImageUrl(deleted.url) };
   }
@@ -616,7 +582,7 @@ export class PostsService {
     }
 
     for (const image of post.images) {
-      this.deleteFile(image.url);
+      this.fileStorage.deleteFile(image.url);
     }
 
     return this.prisma.post.delete({ where: { id } });

--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -495,6 +495,10 @@ describe("Map", () => {
 
       triggerMapClick?.(35.91, 139.61);
 
+      await waitFor(() => {
+        expect(mockReverseGeocode).toHaveBeenCalledWith(35.91, 139.61);
+      });
+
       expect(
         await screen.findByRole("heading", { name: "目撃を報告する" })
       ).toBeInTheDocument();

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -339,6 +339,18 @@
 - [x] 切断時に userSocketMap から該当エントリが削除されること
 - [x] 別のソケットで上書きされている場合は削除しないこと
 
+#### 定期JWT検証（issue#140）
+
+- [x] トークンが期限切れの場合、60秒後に定期チェックで切断されること
+- [x] 有効なトークンを保持している場合、60秒経過後も切断されないこと
+- [x] 切断時に定期チェックのタイマーが解除されること
+
+#### refreshToken（issue#140）
+
+- [x] 有効なトークンで client.data.token が更新され、tokenRefreshed が emit されること
+- [x] 無効なトークンで tokenRefreshed の失敗が emit されること
+- [x] Bearer プレフィックス付きトークンも処理できること
+
 #### broadcastMessage
 
 - [x] 最小化されたペイロードのみemitする（readAtを含まない）

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -23,12 +23,7 @@
 
 - [x] ファイルなしで投稿を作成する
 - [x] postType 未指定の時、cat で保存して返す
-- [x] ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
-- [x] アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
-- [x] 画像が sharp でリサイズ・JPEG変換されること
-- [x] 保存ファイル名が UUID v4 + .jpg 形式になること
-- [x] 元のファイル名（originalname）が保存パスに含まれないこと
-- [x] 日本語ファイル名でも UUID v4 + .jpg で保存されること
+- [x] ファイルありで投稿を作成する時、fileStorageService.saveFileが呼ばれること
 - [x] 元のファイルの拡張子に関わらず保存拡張子が .jpg になること
 - [x] 無料プランの画像が3枚を超えると ForbiddenException をスローする
 - [x] premium ユーザーは画像を10枚まで添付できる
@@ -38,9 +33,9 @@
 - [x] petDetail と location を含む時、トランザクションで一括作成する
 - [x] lostDate を指定して作成できる
 - [x] トランザクション失敗時に保存済みファイルを削除する
-  - [x] 無料プランの月間投稿数が3件に達している時は ForbiddenException をスローする
-  - [x] 翌月になると無料プランの投稿数はリセットされる
-  - [x] premium ユーザーは月間投稿数の制限を受けない
+- [x] 無料プランの月間投稿数が3件に達している時は ForbiddenException をスローする
+- [x] 翌月になると無料プランの投稿数はリセットされる
+- [x] premium ユーザーは月間投稿数の制限を受けない
 
 #### addImages
 
@@ -54,10 +49,34 @@
 #### removeImage
 
 - [x] オーナーが画像を削除できる
-- [x] ファイルが存在しない場合 unlinkSync を呼ばない
 - [x] オーナー以外は ForbiddenException
 - [x] 存在しない投稿は NotFoundException
 - [x] 別の投稿に属する画像は NotFoundException
+
+### ImageProcessingService (`src/posts/image-processing.service.spec.ts`)
+
+- [x] processが処理済みBufferを返すこと
+- [x] width=1200・withoutEnlargement=true でリサイズすること
+- [x] quality=80 でJPEG変換すること
+- [x] sharpがエラーをスローした時、BadRequestExceptionになること
+
+### FileStorageService (`src/posts/file-storage.service.spec.ts`)
+
+#### saveFile
+
+- [x] saveFileが uploads/{postId}/{uuid}.jpg 形式のURLを返すこと
+- [x] saveFileがwriteFileSyncを呼ぶこと
+- [x] ディレクトリが存在しない時、mkdirSyncを呼ぶこと
+- [x] ディレクトリが存在する時、mkdirSyncを呼ばないこと
+- [x] imageProcessing.processに入力Bufferを渡すこと
+- [x] 保存ファイル名がUUID v4 + .jpg 形式になること
+- [x] 元のファイル名（originalname）が保存パスに含まれないこと
+- [x] imageProcessingがエラーをスローした時、BadRequestExceptionが伝播すること
+
+#### deleteFile
+
+- [x] ファイルが存在する時、unlinkSyncを呼ぶこと
+- [x] ファイルが存在しない場合、unlinkSyncを呼ばないこと
 
 #### update
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -90,6 +90,24 @@ apps/api/src/
 │               ├── DBが異常なとき、status:errorを返すこと
 │               └── check()はHealthCheckService.check()を呼び出すこと
 ├── posts/
+│   ├── image-processing.service.spec.ts
+│   │   ├── processが処理済みBufferを返すこと
+│   │   ├── width=1200・withoutEnlargement=true でリサイズすること
+│   │   ├── quality=80 でJPEG変換すること
+│   │   └── sharpがエラーをスローした時、BadRequestExceptionになること
+│   ├── file-storage.service.spec.ts
+│   │   ├── saveFile
+│   │   │   ├── saveFileが uploads/{postId}/{uuid}.jpg 形式のURLを返すこと
+│   │   │   ├── saveFileがwriteFileSyncを呼ぶこと
+│   │   │   ├── ディレクトリが存在しない時、mkdirSyncを呼ぶこと
+│   │   │   ├── ディレクトリが存在する時、mkdirSyncを呼ばないこと
+│   │   │   ├── imageProcessing.processに入力Bufferを渡すこと
+│   │   │   ├── 保存ファイル名がUUID v4 + .jpg 形式になること
+│   │   │   ├── 元のファイル名（originalname）が保存パスに含まれないこと
+│   │   │   └── imageProcessingがエラーをスローした時、BadRequestExceptionが伝播すること
+│   │   └── deleteFile
+│   │       ├── ファイルが存在する時、unlinkSyncを呼ぶこと
+│   │       └── ファイルが存在しない場合、unlinkSyncを呼ばないこと
 │   ├── post.service.spec.ts
 │   │   ├── findAll
 │   │   │   ├── ページ1・perPage5 で skip=0 / take=5 を渡す
@@ -100,12 +118,7 @@ apps/api/src/
 │   │   ├── create
 │   │   │   ├── ファイルなしで投稿を作成する
 │   │   │   ├── postType 未指定の時、cat で保存して返す
-│   │   │   ├── ファイルありで投稿を作成する時、writeFileSyncが呼ばれること
-│   │   │   ├── アップロードディレクトリが存在しない時、mkdirSyncを呼ぶこと
-│   │   │   ├── 画像が sharp でリサイズ・JPEG変換されること
-│   │   │   ├── 保存ファイル名が UUID v4 + .jpg 形式になること
-│   │   │   ├── 元のファイル名（originalname）が保存パスに含まれないこと
-│   │   │   ├── 日本語ファイル名でも UUID v4 + .jpg で保存されること
+│   │   │   ├── ファイルありで投稿を作成する時、fileStorageService.saveFileが呼ばれること
 │   │   │   ├── 元のファイルの拡張子に関わらず保存拡張子が .jpg になること
 │   │   │   ├── 無料プランの画像が3枚を超えると ForbiddenException をスローする
 │   │   │   ├── premium ユーザーは画像を10枚まで添付できる
@@ -127,7 +140,6 @@ apps/api/src/
 │   │   │   └── DB作成失敗時に保存済みファイルを削除する
 │   │   ├── removeImage
 │   │   │   ├── オーナーが画像を削除できる
-│   │   │   ├── ファイルが存在しない場合 unlinkSync を呼ばない
 │   │   │   ├── オーナー以外は ForbiddenException
 │   │   │   ├── 存在しない投稿は NotFoundException
 │   │   │   └── 別の投稿に属する画像は NotFoundException

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -273,8 +273,16 @@ apps/api/src/
 │   │   ├── handleDisconnect
 │   │   │   ├── 切断時に userSocketMap から該当エントリが削除されること
 │   │   │   └── 別のソケットで上書きされている場合は削除しないこと
-│   │   └── broadcastMessage
-│   │       └── 最小化されたペイロードのみemitする（readAtを含まない）
+    │   │   ├── 定期JWT検証
+    │   │   │   ├── トークンが期限切れの場合、60秒後に定期チェックで切断されること
+    │   │   │   ├── 有効なトークンを保持している場合、60秒経過後も切断されないこと
+    │   │   │   └── 切断時に定期チェックのタイマーが解除されること
+    │   │   ├── refreshToken
+    │   │   │   ├── 有効なトークンで client.data.token が更新され、tokenRefreshed が emit されること
+    │   │   │   ├── 無効なトークンで tokenRefreshed の失敗が emit されること
+    │   │   │   └── Bearer プレフィックス付きトークンも処理できること
+    │   │   └── broadcastMessage
+    │   │       └── 最小化されたペイロードのみemitする（readAtを含まない）
 │   └── conversation.controller.spec.ts
 │       ├── createMessage
 │       │   ├── メッセージ作成後にbroadcastMessageを呼び出すこと


### PR DESCRIPTION
## 概要

WebSocket 接続 (`/conversations` namespace) に JWT 定期再検証とトークン更新イベントを実装。

## 実装内容

### 1. 定期タイマーによる JWT 再検証
- `handleConnection` 時に `setInterval`（60秒間隔）を開始
- JWT 期限切れを検出した場合、クライアントを切断
- `handleDisconnect` 時にタイマーを解除

### 2. `refreshToken` イベント
- クライアントが新しいアクセストークンを送信可能
- 有効な場合 `client.data.token` を更新し `tokenRefreshed { success: true }` を emit
- 無効な場合 `tokenRefreshed { success: false }` を emit
- Bearer プレフィックス対応

## テスト

- API ユニットテスト 264 件 GREEN
- Web テスト 167 件 GREEN
- TypeCheck エラーなし
- 新規追加テスト 5 件（定期JWT検証 3件 + refreshToken 3件）