### PR TITLE
fix: 目撃情報コメントの改行を保持

### DIFF
--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -479,7 +479,9 @@ function SightingDetailSection({
             <span className="text-muted-foreground text-xs font-bold">
               コメント
             </span>
-            <p className="text-sm text-foreground mt-1">{sighting.comment}</p>
+            <p className="text-sm text-foreground mt-1 whitespace-pre-wrap">
+              {sighting.comment}
+            </p>
           </div>
         )}
         {sighting.nickname && (


### PR DESCRIPTION
## Summary
- `SightingDetailSection` のコメント `<p>` に `whitespace-pre-wrap` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)