### PR TITLE
fix: JWTペイロードの日本語ニックネーム文字化けを修正

### DIFF
--- a/apps/web/src/auth/AuthProvider.tsx
+++ b/apps/web/src/auth/AuthProvider.tsx
@@ -20,9 +20,12 @@ type AuthContextValue = {
 function decodePayload(token: string | null): Record<string, unknown> | null {
   if (!token) return null;
   try {
-    return JSON.parse(
-      atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/"))
-    ) as Record<string, unknown>;
+    const base64 = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+    const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+    return JSON.parse(new TextDecoder().decode(bytes)) as Record<
+      string,
+      unknown
+    >;
   } catch {
     return null;
   }


### PR DESCRIPTION
## 概要

会話一覧ヘッダーの「ニックネーム 様」が文字化けする問題を修正。

## 原因

`AuthProvider.tsx` の `decodePayload` 関数で `atob()` を直接 `JSON.parse` に渡していた。`atob()` はBase64をLatin-1バイト列として返すだけで、UTF-8マルチバイト文字（日本語）を正しく扱えない。

## 修正内容

`atob()` → `Uint8Array` → `TextDecoder` の順でUTF-8デコードするよう変更。

```ts
// Before
JSON.parse(atob(base64))

// After
const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
JSON.parse(new TextDecoder().decode(bytes))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)