### PR TITLE
fix: 画像のみメッセージ送信時の400エラーを修正

### DIFF
--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -284,6 +284,12 @@ describe("ConversationsService", () => {
       expect(result).toMatchObject({ id: "msg-1" });
     });
 
+    it("bodyもimageUrlも両方なしはBadRequestException", async () => {
+      await expect(
+        service.createMessage("user-1", "conv-1", {})
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it("bodyが1000文字超過はBadRequestException", async () => {
       mockPrisma.conversation.findUnique.mockResolvedValue(conversation);
 

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -179,6 +179,11 @@ export class ConversationsService {
     conversationId: string,
     dto: CreateMessageDto
   ) {
+    if (!dto.body && !dto.imageUrl) {
+      throw new BadRequestException(
+        "メッセージ本文または画像のいずれかは必須です"
+      );
+    }
     if (dto.body && dto.body.length > 1000) {
       throw new BadRequestException(
         "メッセージは1000文字以内で入力してください"

--- a/apps/api/src/conversations/dto/create-message.dto.spec.ts
+++ b/apps/api/src/conversations/dto/create-message.dto.spec.ts
@@ -3,10 +3,10 @@ import { plainToInstance } from "class-transformer";
 import { CreateMessageDto } from "./create-message.dto";
 
 describe("CreateMessageDto", () => {
-  it("bodyもimageUrlも両方nullの場合、バリデーションエラーになること", async () => {
+  it("bodyもimageUrlも両方指定なしでもDTOバリデーションは通過すること（空メッセージチェックはサービス層で行う）", async () => {
     const dto = plainToInstance(CreateMessageDto, {});
     const errors = await validate(dto);
-    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.length).toBe(0);
   });
 
   it("bodyのみ指定でバリデーションが通過すること", async () => {

--- a/apps/api/src/conversations/dto/create-message.dto.ts
+++ b/apps/api/src/conversations/dto/create-message.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString, MaxLength, ValidateIf } from "class-validator";
+import { IsOptional, IsString, MaxLength } from "class-validator";
 
 export class CreateMessageDto {
   @ApiProperty({
@@ -8,7 +8,7 @@ export class CreateMessageDto {
     required: false,
     nullable: true,
   })
-  @ValidateIf((o) => !o.imageUrl)
+  @IsOptional()
   @IsString()
   @MaxLength(1000)
   body?: string | null;
@@ -18,7 +18,7 @@ export class CreateMessageDto {
     nullable: true,
     example: "/uploads/conversations/conv-1/uuid.jpg",
   })
-  @ValidateIf((o) => !o.body)
+  @IsOptional()
   @IsString()
   imageUrl?: string | null;
 }


### PR DESCRIPTION
## Summary
- ValidationPipeがファイル処理より先に実行されるため、画像のみ送信時にDTOバリデーションが400を返していたバグを修正
- `CreateMessageDto` の `body` / `imageUrl` を `@IsOptional()` に変更
- 空メッセージ（body も imageUrl も両方なし）のチェックをサービス層へ移動

## Root Cause
`@Body() dto` の ValidationPipe がマルチパートのファイル処理より先に実行される。画像のみ送信時は `imageUrl` が FormData に含まれず、DTO バリデーションで弾かれていた。

## Test plan
- [ ] 画像のみ送信が成功すること
- [ ] テキストのみ送信が引き続き成功すること
- [ ] 画像＋テキスト同時送信が引き続き成功すること
- [ ] 何も送信しない場合は 400 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)