### PR TITLE
fix: @types/expressをdevDependenciesに追加してVPSビルドエラーを修正

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -92,6 +92,7 @@
   "devDependencies": {
     "@nestjs/testing": "^11.1.19",
     "@types/jest": "^30.0.0",
+    "@types/express": "^4.17.21",
     "@types/multer": "^2.1.0",
     "@types/node": "^25.6.0",
     "@types/passport-jwt": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       },
       "devDependencies": {
         "@nestjs/testing": "^11.1.19",
+        "@types/express": "^4.17.21",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
         "@types/node": "^25.6.0",
@@ -1368,15 +1369,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "apps/api/node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "apps/api/node_modules/@types/express": {
       "version": "5.0.6",
       "dev": true,
@@ -1397,11 +1389,6 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
-    },
-    "apps/api/node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/api/node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1477,24 +1464,6 @@
       "dependencies": {
         "@types/express": "*",
         "@types/passport": "*"
-      }
-    },
-    "apps/api/node_modules/@types/qs": {
-      "version": "6.15.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/api/node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/api/node_modules/@types/send": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "apps/api/node_modules/@types/serve-static": {
@@ -8927,6 +8896,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -8991,6 +8971,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -9051,6 +9038,30 @@
       "license": "MIT",
       "dependencies": {
         "@types/pg": "*"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/sharp": {


### PR DESCRIPTION
## Summary
- `apps/api/package.json` の `devDependencies` に `@types/express@^4.17.21` を追加
- `@types/multer` v2.x は `@types/express` をpeer dependencyとして必要とするが未記載だった
- CIではnpmホイスティングで偶然解決されていたが、VPSの `npm ci` では未インストールとなりビルドエラー

## Root Cause
```
src/posts/file-storage.service.ts:13:40 - error TS2503: Cannot find namespace 'Express'.
```
`Express.Multer.File` 型は `@types/multer` が `@types/express` の `Express` 名前空間を拡張して提供するが、`@types/express` 自体が `package.json` に記載されていなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)