### PR TITLE
fix: auth/refreshのSkipThrottleにpublicスロットラーを追加 (#169)

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -37,7 +37,7 @@ export class AuthController {
   }
 
   @Post("refresh")
-  @SkipThrottle()
+  @SkipThrottle({ default: true, public: true })
   @HttpCode(HttpStatus.OK)
   @ApiResponse({ status: 200, type: AccessTokenResponseDto })
   async refresh(


### PR DESCRIPTION
## 問題

`auth/refresh` に `@SkipThrottle()` を適用済みだが、デフォルト値が `{ default: true }` のため `public` スロットラー（120/min）がスキップされず、429 になっていた。

## 修正

`@SkipThrottle({ default: true, public: true })` に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)