### PR TITLE
fix: ローカル環境でSentryへのエラー送信を無効化

### DIFF
--- a/apps/api/src/sentry/instrument.ts
+++ b/apps/api/src/sentry/instrument.ts
@@ -5,7 +5,7 @@ dotenv.config();
 
 const dsn = process.env.SENTRY_DSN;
 
-if (dsn) {
+if (dsn && process.env.NODE_ENV === "production") {
   Sentry.init({
     dsn,
     sendDefaultPii: false,

--- a/apps/web/tests/playwright/create-post-map-flow.spec.ts
+++ b/apps/web/tests/playwright/create-post-map-flow.spec.ts
@@ -92,6 +92,8 @@ test("画像3枚で迷い猫投稿し、マーカークリックで登録内容�
   await page.getByRole("button", { name: "この内容で報告する" }).click();
   const createResponse = await createResponsePromise;
   expect(createResponse.ok()).toBeTruthy();
+  const createdPost = (await createResponse.json()) as { id: string };
+  const postId = createdPost.id;
 
   await page.waitForURL(
     (url) => {
@@ -111,37 +113,20 @@ test("画像3枚で迷い猫投稿し、マーカークリックで登録内容�
       { timeout: 10000 }
     )
     .catch(() => {});
-  await page.waitForTimeout(1000);
 
   await expect(
     page.getByRole("group", { name: "地図フィルター" })
   ).toBeVisible();
-  await expect(page.locator(".map-marker--pin").first()).toBeVisible();
 
-  const markerCount = await page.locator(".map-marker--pin").count();
-  let found = false;
+  // 新規投稿のマーカーを data-marker-id で特定して待機
+  const newMarker = page.locator(`[data-marker-id="${postId}"]`);
+  await expect(newMarker).toBeVisible({ timeout: 15000 });
+  await newMarker.click({ force: true });
 
-  for (let i = 0; i < markerCount; i += 1) {
-    await page.locator(".map-marker--pin").nth(i).click({ force: true });
-    const detailDialog = page.getByRole("dialog");
-    await expect(detailDialog).toBeVisible({ timeout: 5000 });
-    await expect(detailDialog.locator("text=読み込み中")).not.toBeVisible({
-      timeout: 5000,
-    });
-
-    const titleEl = detailDialog.locator(`text=${uniqueToken}`);
-    if ((await titleEl.count()) > 0) {
-      found = true;
-      break;
-    }
-
-    const closeBtn = page.getByRole("button", { name: "閉じる" }).first();
-    await closeBtn.click();
-    await expect(detailDialog).not.toBeVisible({ timeout: 3000 });
-  }
-
-  if (!found) {
-    console.log(`DEBUG: markerCount=${markerCount}, uniqueToken=${uniqueToken}`);
-  }
-  expect(found).toBeTruthy();
+  const detailDialog = page.getByRole("dialog");
+  await expect(detailDialog).toBeVisible({ timeout: 5000 });
+  await expect(detailDialog.locator("text=読み込み中")).not.toBeVisible({
+    timeout: 5000,
+  });
+  await expect(detailDialog.locator(`text=${uniqueToken}`)).toBeVisible();
 });

--- a/apps/web/tests/playwright/create-post-map-flow.spec.ts
+++ b/apps/web/tests/playwright/create-post-map-flow.spec.ts
@@ -128,5 +128,7 @@ test("画像3枚で迷い猫投稿し、マーカークリックで登録内容�
   await expect(detailDialog.locator("text=読み込み中")).not.toBeVisible({
     timeout: 5000,
   });
-  await expect(detailDialog.locator(`text=${uniqueToken}`)).toBeVisible();
+  await expect(
+    detailDialog.locator(`text=${uniqueToken}`).first()
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- `NODE_ENV === "production"` の場合のみ Sentry を初期化するよう変更
- ローカル開発中に `SENTRY_DSN` が設定されていても、Sentry へエラーが送信されなくなる

## Test plan
- [ ] ローカル（`NODE_ENV=development`）で起動し、Sentry にイベントが送信されないことを確認
- [ ] 本番環境（`NODE_ENV=production`）では引き続き Sentry が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)