### PR TITLE
fix: スロットリング制限超過による429カスケードを修正

### DIFF
--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -87,6 +87,7 @@ export class ConversationsController {
   }
 
   @Get("unread-count")
+  @SkipThrottle()
   @ApiOperation({ summary: "未読メッセージの合計数を取得する" })
   @ApiResponse({
     status: 200,

--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -87,7 +87,7 @@ export class ConversationsController {
   }
 
   @Get("unread-count")
-  @SkipThrottle()
+  @SkipThrottle({ default: true, public: true })
   @ApiOperation({ summary: "未読メッセージの合計数を取得する" })
   @ApiResponse({
     status: 200,


### PR DESCRIPTION
## 概要
スロットリング制限（429 Too Many Requests）の超過が連鎖的に発生する問題を修正。

## 原因
1. `@SkipThrottle()` 単体では `default` スロットラーのみスキップし、`public` スロットラーはスキップされない
2. マップマーカー取得、トークンリフレッシュ、未読カウント等の高頻度エンドポイントで `public` 制限に抵触
3. フロントエンド側で 429 レスポンスに対しても retry が働きリクエスト増幅

## 修正内容

### API
- `app.module.ts`: テスト環境の `public` スロットラーを無効化
- `auth.controller.ts`: `refresh` の `@SkipThrottle` に `public` を追加
- `map.controller.ts`: `markers` の `@SkipThrottle` に `public` を追加
- `conversation.controller.ts`: `unread-count` に `@SkipThrottle({ default: true, public: true })` を追加

### Web
- `main.tsx`: TanStack Query で 429 レスポンスの retry を無効化