### PR TITLE
fix: iPhoneアップロード画像のEXIF回転を自動補正

### DIFF
--- a/apps/api/src/shared/image-processing.service.spec.ts
+++ b/apps/api/src/shared/image-processing.service.spec.ts
@@ -3,6 +3,7 @@ import { ImageProcessingService } from "./image-processing.service";
 
 jest.mock("sharp", () =>
   jest.fn().mockReturnValue({
+    rotate: jest.fn().mockReturnThis(),
     resize: jest.fn().mockReturnThis(),
     jpeg: jest.fn().mockReturnThis(),
     toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed")),
@@ -17,6 +18,7 @@ describe("ImageProcessingService", () => {
     jest.clearAllMocks();
     const sharpMock = jest.requireMock("sharp") as jest.Mock;
     sharpMock.mockReturnValue({
+      rotate: jest.fn().mockReturnThis(),
       resize: jest.fn().mockReturnThis(),
       jpeg: jest.fn().mockReturnThis(),
       toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed")),
@@ -36,6 +38,7 @@ describe("ImageProcessingService", () => {
     const jpegMock = jest.fn().mockReturnThis();
     const toBufferMock = jest.fn().mockResolvedValue(Buffer.from("processed"));
     sharpMock.mockReturnValue({
+      rotate: jest.fn().mockReturnThis(),
       resize: resizeMock,
       jpeg: jpegMock,
       toBuffer: toBufferMock,
@@ -55,6 +58,7 @@ describe("ImageProcessingService", () => {
     const jpegMock = jest.fn().mockReturnThis();
     const toBufferMock = jest.fn().mockResolvedValue(Buffer.from("processed"));
     sharpMock.mockReturnValue({
+      rotate: jest.fn().mockReturnThis(),
       resize: resizeMock,
       jpeg: jpegMock,
       toBuffer: toBufferMock,
@@ -65,9 +69,25 @@ describe("ImageProcessingService", () => {
     expect(jpegMock).toHaveBeenCalledWith({ quality: 80 });
   });
 
+  it("EXIFの向き補正のためrotateを引数なしで呼ぶこと", async () => {
+    const sharpMock = jest.requireMock("sharp") as jest.Mock;
+    const rotateMock = jest.fn().mockReturnThis();
+    sharpMock.mockReturnValue({
+      rotate: rotateMock,
+      resize: jest.fn().mockReturnThis(),
+      jpeg: jest.fn().mockReturnThis(),
+      toBuffer: jest.fn().mockResolvedValue(Buffer.from("processed")),
+    });
+
+    await service.process(Buffer.from("raw"));
+
+    expect(rotateMock).toHaveBeenCalledWith();
+  });
+
   it("sharpがエラーをスローした時、BadRequestExceptionになること", async () => {
     const sharpMock = jest.requireMock("sharp") as jest.Mock;
     sharpMock.mockReturnValue({
+      rotate: jest.fn().mockReturnThis(),
       resize: jest.fn().mockReturnThis(),
       jpeg: jest.fn().mockReturnThis(),
       toBuffer: jest.fn().mockRejectedValue(new Error("corrupt image")),

--- a/apps/api/src/shared/image-processing.service.ts
+++ b/apps/api/src/shared/image-processing.service.ts
@@ -6,6 +6,7 @@ export class ImageProcessingService {
   async process(buffer: Buffer): Promise<Buffer> {
     try {
       return await sharp(buffer)
+        .rotate()
         .resize({ width: 1200, withoutEnlargement: true })
         .jpeg({ quality: 80 })
         .toBuffer();


### PR DESCRIPTION
## Summary

- iPhoneで撮影した写真をアップロードすると90度回転して表示される問題を修正
- `ImageProcessingService` の sharp パイプラインに `.rotate()` を追加
- 投稿・会話メッセージ両方のアップロードに適用される（`FileStorageBase` 経由で共通処理）

## 原因

sharp はデフォルトでは EXIF の `Orientation` タグを無視する。
`.rotate()` を引数なしで呼ぶと EXIF の向き情報をもとに自動補正される。

## Test plan

- [ ] iPhoneで撮影した写真をアップロードして正しい向きで表示されることを確認
- [ ] 全テスト通過（API 317件 / Web 206件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)