### PR TITLE
fix: 投稿削除ボタンを自分の投稿のみに表示するよう修正

### DIFF
--- a/apps/web/src/pages/Posts.tsx
+++ b/apps/web/src/pages/Posts.tsx
@@ -206,36 +206,38 @@ export default function Posts() {
                     >
                       <MapPinned size={18} aria-hidden="true" />
                     </button>
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-sm font-semibold text-destructive hover:text-destructive/80 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded min-h-[44px]"
-                        >
-                          削除
-                        </button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>
-                            投稿を削除しますか？
-                          </AlertDialogTitle>
-                          <AlertDialogDescription>
-                            この操作は取り消せません。関連する会話と目撃情報も削除されます。
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => {
-                              handleDelete(p.id);
-                            }}
+                    {userId === p.userId && (
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <button
+                            type="button"
+                            className="text-sm font-semibold text-destructive hover:text-destructive/80 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none rounded min-h-[44px]"
                           >
-                            削除する
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
+                            削除
+                          </button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>
+                              投稿を削除しますか？
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                              この操作は取り消せません。関連する会話と目撃情報も削除されます。
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogAction
+                              onClick={() => {
+                                handleDelete(p.id);
+                              }}
+                            >
+                              削除する
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- `Posts.tsx` の削除ボタンに所有者チェック（`userId === p.userId`）が欠けていたUIバグを修正
- 他ユーザーの投稿にも削除ボタンが表示されていた（APIは403で正しく拒否していたがUIの問題）
- 目撃情報の削除（`SightingList.tsx`）は既に所有者チェック済みで問題なし

## Test plan

- [ ] 自分の投稿には削除ボタンが表示されること
- [ ] 他ユーザーの投稿には削除ボタンが表示されないこと
- [ ] 削除ボタンを押すと確認ダイアログが表示されること
- [ ] 削除を実行すると投稿が消え、トーストが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)