### PR TITLE
fix: postIdなしの目撃情報マーカークリック時も目撃詳細を表示

### DIFF
--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -358,7 +358,7 @@ export default function PostDetailSheet({
                       <span className="w-1 h-5 bg-primary rounded-full inline-block" />
                       特徴・性格
                     </h3>
-                    <p className="text-sm leading-relaxed text-foreground bg-muted p-4 rounded-2xl">
+                    <p className="text-sm leading-relaxed text-foreground bg-muted p-4 rounded-2xl whitespace-pre-wrap">
                       {post.petDetail.features}
                     </p>
                   </div>
@@ -372,7 +372,7 @@ export default function PostDetailSheet({
                     <span className="w-1 h-5 bg-primary rounded-full inline-block" />
                     詳しい説明
                   </h3>
-                  <p className="text-sm leading-relaxed text-foreground bg-muted p-4 rounded-2xl">
+                  <p className="text-sm leading-relaxed text-foreground bg-muted p-4 rounded-2xl whitespace-pre-wrap">
                     {post.description}
                   </p>
                 </div>

--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -420,6 +420,12 @@ export default function PostDetailSheet({
                 <SightingDetailSection sighting={sightingDetail} />
               )}
             </>
+          ) : markerType === "sighting" ? (
+            sightingDetail ? (
+              <SightingDetailSection sighting={sightingDetail} />
+            ) : (
+              <p className="text-muted-foreground mt-6">読み込み中…</p>
+            )
           ) : (
             <p className="text-muted-foreground mt-6">
               詳細情報を取得できませんでした


### PR DESCRIPTION
## Summary
- 地図下部「目撃を報告」ボタンから作成した目撃情報（`postId` なし）のマーカーをクリックしても目撃詳細が表示されるよう修正

## Root Cause
`PostDetailSheet` は `post` が null の場合に常に「詳細情報を取得できませんでした」を表示していた。
しかし `markerType === "sighting"` の場合は `post` なしでも目撃詳細（`SightingDetailSection`）を表示できる。

`postId` なしで作成された目撃情報は:
- `selectedMarker.postId` が undefined → `setSelectedPost(null)` → `post = null`
- → 従来は「詳細情報を取得できませんでした」が表示されていた

## Fix
`post` が null かつ `markerType === "sighting"` の場合は `SightingDetailSection` をそのまま表示する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)