### PR TITLE
chore: vps-deploy.sh に必須環境変数チェックを追加

### DIFF
--- a/scripts/vps-deploy.sh
+++ b/scripts/vps-deploy.sh
@@ -179,6 +179,23 @@ echo ""
 echo "Step 5/10: API ビルド"
 npm run build --workspace=apps/api
 
+# 5.5. 必須環境変数チェック ----------------------------------------------------------
+echo ""
+echo "Step 5.5/10: 必須環境変数チェック"
+required_vars=(DATABASE_URL JWT_SECRET ENCRYPTION_KEY_CURRENT HMAC_SECRET)
+missing=()
+for var in "${required_vars[@]}"; do
+  if ! grep -q "^${var}=" "$PROJECT_DIR/apps/api/.env" 2>/dev/null; then
+    missing+=("$var")
+  fi
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "❌ apps/api/.env に必須変数が不足しています: ${missing[*]}"
+  echo "   デプロイを中断します。.env を更新してから再実行してください。"
+  exit 1
+fi
+echo "  必須環境変数: すべて確認済み"
+
 # 6. PM2 再起動 ----------------------------------------------------------------------
 echo ""
 echo "Step 6/10: PM2 再起動 ($PM2_NAME)"


### PR DESCRIPTION
## Summary

- PM2 再起動前（Step 5.5）に必須環境変数の存在チェックを追加
- `DATABASE_URL` / `JWT_SECRET` / `ENCRYPTION_KEY_CURRENT` / `HMAC_SECRET` が `.env` に存在しない場合はデプロイを中断
- `.env` 更新漏れによる起動クラッシュループ（過去に 111 回発生）の再発防止

## Background

`ENCRYPTION_KEY_CURRENT` が VPS の `.env` に未設定の状態でデプロイされ、`CryptoService.onModuleInit()` が起動のたびにクラッシュ。PM2 が自動再起動を繰り返し 111 回に達していた。

## Test plan

- [ ] `.env` から `ENCRYPTION_KEY_CURRENT` を削除してデプロイを実行 → Step 5.5 で中断されることを確認
- [ ] 全変数が揃った状態でデプロイを実行 → 正常に続行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)