### PR TITLE
fix: ピンチ操作でコンテキストメニューが誤発火するバグを修正

### DIFF
--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -807,6 +807,11 @@ function MapContextMenuHandler({
     };
 
     const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length > 1) {
+        clearTimer();
+        startPos.current = null;
+        return;
+      }
       const touch = e.touches[0];
       startPos.current = { x: touch.clientX, y: touch.clientY };
       timerRef.current = setTimeout(() => {
@@ -815,6 +820,11 @@ function MapContextMenuHandler({
     };
 
     const handleTouchMove = (e: TouchEvent) => {
+      if (e.touches.length > 1) {
+        clearTimer();
+        startPos.current = null;
+        return;
+      }
       if (!startPos.current) return;
       const touch = e.touches[0];
       const dx = touch.clientX - startPos.current.x;


### PR DESCRIPTION
## Summary

- ピンチイン/アウト（2本指ズーム）操作中にボトムシートが表示されてしまうバグを修正
- `MapContextMenuHandler` の `handleTouchStart` / `handleTouchMove` で `e.touches.length > 1`（マルチタッチ）を検出したら長押しタイマーをキャンセルするよう変更

## 原因

1本目の指を置いた時点で長押しタイマー（600ms）が起動する
2本目の指を置いても（`touchstart` 再発火）タイマーをキャンセルしていなかった
ピンチ中に1本目の指の移動量が10px未満だとキャンセル条件を満たさずタイマーが発火してしまっていた

## Test plan

- [ ] 地図上でピンチイン/アウトしてもボトムシートが開かないことを確認
- [ ] 地図上で長押し（1本指）するとボトムシートが正常に開くことを確認
- [ ] 全テスト通過（315 API + 206 Web）

🤖 Generated with [Claude Code](https://claude.com/claude-code)