### PR TITLE
refactor: isPrismaKnownError 型ガード導入・spec の as any 削減

### DIFF
--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { ConversationsService } from "./conversation.service";
+import { PrismaService } from "../prisma.service";
 
 const mockPrisma = {
   post: { findUnique: jest.fn() },
@@ -27,7 +28,7 @@ describe("ConversationsService", () => {
   let service: ConversationsService;
 
   beforeEach(() => {
-    service = new ConversationsService(mockPrisma as any);
+    service = new ConversationsService(mockPrisma as unknown as PrismaService);
     jest.clearAllMocks();
   });
 

--- a/apps/api/src/identity/identity.service.spec.ts
+++ b/apps/api/src/identity/identity.service.spec.ts
@@ -5,6 +5,7 @@ import * as bcrypt from "bcrypt";
 import { Logger } from "nestjs-pino";
 import { IdentityService } from "./identity.service";
 import { CryptoService } from "./crypto.service";
+import { PrismaService } from "../prisma.service";
 
 const mockPrisma = {
   user: {
@@ -74,7 +75,7 @@ describe("IdentityService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     service = new IdentityService(
-      mockPrisma as any,
+      mockPrisma as unknown as PrismaService,
       mockJwt as unknown as JwtService,
       mockConfig,
       mockCrypto as unknown as CryptoService,

--- a/apps/api/src/identity/identity.service.ts
+++ b/apps/api/src/identity/identity.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   UnauthorizedException,
 } from "@nestjs/common";
+import { isPrismaKnownError } from "../shared/prisma-error";
 import { JwtService } from "@nestjs/jwt";
 import { ConfigService } from "@nestjs/config";
 import * as bcrypt from "bcrypt";
@@ -206,10 +207,10 @@ export class IdentityService extends IIdentityService {
         createdAt: user.createdAt,
       };
     } catch (e: unknown) {
-      const err = e as { code?: string; meta?: { target?: unknown[] } };
-      if (err?.code === "P2002") {
-        const target = Array.isArray(err.meta?.target)
-          ? err.meta.target.map(String).join(" ").toLowerCase()
+      if (isPrismaKnownError(e) && e.code === "P2002") {
+        const rawTarget = e.meta?.target;
+        const target = Array.isArray(rawTarget)
+          ? rawTarget.map(String).join(" ").toLowerCase()
           : "";
         if (target.includes("nickname")) {
           throw new ConflictException(

--- a/apps/api/src/map/map.service.spec.ts
+++ b/apps/api/src/map/map.service.spec.ts
@@ -1,4 +1,5 @@
 import { MapService } from "./map.service";
+import { PrismaService } from "../prisma.service";
 
 const mockPrisma = {
   post: {
@@ -13,7 +14,7 @@ describe("MapService", () => {
   let service: MapService;
 
   beforeEach(() => {
-    service = new MapService(mockPrisma as any);
+    service = new MapService(mockPrisma as unknown as PrismaService);
     jest.clearAllMocks();
   });
 

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -7,6 +7,7 @@ import {
 import { Prisma } from "@prisma/client";
 import { PostsService } from "./post.service";
 import { FileStorageService } from "./file-storage.service";
+import { PrismaService } from "../prisma.service";
 
 const mockFileStorage: jest.Mocked<FileStorageService> = {
   saveFile: jest.fn(),
@@ -51,7 +52,10 @@ describe("PostsService", () => {
   let service: PostsService;
 
   beforeEach(() => {
-    service = new PostsService(mockPrisma as any, mockFileStorage);
+    service = new PostsService(
+      mockPrisma as unknown as PrismaService,
+      mockFileStorage
+    );
     jest.clearAllMocks();
     mockFileStorage.saveFile.mockResolvedValue("uploads/post1/uuid.jpg");
     mockFileStorage.deleteFile.mockReturnValue(undefined);

--- a/apps/api/src/shared/prisma-error.ts
+++ b/apps/api/src/shared/prisma-error.ts
@@ -1,0 +1,13 @@
+interface PrismaKnownError {
+  code: string;
+  meta?: Record<string, unknown>;
+}
+
+export function isPrismaKnownError(e: unknown): e is PrismaKnownError {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "code" in e &&
+    typeof (e as { code: unknown }).code === "string"
+  );
+}

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { SightingsService } from "./sighting.service";
+import { PrismaService } from "../prisma.service";
 
 const mockPrisma = {
   post: { findUnique: jest.fn() },
@@ -26,7 +27,7 @@ describe("SightingsService", () => {
   let service: SightingsService;
 
   beforeEach(() => {
-    service = new SightingsService(mockPrisma as any);
+    service = new SightingsService(mockPrisma as unknown as PrismaService);
     jest.clearAllMocks();
     mockPrisma.$transaction.mockImplementation(
       async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma)

--- a/apps/api/src/users/user.controller.ts
+++ b/apps/api/src/users/user.controller.ts
@@ -7,10 +7,12 @@ import {
   HttpCode,
   HttpException,
   HttpStatus,
+  NotFoundException,
   Param,
   Post,
   UseGuards,
 } from "@nestjs/common";
+import { isPrismaKnownError } from "../shared/prisma-error";
 import { Throttle } from "@nestjs/throttler";
 import {
   ApiBearerAuth,
@@ -58,12 +60,8 @@ export class UsersController {
     try {
       return await this.identity.deleteUser(id);
     } catch (e: unknown) {
-      const err = e as { code?: string };
-      if (err?.code === "P2025") {
-        throw new HttpException(
-          { error: "ユーザーが見つかりません" },
-          HttpStatus.NOT_FOUND
-        );
+      if (isPrismaKnownError(e) && e.code === "P2025") {
+        throw new NotFoundException({ error: "ユーザーが見つかりません" });
       }
       throw e;
     }


### PR DESCRIPTION
## Summary

- `shared/prisma-error.ts` に `isPrismaKnownError` 型ガードを追加
- `identity.service.ts` / `user.controller.ts` の `e as { code?: string }` 型アサーションを型ガードに置き換え
- `user.controller.ts` の P2025 エラーを `NotFoundException` に統一（`HttpException` + `HttpStatus.NOT_FOUND` → `NotFoundException`）
- 主要 spec ファイル（post / sighting / conversation / map / identity）の `mockPrisma as any` を `as unknown as PrismaService` に変更

## Test plan

- [x] `npm run test` — API 303件・Web 178件 全パス
- [x] `npm run typecheck:api` / `typecheck:web` — 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)