### PR TITLE
fix: 投稿マーカーにuserIdを含めて自分の投稿判定を修正

### DIFF
--- a/apps/api/src/map/map.service.spec.ts
+++ b/apps/api/src/map/map.service.spec.ts
@@ -222,5 +222,21 @@ describe("MapService", () => {
         expect.arrayContaining(["post", "sighting"])
       );
     });
+
+    it("Postマーカーに投稿者のuserIdが含まれること", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([
+        {
+          id: "post-1",
+          userId: "user-abc",
+          status: "lost",
+          location: { lat: 35.9, lng: 139.6 },
+        },
+      ]);
+      mockPrisma.sighting.findMany.mockResolvedValue([]);
+
+      const result = await service.getMarkers({});
+
+      expect(result[0]).toMatchObject({ type: "post", userId: "user-abc" });
+    });
   });
 });

--- a/apps/api/src/map/map.service.ts
+++ b/apps/api/src/map/map.service.ts
@@ -60,6 +60,7 @@ export class MapService {
       where: postWhere,
       select: {
         id: true,
+        userId: true,
         status: true,
         location: { select: { lat: true, lng: true } },
       },
@@ -87,6 +88,7 @@ export class MapService {
       .map((p) => ({
         type: "post",
         id: p.id,
+        userId: p.userId,
         lat: p.location!.lat,
         lng: p.location!.lng,
         status: p.status,


### PR DESCRIPTION
## Summary

- `map.service.ts` の posts SELECT に `userId` が欠落していたため、迷子猫投稿マーカーの `userId` が常に `null` になっていた
- `userId: true` を SELECT に追加し、postMarkers に `userId: p.userId` を渡すよう修正
- テスト追加: 「Postマーカーに投稿者のuserIdが含まれること」

## Test plan

- [x] `map.service.spec.ts` 全11テスト通過
- [x] API/Webテスト全件通過 (310 + 188)
- [x] seed-owner でログイン → 迷子猫投稿マーカーに `map-marker--own` クラス適用確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)