### PR TITLE
fix: E2Eテストの並列実行によるシリアライザブル競合を解消

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "tests",
   timeout: 120000,
+  workers: 1,
   globalTeardown: "./tests/global-teardown.ts",
   projects: [
     {

--- a/apps/web/tests/playwright/create-post-map-flow.spec.ts
+++ b/apps/web/tests/playwright/create-post-map-flow.spec.ts
@@ -124,7 +124,7 @@ test("画像3枚で迷い猫投稿し、マーカークリックで登録内容�
   for (let i = 0; i < markerCount; i += 1) {
     await page.locator(".map-marker--pin").nth(i).click({ force: true });
     const detailDialog = page.getByRole("dialog");
-    await expect(detailDialog).toBeVisible();
+    await expect(detailDialog).toBeVisible({ timeout: 5000 });
     await expect(detailDialog.locator("text=読み込み中")).not.toBeVisible({
       timeout: 5000,
     });
@@ -140,5 +140,8 @@ test("画像3枚で迷い猫投稿し、マーカークリックで登録内容�
     await expect(detailDialog).not.toBeVisible({ timeout: 3000 });
   }
 
+  if (!found) {
+    console.log(`DEBUG: markerCount=${markerCount}, uniqueToken=${uniqueToken}`);
+  }
   expect(found).toBeTruthy();
 });


### PR DESCRIPTION
## 概要
CI の E2E テスト (`create-post-map-flow.spec.ts`) が失敗する問題を修正。

## 原因
Playwright がデフォルトで 2 workers の並列実行を行うため、2つのテスト (`e2e.spec.ts` と `create-post-map-flow.spec.ts`) が同時に実行される。両テストが PostgreSQL に対して `Serializable` 分離レベルでトランザクションを実行する投稿作成を行うため、競合が発生し `could not serialize access due to read/write dependencies among transactions` エラーが起きていた。

## 修正内容
1. `apps/web/playwright.config.ts` に `workers: 1` を追加し、テストを逐次実行に変更
2. `apps/web/tests/playwright/create-post-map-flow.spec.ts` に失敗時の診断ログを追加