### PR TITLE
feat: Sentry Performance Monitoring + Prisma DB遅延計測を有効化

### DIFF
--- a/apps/api/src/sentry/instrument.ts
+++ b/apps/api/src/sentry/instrument.ts
@@ -1,5 +1,7 @@
 import * as dotenv from "dotenv";
 import * as Sentry from "@sentry/nestjs";
+import { prismaIntegration } from "@sentry/node";
+import { PrismaInstrumentation } from "@prisma/instrumentation";
 
 dotenv.config();
 
@@ -9,5 +11,11 @@ if (dsn && process.env.NODE_ENV === "production") {
   Sentry.init({
     dsn,
     sendDefaultPii: false,
+    tracesSampleRate: 0.2,
+    integrations: [
+      prismaIntegration({
+        prismaInstrumentation: new PrismaInstrumentation(),
+      }),
+    ],
   });
 }


### PR DESCRIPTION
## Summary

- `tracesSampleRate: 0.2` を追加し HTTP トレース収集を有効化（本番 20% サンプリング）
- `prismaIntegration` + `PrismaInstrumentation` で SQL 単位の span を取得
- `SENTRY_DSN` 未設定時は引き続き無効（開発環境に影響なし）

## これで見えるようになるもの

Sentry の Performance 画面で以下が確認できる：

```
Transaction: GET /api/posts
Total: 320ms
├─ middleware  10ms
├─ auth        30ms
├─ SQL query  260ms  ← 遅いSQLを特定できる
└─ serialize   20ms
```

- SQL 単位の実行時間
- N+1 クエリの検出
- どのユーザー操作で遅くなったか

## VPS 対応

`SENTRY_DSN` を VPS の `.env` に追加済み。デプロイ後に有効になる。

## Test plan

- [ ] デプロイ後に Sentry ダッシュボード → Performance でトレースが表示されることを確認
- [ ] SQL span が transaction 内に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)