### PR TITLE
fix: npm ciにNODE_ENV=developmentを設定してVPSビルドのdevDepsスキップを防止

### DIFF
--- a/scripts/vps-deploy.sh
+++ b/scripts/vps-deploy.sh
@@ -161,7 +161,7 @@ git pull --ff-only origin main
 # 3. 依存インストール ----------------------------------------------------------------
 echo ""
 echo "Step 3/10: npm ci"
-npm ci --ignore-scripts
+NODE_ENV=development npm ci --ignore-scripts
 
 # 3.5. bcrypt ネイティブバイナリのリビルド（--ignore-scripts でスキップされるため）
 echo ""


### PR DESCRIPTION
## Summary
- `scripts/vps-deploy.sh` の `npm ci` を `NODE_ENV=development npm ci` に変更

## Root Cause
VPS本番環境では `NODE_ENV=production` が設定されており、`npm ci` 実行時にdevDependenciesがスキップされる。
その結果 `@types/express` などのビルドに必要な型パッケージがインストールされず、`tsc` ビルドが失敗していた。

```
Cannot find namespace 'Express'  ← @types/express が未インストール
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)