### PR TITLE
feat: issue#181 チャットメッセージ画像アップロードAPIエンドポイント実装

### DIFF
--- a/apps/api/src/conversations/conversation-file-storage.service.spec.ts
+++ b/apps/api/src/conversations/conversation-file-storage.service.spec.ts
@@ -1,6 +1,5 @@
 import { BadRequestException } from "@nestjs/common";
 import * as fs from "fs";
-import * as path from "path";
 import { ConversationFileStorageService } from "./conversation-file-storage.service";
 import { ImageProcessingService } from "./image-processing.service";
 

--- a/apps/api/src/conversations/conversation-file-storage.service.spec.ts
+++ b/apps/api/src/conversations/conversation-file-storage.service.spec.ts
@@ -1,0 +1,95 @@
+import { BadRequestException } from "@nestjs/common";
+import * as fs from "fs";
+import * as path from "path";
+import { ConversationFileStorageService } from "./conversation-file-storage.service";
+import { ImageProcessingService } from "./image-processing.service";
+
+jest.mock("fs");
+jest.mock("uuid", () => ({ v4: () => "test-uuid" }));
+
+const mockImageProcessing = {
+  process: jest.fn(),
+} as unknown as jest.Mocked<ImageProcessingService>;
+
+describe("ConversationFileStorageService", () => {
+  let service: ConversationFileStorageService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    (fs.mkdirSync as jest.Mock).mockReturnValue(undefined);
+    (fs.writeFileSync as jest.Mock).mockReturnValue(undefined);
+    mockImageProcessing.process.mockResolvedValue(
+      Buffer.from("processed-image")
+    );
+    service = new ConversationFileStorageService(mockImageProcessing);
+  });
+
+  describe("saveFile", () => {
+    it("画像を処理してuploads/conversations/{conversationId}/{uuid}.jpgに保存し、URLを返すこと", async () => {
+      const file = {
+        buffer: Buffer.from("raw-image"),
+        originalname: "photo.jpg",
+        mimetype: "image/jpeg",
+      } as Express.Multer.File;
+
+      const result = await service.saveFile("conv-1", file);
+
+      expect(mockImageProcessing.process).toHaveBeenCalledWith(file.buffer);
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      expect(result).toBe("uploads/conversations/conv-1/test-uuid.jpg");
+    });
+
+    it("ディレクトリが存在しない場合はmkdirSyncで作成すること", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+      const file = { buffer: Buffer.from("x") } as Express.Multer.File;
+
+      await service.saveFile("conv-2", file);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), {
+        recursive: true,
+      });
+    });
+
+    it("ディレクトリが既に存在する場合はmkdirSyncを呼ばないこと", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      const file = { buffer: Buffer.from("x") } as Express.Multer.File;
+
+      await service.saveFile("conv-3", file);
+
+      expect(fs.mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it("不正なconversationIdでパストラバーサルを防ぐこと", async () => {
+      const file = { buffer: Buffer.from("x") } as Express.Multer.File;
+
+      await expect(service.saveFile("../../../etc", file)).rejects.toThrow(
+        BadRequestException
+      );
+    });
+  });
+
+  describe("deleteFile", () => {
+    it("ファイルが存在する場合は削除すること", () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.unlinkSync as jest.Mock).mockReturnValue(undefined);
+
+      service.deleteFile("uploads/conversations/conv-1/test-uuid.jpg");
+
+      expect(fs.unlinkSync).toHaveBeenCalled();
+    });
+
+    it("ファイルが存在しない場合は何もしないこと", () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      service.deleteFile("uploads/conversations/conv-1/test-uuid.jpg");
+
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it("不正なパスでパストラバーサルを防ぐこと", () => {
+      service.deleteFile("../../etc/passwd");
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/conversations/conversation-file-storage.service.ts
+++ b/apps/api/src/conversations/conversation-file-storage.service.ts
@@ -1,0 +1,49 @@
+import { BadRequestException, Injectable } from "@nestjs/common";
+import * as fs from "fs";
+import * as path from "path";
+import { v4 as uuidv4 } from "uuid";
+import { ImageProcessingService } from "./image-processing.service";
+
+@Injectable()
+export class ConversationFileStorageService {
+  private readonly uploadsBase = path.resolve(__dirname, "../../uploads");
+
+  constructor(private imageProcessing: ImageProcessingService) {}
+
+  async saveFile(
+    conversationId: string,
+    file: Express.Multer.File
+  ): Promise<string> {
+    const uploadDir = path.resolve(
+      this.uploadsBase,
+      "conversations",
+      conversationId
+    );
+    if (!uploadDir.startsWith(this.uploadsBase + path.sep)) {
+      throw new BadRequestException("不正なconversationIdです");
+    }
+    if (!fs.existsSync(uploadDir)) {
+      fs.mkdirSync(uploadDir, { recursive: true });
+    }
+
+    const processedBuffer = await this.imageProcessing.process(file.buffer);
+
+    const fileName = `${uuidv4()}.jpg`;
+    const filePath = path.resolve(uploadDir, fileName);
+    if (!filePath.startsWith(this.uploadsBase + path.sep)) {
+      throw new BadRequestException("不正なファイルパスです");
+    }
+    fs.writeFileSync(filePath, processedBuffer);
+    return `uploads/conversations/${conversationId}/${fileName}`;
+  }
+
+  deleteFile(url: string): void {
+    const filePath = path.resolve(__dirname, "../../", url);
+    if (!filePath.startsWith(this.uploadsBase + path.sep)) {
+      return;
+    }
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+}

--- a/apps/api/src/conversations/conversation.controller.spec.ts
+++ b/apps/api/src/conversations/conversation.controller.spec.ts
@@ -1,4 +1,6 @@
+import { BadRequestException } from "@nestjs/common";
 import { ConversationsController } from "./conversation.controller";
+import { ConversationFileStorageService } from "./conversation-file-storage.service";
 
 const mockService = {
   create: jest.fn(),
@@ -14,6 +16,11 @@ const mockGateway = {
   broadcastMessage: jest.fn(),
 };
 
+const mockFileStorage: jest.Mocked<ConversationFileStorageService> = {
+  saveFile: jest.fn(),
+  deleteFile: jest.fn(),
+} as unknown as jest.Mocked<ConversationFileStorageService>;
+
 const req = {
   user: { id: "user-1", email: "test@test.com", role: "user" as const },
 };
@@ -24,7 +31,8 @@ describe("ConversationsController", () => {
   beforeEach(() => {
     controller = new ConversationsController(
       mockService as never,
-      mockGateway as never
+      mockGateway as never,
+      mockFileStorage
     );
     jest.clearAllMocks();
   });
@@ -96,6 +104,66 @@ describe("ConversationsController", () => {
       ).rejects.toThrow("forbidden");
 
       expect(mockGateway.broadcastMessage).not.toHaveBeenCalled();
+    });
+
+    it("画像ファイルが添付された場合はfileStorageに保存してimageUrlを含むDTOでcreateMessageを呼ぶこと", async () => {
+      const file = {
+        buffer: Buffer.from("image"),
+        originalname: "photo.jpg",
+        mimetype: "image/jpeg",
+        size: 100,
+      } as Express.Multer.File;
+      mockFileStorage.saveFile.mockResolvedValue(
+        "uploads/conversations/conv-1/uuid.jpg"
+      );
+      const message = {
+        id: "msg-2",
+        conversationId: "conv-1",
+        senderId: "user-1",
+        body: null,
+        imageUrl: "/uploads/conversations/conv-1/uuid.jpg",
+        createdAt: new Date(),
+        readAt: null,
+      };
+      mockService.createMessage.mockResolvedValue(message);
+
+      const result = await controller.createMessage(req, "conv-1", {}, file);
+
+      expect(mockFileStorage.saveFile).toHaveBeenCalledWith("conv-1", file);
+      expect(mockService.createMessage).toHaveBeenCalledWith(
+        "user-1",
+        "conv-1",
+        {
+          imageUrl: "/uploads/conversations/conv-1/uuid.jpg",
+        }
+      );
+      expect(result).toBe(message);
+    });
+
+    it("JPEG・PNG以外のファイルは400エラーになること", async () => {
+      const file = {
+        buffer: Buffer.from("gif"),
+        originalname: "anim.gif",
+        mimetype: "image/gif",
+        size: 100,
+      } as Express.Multer.File;
+
+      await expect(
+        controller.createMessage(req, "conv-1", {}, file)
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("2MB超のファイルは400エラーになること", async () => {
+      const file = {
+        buffer: Buffer.alloc(3 * 1024 * 1024),
+        originalname: "big.jpg",
+        mimetype: "image/jpeg",
+        size: 3 * 1024 * 1024,
+      } as Express.Multer.File;
+
+      await expect(
+        controller.createMessage(req, "conv-1", {}, file)
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
@@ -7,11 +8,16 @@ import {
   Patch,
   Post,
   Request,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from "@nestjs/common";
+import { FileInterceptor } from "@nestjs/platform-express";
+import { memoryStorage } from "multer";
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiConsumes,
   ApiOperation,
   ApiParam,
   ApiResponse,
@@ -33,7 +39,11 @@ import {
 import { MessageResponseDto } from "./dto/message-response.dto";
 import { ConversationsService } from "./conversation.service";
 import { ConversationsGateway } from "./conversations.gateway";
+import { ConversationFileStorageService } from "./conversation-file-storage.service";
 import { AuthenticatedRequest } from "../auth/interfaces/authenticated-request.interface";
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png"];
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 
 @ApiTags("conversations")
 @Controller("conversations")
@@ -43,7 +53,8 @@ import { AuthenticatedRequest } from "../auth/interfaces/authenticated-request.i
 export class ConversationsController {
   constructor(
     private readonly conversationsService: ConversationsService,
-    private readonly conversationsGateway: ConversationsGateway
+    private readonly conversationsGateway: ConversationsGateway,
+    private readonly conversationFileStorage: ConversationFileStorageService
   ) {}
 
   private getAuthenticatedUserId(req: AuthenticatedRequest): string {
@@ -113,30 +124,52 @@ export class ConversationsController {
   }
 
   @Post(":id/messages")
-  @ApiOperation({ summary: "メッセージを送信する" })
+  @ApiConsumes("multipart/form-data", "application/json")
+  @ApiOperation({ summary: "メッセージを送信する（テキストまたは画像）" })
   @ApiParam({ name: "id", example: OPENAPI_CONVERSATION_ID_EXAMPLE })
   @ApiBody({
     schema: {
       type: "object",
-      required: ["body"],
-      example: {
-        body: "こんにちは、見つかりましたか？",
-      },
       properties: {
         body: {
           type: "string",
           maxLength: 1000,
           example: "こんにちは、見つかりましたか？",
         },
+        image: {
+          type: "string",
+          format: "binary",
+          description: "JPEG/PNG、2MB以下",
+        },
       },
     },
   })
   @ApiResponse({ status: 201, type: MessageResponseDto })
+  @UseInterceptors(
+    FileInterceptor("image", {
+      storage: memoryStorage(),
+      limits: { fileSize: MAX_FILE_SIZE },
+    })
+  )
   async createMessage(
     @Request() req: AuthenticatedRequest,
     @Param("id") id: string,
-    @Body() dto: CreateMessageDto
+    @Body() dto: CreateMessageDto,
+    @UploadedFile() file?: Express.Multer.File
   ) {
+    if (file) {
+      if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+        throw new BadRequestException(
+          `未対応のファイル形式です: ${file.mimetype}。JPEG または PNG を使用してください。`
+        );
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        throw new BadRequestException("ファイルサイズは2MB以内にしてください");
+      }
+      const savedUrl = await this.conversationFileStorage.saveFile(id, file);
+      dto = { imageUrl: `/${savedUrl}` };
+    }
+
     const message = await this.conversationsService.createMessage(
       this.getAuthenticatedUserId(req),
       id,

--- a/apps/api/src/conversations/conversation.module.ts
+++ b/apps/api/src/conversations/conversation.module.ts
@@ -4,6 +4,8 @@ import { JwtModule } from "@nestjs/jwt";
 import { ConversationsController } from "./conversation.controller";
 import { ConversationsService } from "./conversation.service";
 import { ConversationsGateway } from "./conversations.gateway";
+import { ImageProcessingService } from "./image-processing.service";
+import { ConversationFileStorageService } from "./conversation-file-storage.service";
 import { IdentityModule } from "../identity/identity.module";
 
 @Module({
@@ -17,6 +19,11 @@ import { IdentityModule } from "../identity/identity.module";
     }),
   ],
   controllers: [ConversationsController],
-  providers: [ConversationsService, ConversationsGateway],
+  providers: [
+    ConversationsService,
+    ConversationsGateway,
+    ImageProcessingService,
+    ConversationFileStorageService,
+  ],
 })
 export class ConversationsModule {}

--- a/apps/api/src/conversations/conversations.gateway.spec.ts
+++ b/apps/api/src/conversations/conversations.gateway.spec.ts
@@ -332,6 +332,7 @@ describe("ConversationsGateway", () => {
         conversationId: "conv-1",
         senderId: "user-1",
         body: "hello",
+        imageUrl: null,
         createdAt: new Date("2026-01-01"),
         readAt: new Date("2026-01-02"),
       } as import("@prisma/client").Message;
@@ -344,11 +345,33 @@ describe("ConversationsGateway", () => {
         conversationId: "conv-1",
         senderId: "user-1",
         body: "hello",
+        imageUrl: null,
         createdAt: message.createdAt,
       });
       // readAt は含まれないこと
       const emitted = emitMock.mock.calls[0][1] as Record<string, unknown>;
       expect(emitted).not.toHaveProperty("readAt");
+    });
+
+    it("imageUrlがある場合はペイロードに含まれること", () => {
+      const emitMock = jest.fn();
+      const toMock = jest.fn().mockReturnValue({ emit: emitMock });
+      gateway.server = { to: toMock } as never;
+
+      const message = {
+        id: "msg-2",
+        conversationId: "conv-1",
+        senderId: "user-1",
+        body: null,
+        imageUrl: "/uploads/conversations/conv-1/abc.jpg",
+        createdAt: new Date("2026-01-01"),
+        readAt: null,
+      } as import("@prisma/client").Message;
+
+      gateway.broadcastMessage("conv-1", message);
+
+      const emitted = emitMock.mock.calls[0][1] as Record<string, unknown>;
+      expect(emitted.imageUrl).toBe("/uploads/conversations/conv-1/abc.jpg");
     });
   });
 });

--- a/apps/api/src/conversations/conversations.gateway.ts
+++ b/apps/api/src/conversations/conversations.gateway.ts
@@ -144,7 +144,7 @@ export class ConversationsGateway
   }
 
   broadcastMessage(conversationId: string, message: Message) {
-    const { id, senderId, body, createdAt } = message;
+    const { id, senderId, body, imageUrl, createdAt } = message;
     const senderSocketId = this.userSocketMap.get(senderId);
     const target = senderSocketId
       ? this.server.except(senderSocketId).to(`conversation:${conversationId}`)
@@ -154,6 +154,7 @@ export class ConversationsGateway
       conversationId,
       senderId,
       body,
+      imageUrl,
       createdAt,
     });
   }

--- a/apps/api/src/conversations/image-processing.service.ts
+++ b/apps/api/src/conversations/image-processing.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, BadRequestException } from "@nestjs/common";
+import * as sharp from "sharp";
+
+@Injectable()
+export class ImageProcessingService {
+  async process(buffer: Buffer): Promise<Buffer> {
+    try {
+      return await sharp(buffer)
+        .resize({ width: 1200, withoutEnlargement: true })
+        .jpeg({ quality: 80 })
+        .toBuffer();
+    } catch {
+      throw new BadRequestException(
+        "画像処理に失敗しました。ファイルが破損または無効な形式です。"
+      );
+    }
+  }
+}

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -366,6 +366,24 @@
 #### broadcastMessage
 
 - [x] 最小化されたペイロードのみemitする（readAtを含まない）
+- [x] imageUrlがある場合はペイロードに含まれること
+
+---
+
+### ConversationFileStorageService (`src/conversations/conversation-file-storage.service.spec.ts`)
+
+#### saveFile
+
+- [x] 画像を処理してuploads/conversations/{conversationId}/{uuid}.jpgに保存し、URLを返すこと
+- [x] ディレクトリが存在しない場合はmkdirSyncで作成すること
+- [x] ディレクトリが既に存在する場合はmkdirSyncを呼ばないこと
+- [x] 不正なconversationIdでパストラバーサルを防ぐこと
+
+#### deleteFile
+
+- [x] ファイルが存在する場合は削除すること
+- [x] ファイルが存在しない場合は何もしないこと
+- [x] 不正なパスでパストラバーサルを防ぐこと
 
 ---
 
@@ -375,6 +393,9 @@
 
 - [x] メッセージ作成後にbroadcastMessageを呼び出すこと
 - [x] サービスが例外を投げた場合はbroadcastMessageを呼ばないこと
+- [x] 画像ファイルが添付された場合はfileStorageに保存してimageUrlを含むDTOでcreateMessageを呼ぶこと
+- [x] JPEG・PNG以外のファイルは400エラーになること
+- [x] 2MB超のファイルは400エラーになること
 
 #### markAsRead
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -328,11 +328,25 @@ apps/api/src/
     │   │   │   ├── 無効なトークンで tokenRefreshed の失敗が emit されること
     │   │   │   └── Bearer プレフィックス付きトークンも処理できること
     │   │   └── broadcastMessage
-    │   │       └── 最小化されたペイロードのみemitする（readAtを含まない）
+    │   │       ├── 最小化されたペイロードのみemitする（readAtを含まない）
+    │   │       └── imageUrlがある場合はペイロードに含まれること
+│   ├── conversation-file-storage.service.spec.ts
+│   │   ├── saveFile
+│   │   │   ├── 画像を処理してuploads/conversations/{conversationId}/{uuid}.jpgに保存し、URLを返すこと
+│   │   │   ├── ディレクトリが存在しない場合はmkdirSyncで作成すること
+│   │   │   ├── ディレクトリが既に存在する場合はmkdirSyncを呼ばないこと
+│   │   │   └── 不正なconversationIdでパストラバーサルを防ぐこと
+│   │   └── deleteFile
+│   │       ├── ファイルが存在する場合は削除すること
+│   │       ├── ファイルが存在しない場合は何もしないこと
+│   │       └── 不正なパスでパストラバーサルを防ぐこと
 │   └── conversation.controller.spec.ts
 │       ├── createMessage
 │       │   ├── メッセージ作成後にbroadcastMessageを呼び出すこと
-│       │   └── サービスが例外を投げた場合はbroadcastMessageを呼ばないこと
+│       │   ├── サービスが例外を投げた場合はbroadcastMessageを呼ばないこと
+│       │   ├── 画像ファイルが添付された場合はfileStorageに保存してimageUrlを含むDTOでcreateMessageを呼ぶこと
+│       │   ├── JPEG・PNG以外のファイルは400エラーになること
+│       │   └── 2MB超のファイルは400エラーになること
 │       ├── markAsRead
 │       │   └── 既読更新結果を返すこと
 │       └── getUnreadCount


### PR DESCRIPTION
## Summary

- `POST /api/conversations/:id/messages` を `multipart/form-data` 対応に拡張し、`image` フィールドで画像ファイルを受け付けるようにした
- `ImageProcessingService` + `ConversationFileStorageService` により JPEG変換・圧縮後 `/uploads/conversations/{conversationId}/{uuid}.jpg` に保存
- ファイルタイプ（JPEG/PNG のみ）と 2MB サイズ制限を適用（違反時 400エラー）
- WebSocket `newMessage` イベントのペイロードに `imageUrl` フィールドを追加

## Closes

Closes #181

## Test plan

- [x] `ConversationFileStorageService` — saveFile/deleteFile の 7 テスト（パストラバーサル防御含む）
- [x] `ConversationsController` — 画像アップロード・ファイルタイプ・サイズ制限の 3 テスト追加
- [x] `ConversationsGateway` — `broadcastMessage` が `imageUrl` を含むことを確認するテスト追加
- [x] 全テストスイート通過: API 303 tests / Web 167 tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)