### PR TITLE
fix: 会話メッセージの画像アップロード上限を20MBに拡大

### DIFF
--- a/apps/api/src/conversations/conversation.controller.spec.ts
+++ b/apps/api/src/conversations/conversation.controller.spec.ts
@@ -140,11 +140,11 @@ describe("ConversationsController", () => {
       expect(result).toBe(message);
     });
 
-    it("JPEG・PNG以外のファイルは400エラーになること", async () => {
+    it("未対応のファイル形式（HEIC等）は400エラーになること", async () => {
       const file = {
-        buffer: Buffer.from("gif"),
-        originalname: "anim.gif",
-        mimetype: "image/gif",
+        buffer: Buffer.from("heic"),
+        originalname: "photo.heic",
+        mimetype: "image/heic",
         size: 100,
       } as Express.Multer.File;
 
@@ -153,12 +153,27 @@ describe("ConversationsController", () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it("2MB超のファイルは400エラーになること", async () => {
+    it("GIF・WebP は許容されること", async () => {
+      for (const mimetype of ["image/gif", "image/webp"]) {
+        const file = {
+          buffer: Buffer.from("data"),
+          originalname: "image",
+          mimetype,
+          size: 100,
+        } as Express.Multer.File;
+
+        await expect(
+          controller.createMessage(req, "conv-1", {}, file)
+        ).resolves.not.toThrow();
+      }
+    });
+
+    it("20MB超のファイルは400エラーになること", async () => {
       const file = {
-        buffer: Buffer.alloc(3 * 1024 * 1024),
+        buffer: Buffer.alloc(0),
         originalname: "big.jpg",
         mimetype: "image/jpeg",
-        size: 3 * 1024 * 1024,
+        size: 21 * 1024 * 1024,
       } as Express.Multer.File;
 
       await expect(

--- a/apps/api/src/conversations/conversation.controller.ts
+++ b/apps/api/src/conversations/conversation.controller.ts
@@ -42,8 +42,13 @@ import { ConversationsGateway } from "./conversations.gateway";
 import { ConversationFileStorageService } from "./conversation-file-storage.service";
 import { AuthenticatedRequest } from "../auth/interfaces/authenticated-request.interface";
 
-const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png"];
-const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
+const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB（sharp で圧縮するため生ファイルは大きくても許容）
 
 @ApiTags("conversations")
 @Controller("conversations")
@@ -160,11 +165,11 @@ export class ConversationsController {
     if (file) {
       if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
         throw new BadRequestException(
-          `未対応のファイル形式です: ${file.mimetype}。JPEG または PNG を使用してください。`
+          `未対応のファイル形式です: ${file.mimetype}。JPEG、PNG、GIF、WebP を使用してください。`
         );
       }
       if (file.size > MAX_FILE_SIZE) {
-        throw new BadRequestException("ファイルサイズは2MB以内にしてください");
+        throw new BadRequestException("ファイルサイズは20MB以内にしてください");
       }
       const savedUrl = await this.conversationFileStorage.saveFile(id, file);
       dto = { ...dto, imageUrl: `/${savedUrl}` };


### PR DESCRIPTION
## Summary

- iPhoneから画像を送信すると `PayloadTooLargeException` が発生する Sentry エラーを修正
- multer の受け入れ上限 2MB → 20MB に変更（sharp が1200px+80%JPEGで圧縮するため、保存後のサイズは大幅に小さくなる）
- `ALLOWED_MIME_TYPES` に `image/gif` / `image/webp` を追加し、投稿エンドポイントと統一

## 原因

multer のサイズチェックは `ImageProcessingService`（sharp 圧縮）より先に実行されるため、
圧縮前の生ファイル（iPhone 写真は 3〜15MB）で弾かれていた。

## Test plan

- [ ] iPhoneから会話画像を送信できることを確認
- [ ] 20MB超のファイルは 400 エラーになることを確認
- [ ] HEIC 等の未対応形式は 400 エラーになることを確認
- [ ] 全テスト通過（API 316件 / Web 206件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)