### PR TITLE
feat: issue#202 JWT payload に nickname を追加し AuthProvider で公開する

### DIFF
--- a/apps/api/src/auth/interfaces/jwt-payload.interface.ts
+++ b/apps/api/src/auth/interfaces/jwt-payload.interface.ts
@@ -4,4 +4,5 @@ export interface JwtPayload {
   sub: string;
   email: string;
   role: Role;
+  nickname: string;
 }

--- a/apps/api/src/identity/identity.service.spec.ts
+++ b/apps/api/src/identity/identity.service.spec.ts
@@ -182,6 +182,18 @@ describe("IdentityService", () => {
       expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(1);
     });
 
+    it("ログイン成功時、JWTペイロードにnicknameが含まれること", async () => {
+      const user = await makeUser();
+      mockPrisma.user.findUnique.mockResolvedValueOnce(user);
+      mockPrisma.refreshToken.create.mockResolvedValueOnce({});
+
+      await service.login("user@example.com", "password123");
+
+      expect(mockJwt.sign).toHaveBeenCalledWith(
+        expect.objectContaining({ nickname: "Alice" })
+      );
+    });
+
     it("production環境ではCookieのsecureとsameSiteが適切に設定されること", async () => {
       const prodConfig = {
         get: jest.fn((key: string) => {
@@ -220,7 +232,7 @@ describe("IdentityService", () => {
         tokenHash: "token-hash",
         userId: "user-1",
         expiresAt: ts,
-        user: { emailEncrypted: "enc-email", role: "user" },
+        user: { emailEncrypted: "enc-email", role: "user", nickname: "Alice" },
       });
       mockPrisma.refreshToken.create.mockResolvedValueOnce({});
 
@@ -238,7 +250,7 @@ describe("IdentityService", () => {
         tokenHash: "token-hash",
         userId: "user-1",
         expiresAt: ts,
-        user: { emailEncrypted: "enc-email", role: "user" },
+        user: { emailEncrypted: "enc-email", role: "user", nickname: "Alice" },
       });
       mockPrisma.refreshToken.create.mockResolvedValueOnce({});
 
@@ -257,7 +269,7 @@ describe("IdentityService", () => {
         tokenHash: "token-hash",
         userId: "user-1",
         expiresAt: ts,
-        user: { emailEncrypted: "enc-email", role: "user" },
+        user: { emailEncrypted: "enc-email", role: "user", nickname: "Alice" },
       });
       mockPrisma.refreshToken.create.mockResolvedValueOnce({});
 
@@ -295,7 +307,7 @@ describe("IdentityService", () => {
         tokenHash: "token-hash",
         userId: "user-1",
         expiresAt: ts,
-        user: { emailEncrypted: "enc-email", role: "user" },
+        user: { emailEncrypted: "enc-email", role: "user", nickname: "Alice" },
       });
       mockPrisma.refreshToken.delete.mockRejectedValueOnce(
         new Error("already deleted")
@@ -312,7 +324,7 @@ describe("IdentityService", () => {
         tokenHash: "token-hash",
         userId: "user-1",
         expiresAt: ts,
-        user: { emailEncrypted: "enc-email", role: "user" },
+        user: { emailEncrypted: "enc-email", role: "user", nickname: "Alice" },
       });
       mockPrisma.refreshToken.delete.mockRejectedValueOnce(
         new Error("already deleted")
@@ -327,6 +339,23 @@ describe("IdentityService", () => {
         userId: "user-1",
         reason: "token already used",
       });
+    });
+
+    it("リフレッシュ成功時、JWTペイロードにnicknameが含まれること", async () => {
+      const ts = new Date(Date.now() + 86400000);
+      mockPrisma.refreshToken.findUnique.mockResolvedValueOnce({
+        tokenHash: "token-hash",
+        userId: "user-1",
+        expiresAt: ts,
+        user: { emailEncrypted: "enc-email", role: "user", nickname: "Alice" },
+      });
+      mockPrisma.refreshToken.create.mockResolvedValueOnce({});
+
+      await service.refresh("old-refresh-token");
+
+      expect(mockJwt.sign).toHaveBeenCalledWith(
+        expect.objectContaining({ nickname: "Alice" })
+      );
     });
   });
 

--- a/apps/api/src/identity/identity.service.ts
+++ b/apps/api/src/identity/identity.service.ts
@@ -95,6 +95,7 @@ export class IdentityService extends IIdentityService {
       sub: user.id,
       email: this.decryptSafely(user.emailEncrypted),
       role: user.role,
+      nickname: user.nickname,
     };
     const accessToken = this.jwt.sign(payload);
     this.logger.log("auth.login.success", {
@@ -112,7 +113,9 @@ export class IdentityService extends IIdentityService {
     const tokenHash = this.crypto.sha256Hex(cookieToken);
     const rec = await this.prisma.refreshToken.findUnique({
       where: { tokenHash },
-      include: { user: { select: { emailEncrypted: true, role: true } } },
+      include: {
+        user: { select: { emailEncrypted: true, role: true, nickname: true } },
+      },
     });
     if (!rec || rec.expiresAt <= new Date()) {
       throw new UnauthorizedException("無効なリフレッシュトークンです");
@@ -142,6 +145,7 @@ export class IdentityService extends IIdentityService {
       sub: rec.userId,
       email: this.decryptSafely(rec.user.emailEncrypted),
       role: rec.user.role,
+      nickname: rec.user.nickname,
     };
     const accessToken = this.jwt.sign(payload);
     this.logger.log("auth.refresh.success", {
@@ -269,10 +273,17 @@ export class IdentityService extends IIdentityService {
     password: string;
     emailEncrypted: string;
     role: string;
+    nickname: string;
   } | null> {
     return this.prisma.user.findUnique({
       where: { emailHash: hmac },
-      select: { id: true, password: true, emailEncrypted: true, role: true },
+      select: {
+        id: true,
+        password: true,
+        emailEncrypted: true,
+        role: true,
+        nickname: true,
+      },
     });
   }
 

--- a/apps/web/src/auth/AuthProvider.test.tsx
+++ b/apps/web/src/auth/AuthProvider.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { AuthProvider, useAuth } from "./AuthProvider";
+
+function makeTestToken(payload: Record<string, unknown>) {
+  const b64 = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+  return `${b64({ alg: "HS256", typ: "JWT" })}.${b64(payload)}.sig`;
+}
+
+vi.mock("../../../../packages/api-client/src/index", () => ({
+  authControllerRefresh: vi.fn().mockResolvedValue({
+    data: {
+      accessToken: makeTestToken({
+        sub: "user-1",
+        email: "test@example.com",
+        role: "user",
+        nickname: "Alice",
+      }),
+    },
+  }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("react-router-dom")>();
+  return { ...mod, useNavigate: () => vi.fn() };
+});
+
+function NicknameDisplay() {
+  const { nickname } = useAuth();
+  return <span data-testid="nickname">{nickname ?? "null"}</span>;
+}
+
+describe("AuthProvider", () => {
+  it("JWTにnicknameが含まれる場合、AuthProviderがnicknameを公開すること", async () => {
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <NicknameDisplay />
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("nickname").textContent).toBe("Alice");
+    });
+  });
+
+  it("nicknameを含まないJWTの場合、nicknameがnullを返すこと", async () => {
+    const { authControllerRefresh } =
+      await import("../../../../packages/api-client/src/index");
+    vi.mocked(authControllerRefresh).mockResolvedValueOnce({
+      data: {
+        accessToken: makeTestToken({
+          sub: "user-2",
+          email: "other@example.com",
+          role: "user",
+        }),
+      },
+    } as never);
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <NicknameDisplay />
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("nickname").textContent).toBe("null");
+    });
+  });
+});

--- a/apps/web/src/auth/AuthProvider.tsx
+++ b/apps/web/src/auth/AuthProvider.tsx
@@ -11,18 +11,18 @@ import { authControllerRefresh } from "../../../../packages/api-client/src/index
 type AuthContextValue = {
   token: string | null;
   userId: string | null;
+  nickname: string | null;
   isRestoring: boolean;
   setToken: (t: string | null) => void;
   clearToken: () => void;
 };
 
-function decodeUserId(token: string | null): string | null {
+function decodePayload(token: string | null): Record<string, unknown> | null {
   if (!token) return null;
   try {
-    const payload = JSON.parse(
+    return JSON.parse(
       atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/"))
-    );
-    return (payload.sub as string) ?? null;
+    ) as Record<string, unknown>;
   } catch {
     return null;
   }
@@ -62,11 +62,13 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
     navigate("/login");
   };
 
-  const userId = decodeUserId(token);
+  const payload = decodePayload(token);
+  const userId = (payload?.sub as string) ?? null;
+  const nickname = (payload?.nickname as string) ?? null;
 
   return (
     <AuthContext.Provider
-      value={{ token, userId, isRestoring, setToken, clearToken }}
+      value={{ token, userId, nickname, isRestoring, setToken, clearToken }}
     >
       {children}
     </AuthContext.Provider>

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -450,6 +450,7 @@
 - [x] ログイン成功時に auth.login.success イベントをログ出力すること
 - [x] パスワード不一致時に auth.login.failure イベントをログ出力すること
 - [x] メールアドレス未登録時に auth.login.failure イベントをログ出力すること
+- [x] ログイン成功時、JWTペイロードにnicknameが含まれること
 
 #### refresh
 
@@ -460,6 +461,7 @@
 - [x] 再利用検知: delete失敗時にUnauthorizedExceptionを投げること
 - [x] リフレッシュ成功時に auth.refresh.success イベントをログ出力すること
 - [x] 再利用検知時に auth.refresh.reuse イベントをログ出力すること
+- [x] リフレッシュ成功時、JWTペイロードにnicknameが含まれること
 
 #### logout
 
@@ -750,6 +752,11 @@
 
 ## Web Unit (`apps/web/src/**/*.test.tsx`)
 
+### AuthProvider (`src/auth/AuthProvider.test.tsx`)
+
+- [x] JWTにnicknameが含まれる場合、AuthProviderがnicknameを公開すること
+- [x] nicknameを含まないJWTの場合、nicknameがnullを返すこと
+
 - [x] App で未認証で /posts にアクセスしたとき、Posts ページが表示されること
 - [x] App で未認証で /create にアクセスしたとき、/login にリダイレクトされること
 - [x] CreatePost で必須項目を入力して送信した時、lostDate を正規化して cat投稿として作成し /posts へ戻る
@@ -834,6 +841,10 @@
 - [x] Map で「地図から選択」クリック後、「タップして場所を選択」バナーが表示されること
 - [x] Map で地図クリックで lat/lng・住所が SightingModal にセットされ再表示されること
 - [x] Map で Nominatim 失敗時、lat/lng セット済みでモーダルが再表示されエラーメッセージが表示されること
+- [x] createMarkerIcon で isOwn=trueの時、map-marker--ownクラスが付与されること
+- [x] createMarkerIcon で isOwn=falseの時、map-marker--ownクラスが付与されないこと
+- [x] createMarkerIcon で解決済みの自分のマーカーにもmap-marker--ownクラスが付与されること
+- [x] createMarkerIcon で自分の目撃投稿マーカーにもmap-marker--ownクラスが付与されること
 - [x] reverseGeocode で正常時、Nominatim から住所文字列を返すこと
 - [x] reverseGeocode で HTTP エラー時、geocodeError を返すこと
 - [x] reverseGeocode でネットワークエラー時、geocodeError を返すこと

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -58,7 +58,8 @@ apps/api/src/
 │   │       │   ├── production環境ではCookieのsecureとsameSiteが適切に設定されること
 │   │       │   ├── ログイン成功時に auth.login.success イベントをログ出力すること
 │   │       │   ├── パスワード不一致時に auth.login.failure イベントをログ出力すること
-│   │       │   └── メールアドレス未登録時に auth.login.failure イベントをログ出力すること
+│   │       │   ├── メールアドレス未登録時に auth.login.failure イベントをログ出力すること
+│   │       │   └── ログイン成功時、JWTペイロードにnicknameが含まれること
 │   │       ├── refresh
 │   │       │   ├── 有効なトークンで新しいAuthResultを返すこと
 │   │       │   ├── トークンが存在しない場合はUnauthorizedExceptionを投げること
@@ -66,7 +67,8 @@ apps/api/src/
 │   │       │   ├── ローテーション: 新しいトークンのハッシュがDBに保存されること
 │   │       │   ├── 再利用検知: delete失敗時にUnauthorizedExceptionを投げること
 │   │       │   ├── リフレッシュ成功時に auth.refresh.success イベントをログ出力すること
-│   │       │   └── 再利用検知時に auth.refresh.reuse イベントをログ出力すること
+│   │       │   ├── 再利用検知時に auth.refresh.reuse イベントをログ出力すること
+│   │       │   └── リフレッシュ成功時、JWTペイロードにnicknameが含まれること
 │   │       ├── logout
 │   │       │   ├── リフレッシュトークンを削除すること
 │   │       │   ├── 存在しないトークンでもエラーを投げないこと
@@ -491,6 +493,10 @@ apps/api/test/
     └── POST /api/auth/logout
         └── ログアウトで Cookie が削除される (200)
 apps/web/src/
+├── auth/AuthProvider.test.tsx
+│   └── AuthProvider
+│       ├── JWTにnicknameが含まれる場合、AuthProviderがnicknameを公開すること
+│       └── nicknameを含まないJWTの場合、nicknameがnullを返すこと
 ├── App.test.tsx
 │   └── App
 │       ├── 未認証で /posts にアクセスしたとき、Posts ページが表示されること
@@ -525,6 +531,11 @@ apps/web/src/
     │           ├── 「地図から選択」クリック後、「タップして場所を選択」バナーが表示されること
     │           ├── 選択モード中に地図クリックで lat/lng・住所が SightingModal にセットされ再表示されること
     │           └── Nominatim 失敗時、lat/lng セット済みでモーダルが再表示されエラーメッセージが表示されること
+    │   └── createMarkerIcon
+    │       ├── isOwn=trueの時、map-marker--ownクラスが付与されること
+    │       ├── isOwn=falseの時、map-marker--ownクラスが付与されないこと
+    │       ├── 解決済みの自分のマーカーにもmap-marker--ownクラスが付与されること
+    │       └── 自分の目撃投稿マーカーにもmap-marker--ownクラスが付与されること
     ├── components/PostDetailSheet.test.tsx
     │   └── PostDetailSheet
     │       ├── isOpen=true の時、ダイアログが表示されること


### PR DESCRIPTION
## Summary

- `JwtPayload` インターフェースに `nickname: string` フィールドを追加
- `identity.service` の login/refresh 処理でトークン生成時に `nickname: user.nickname` を含める（`findUserByHash` と refresh の include にも `nickname` を追加）
- `AuthProvider` の `decodeUserId` を `decodePayload` に汎用化し、context に `nickname: string | null` を追加して JWT から公開

## Test plan

- [x] `identity.service.spec.ts`: login 時に JWT payload に nickname が含まれること
- [x] `identity.service.spec.ts`: refresh 時に JWT payload に nickname が含まれること
- [x] `AuthProvider.test.tsx`（新規）: nickname 含む JWT → nickname を公開すること
- [x] `AuthProvider.test.tsx`（新規）: nickname なし JWT → null を返すこと
- [x] 既存テスト 309 件（バックエンド）+ 180 件（フロントエンド）全パス

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)