### PR TITLE
feat: issue#203 自分の投稿マーカーをパルスアニメーションで区別する

### DIFF
--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -140,13 +140,21 @@ vi.mock("../auth/AuthProvider", () => ({
 }));
 
 const sampleMarkers = [
-  { id: "post-1", type: "post", status: "lost", lat: 35.9, lng: 139.6 },
+  {
+    id: "post-1",
+    type: "post",
+    status: "lost",
+    lat: 35.9,
+    lng: 139.6,
+    userId: "user-1",
+  },
   {
     id: "post-2",
     type: "post",
     status: "resolved",
     lat: 35.905,
     lng: 139.605,
+    userId: "user-2",
   },
   {
     id: "sighting-1",
@@ -154,6 +162,7 @@ const sampleMarkers = [
     status: "lost",
     lat: 35.91,
     lng: 139.61,
+    userId: "user-1",
   },
 ] as const;
 
@@ -173,7 +182,8 @@ const samplePost = {
   location: null,
 };
 
-import Map from "./Map";
+import Map, { createMarkerIcon } from "./Map";
+import type { MapMarkerDto } from "../../../../packages/api-client/src/index";
 
 describe("Map", () => {
   function renderMap() {
@@ -509,5 +519,59 @@ describe("Map", () => {
         "住所の自動取得に失敗しました。手動で入力してください"
       );
     });
+  });
+});
+
+describe("createMarkerIcon", () => {
+  it("isOwn=trueの時、map-marker--ownクラスが付与されること", () => {
+    const marker: MapMarkerDto = {
+      id: "post-1",
+      type: "post",
+      status: "lost",
+      lat: 35.9,
+      lng: 139.6,
+      userId: "user-1",
+    };
+    const icon = createMarkerIcon(marker, true);
+    expect(icon.options.html).toContain("map-marker--own");
+  });
+
+  it("isOwn=falseの時、map-marker--ownクラスが付与されないこと", () => {
+    const marker: MapMarkerDto = {
+      id: "post-2",
+      type: "post",
+      status: "lost",
+      lat: 35.9,
+      lng: 139.6,
+      userId: "user-2",
+    };
+    const icon = createMarkerIcon(marker, false);
+    expect(icon.options.html).not.toContain("map-marker--own");
+  });
+
+  it("解決済みの自分のマーカーにもmap-marker--ownクラスが付与されること", () => {
+    const marker: MapMarkerDto = {
+      id: "post-3",
+      type: "post",
+      status: "resolved",
+      lat: 35.9,
+      lng: 139.6,
+      userId: "user-1",
+    };
+    const icon = createMarkerIcon(marker, true);
+    expect(icon.options.html).toContain("map-marker--own");
+  });
+
+  it("自分の目撃投稿マーカーにもmap-marker--ownクラスが付与されること", () => {
+    const marker: MapMarkerDto = {
+      id: "sighting-1",
+      type: "sighting",
+      status: "lost",
+      lat: 35.9,
+      lng: 139.6,
+      userId: "user-1",
+    };
+    const icon = createMarkerIcon(marker, true);
+    expect(icon.options.html).toContain("map-marker--own");
   });
 });

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -75,16 +75,17 @@ function getMarkerTone(marker: MapMarkerDto) {
   return { fill: "#1a73e8", edge: "#185abc" };
 }
 
-function createMarkerIcon(marker: MapMarkerDto) {
+export function createMarkerIcon(marker: MapMarkerDto, isOwn: boolean) {
   const tone = getMarkerTone(marker);
   const shapeClass =
     marker.type === "post" ? "map-marker--pin" : "map-marker--circle";
+  const ownClass = isOwn ? " map-marker--own" : "";
 
   const label = getMarkerLabel(marker);
   return L.divIcon({
     className: "map-marker-icon",
     html: `
-      <span class="map-marker ${shapeClass}" role="button" tabindex="0" aria-label="${label}" data-marker-id="${marker.id}" style="--marker-fill:${tone.fill};--marker-edge:${tone.edge};">
+      <span class="map-marker ${shapeClass}${ownClass}" role="button" tabindex="0" aria-label="${label}" data-marker-id="${marker.id}" style="--marker-fill:${tone.fill};--marker-edge:${tone.edge};">
         <span class="map-marker__core"></span>
       </span>
       <span class="map-marker-label" aria-hidden="true">${label}</span>
@@ -421,7 +422,7 @@ export default function Map() {
               <Marker
                 key={`${marker.type}-${marker.id}`}
                 position={[marker.lat, marker.lng]}
-                icon={createMarkerIcon(marker)}
+                icon={createMarkerIcon(marker, marker.userId === currentUserId)}
                 title={marker.type === "post" ? "迷子投稿" : "目撃情報"}
                 eventHandlers={{
                   click: () => setSelectedMarker(marker),

--- a/apps/web/src/styles/map.css
+++ b/apps/web/src/styles/map.css
@@ -93,6 +93,32 @@
   box-shadow: 0 2px 8px rgba(15, 23, 42, 0.14);
 }
 
+/* ── 自分の投稿マーカー: パルスアニメーション ── */
+@keyframes map-marker-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  70% {
+    transform: scale(2.2);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(2.2);
+    opacity: 0;
+  }
+}
+
+.map-marker--own::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--marker-fill);
+  animation: map-marker-pulse 1.8s ease-out infinite;
+  z-index: -1;
+}
+
 /* ── Leaflet ポップアップ ── */
 .map-popup {
   min-width: 140px;


### PR DESCRIPTION
## Summary

- `createMarkerIcon` を `export` して `isOwn: boolean` パラメータを追加
- `marker.userId === currentUserId` の時に `map-marker--own` クラスを付与
- `map.css` にパルスアニメーション（波紋が外側に広がる `::before` 疑似要素）を追加
- 迷子投稿・目撃投稿・解決済み全パターンに適用

## Test plan

- [x] `createMarkerIcon(marker, true)` → icon HTML に `map-marker--own` が含まれること
- [x] `createMarkerIcon(marker, false)` → icon HTML に `map-marker--own` が含まれないこと
- [x] 解決済みマーカー（status=resolved）も `isOwn=true` でクラス付与
- [x] 目撃マーカー（type=sighting）も `isOwn=true` でクラス付与
- [x] 既存 Map テスト 14件 + 新規 4件 = 18件全パス
- [x] 全 Web テスト 182件パス
- [x] 全 API テスト 307件パス

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)