### PR TITLE
fix: Web E2EテストのDB接続枯渇によるフレーキーテスト修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm test
         working-directory: apps/api
         env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test
+          DATABASE_URL: postgresql://test:test@localhost:5432/test?connection_limit=5
           HMAC_SECRET: ${{ secrets.HMAC_SECRET || 'ci-hmac-secret' }}
           ENCRYPTION_KEY_V1: ${{ secrets.ENCRYPTION_KEY || 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' }}
           ENCRYPTION_KEY_CURRENT: v1
@@ -109,11 +109,14 @@ jobs:
         run: npm run test:e2e
         working-directory: apps/api
         env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test
+          DATABASE_URL: postgresql://test:test@localhost:5432/test?connection_limit=5
           JWT_SECRET: ci-test-secret
           HMAC_SECRET: ${{ secrets.HMAC_SECRET || 'ci-hmac-secret' }}
           ENCRYPTION_KEY_V1: ${{ secrets.ENCRYPTION_KEY || 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' }}
           ENCRYPTION_KEY_CURRENT: v1
+
+      - name: Wait for DB connections to release
+        run: sleep 5
 
       - name: Cache Playwright browsers
         uses: actions/cache@v3
@@ -134,7 +137,7 @@ jobs:
         run: npm run start > /tmp/api.log 2>&1 &
         working-directory: apps/api
         env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test
+          DATABASE_URL: postgresql://test:test@localhost:5432/test?connection_limit=10
           NODE_ENV: test
           JWT_SECRET: ci-test-secret
           HMAC_SECRET: ${{ secrets.HMAC_SECRET || 'ci-hmac-secret' }}
@@ -143,6 +146,21 @@ jobs:
 
       - name: Wait for API
         run: npx wait-on -t 60000 http://localhost:3000/api-json || (cat /tmp/api.log && exit 1)
+
+      - name: Wait for API health (DB included)
+        run: |
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/healthz || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "API health check passed (attempt $i)"
+              exit 0
+            fi
+            echo "Attempt $i: status=$STATUS, retrying in 2s..."
+            sleep 2
+          done
+          echo "API health check failed after 30 attempts"
+          cat /tmp/api.log
+          exit 1
 
       - name: Start web dev server
         run: npm run dev > /tmp/web.log 2>&1 &
@@ -280,7 +298,7 @@ jobs:
         run: npm run start > /tmp/api.log 2>&1 &
         working-directory: apps/api
         env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test
+          DATABASE_URL: postgresql://test:test@localhost:5432/test?connection_limit=10
           NODE_ENV: test
           JWT_SECRET: ci-test-secret
           HMAC_SECRET: ${{ secrets.HMAC_SECRET || 'ci-hmac-secret' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Wait for API health (DB included)
         run: |
           for i in $(seq 1 30); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/healthz || echo "000")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/health || echo "000")
             if [ "$STATUS" = "200" ]; then
               echo "API health check passed (attempt $i)"
               exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Wait for API health (DB included)
         run: |
           for i in $(seq 1 30); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/health || echo "000")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health || echo "000")
             if [ "$STATUS" = "200" ]; then
               echo "API health check passed (attempt $i)"
               exit 0


### PR DESCRIPTION
## 原因

`API E2E tests` ステップがPrismaコネクションを正しくクリーンアップしないまま終了し、その後に起動するAPIサーバーがPostgreSQLのコネクションプール枯渇でDB接続に失敗していた。

また `Wait for API` が `/api-json`（静的エンドポイント）しか確認せず、DB込みのヘルスを保証していなかったため、DBが落ちたままWeb E2Eテストが開始されていた。

## 変更内容

- `API E2E tests` / `API tests` ステップの `DATABASE_URL` に `?connection_limit=5` を追加（コネクション枯渇防止）
- `Start API server` ステップの `DATABASE_URL` に `?connection_limit=10` を追加
- `API E2E tests` 終了後に `Wait for DB connections to release`（5秒待機）を追加
- `Wait for API` の後に **`Wait for API health (DB included)`** ステップを追加 — `/healthz` が 200 を返すまで最大60秒ポーリングし、DBが正常であることを確認してからWeb E2Eテストを実行する
- `schemathesis` ジョブの `Start API server` にも同様の `connection_limit=10` を適用

## テスト計画

- [ ] このPRのCI（E2E Testsジョブ）がグリーンになることを確認