### PR TITLE
fix: issue#237 axios に withCredentials: true を設定し本番クロスオリジンで Cookie を送受信可能にする

### DIFF
--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -1,0 +1,54 @@
+import axios from "axios";
+import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
+import { createClient } from "../../../../packages/api-client/src/client";
+
+vi.mock("../../../../packages/api-client/src/index", () => ({
+  authControllerLogin: vi.fn(),
+  authControllerRefresh: vi.fn(),
+  authControllerLogout: vi.fn(),
+  postsControllerList: vi.fn(),
+  postsControllerCreate: vi.fn(),
+  postsControllerUpdate: vi.fn(),
+  postsControllerGet: vi.fn(),
+  postsControllerRemove: vi.fn(),
+  postsControllerAddImages: vi.fn(),
+  postsControllerRemoveImage: vi.fn(),
+  usersControllerRegister: vi.fn(),
+  mapControllerGetMarkers: vi.fn(),
+  conversationsControllerFindAll: vi.fn(),
+  conversationsControllerCreate: vi.fn(),
+  conversationsControllerFindOne: vi.fn(),
+  conversationsControllerFindMessages: vi.fn(),
+  conversationsControllerCreateMessage: vi.fn(),
+  conversationsControllerMarkAsRead: vi.fn(),
+  sightingsControllerCreate: vi.fn(),
+  sightingsControllerFindByPost: vi.fn(),
+  sightingsControllerFindOne: vi.fn(),
+  sightingsControllerRemove: vi.fn(),
+  conversationsControllerGetUnreadCount: vi.fn(),
+}));
+
+describe("createClient", () => {
+  let savedWithCredentials: boolean | undefined;
+
+  beforeEach(() => {
+    savedWithCredentials = axios.defaults.withCredentials;
+    axios.defaults.withCredentials = undefined as unknown as boolean;
+  });
+
+  afterEach(() => {
+    axios.defaults.withCredentials = savedWithCredentials as boolean;
+  });
+
+  it("createClient を呼び出した後、axios.defaults.withCredentials が true になること", () => {
+    const client = createClient({});
+    expect(axios.defaults.withCredentials).toBe(true);
+    client.dispose();
+  });
+
+  it("baseURL オプション指定時も withCredentials が true になること", () => {
+    const client = createClient({ baseURL: "http://localhost:3000" });
+    expect(axios.defaults.withCredentials).toBe(true);
+    client.dispose();
+  });
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -48,6 +48,7 @@ export type ClientOptions = {
 
 export function createClient(options: ClientOptions) {
   if (options.baseURL) axios.defaults.baseURL = options.baseURL;
+  axios.defaults.withCredentials = true;
 
   const reqId = axios.interceptors.request.use(
     async (config: InternalAxiosRequestConfig) => {

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -796,6 +796,11 @@
 
 ## Web Unit (`apps/web/src/**/*.test.tsx`)
 
+### createClient (`src/api/client.test.ts`)
+
+- [x] createClient を呼び出した後、axios.defaults.withCredentials が true になること
+- [x] baseURL オプション指定時も withCredentials が true になること
+
 ### AuthProvider (`src/auth/AuthProvider.test.tsx`)
 
 - [x] JWTにnicknameが含まれる場合、AuthProviderがnicknameを公開すること

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -516,6 +516,10 @@ apps/api/test/
     └── POST /api/auth/logout
         └── ログアウトで Cookie が削除される (200)
 apps/web/src/
+├── api/client.test.ts
+│   └── createClient
+│       ├── createClient を呼び出した後、axios.defaults.withCredentials が true になること
+│       └── baseURL オプション指定時も withCredentials が true になること
 ├── auth/AuthProvider.test.tsx
 │   └── AuthProvider
 │       ├── JWTにnicknameが含まれる場合、AuthProviderがnicknameを公開すること


### PR DESCRIPTION
## Summary

- `packages/api-client/src/client.ts` の `createClient` に `axios.defaults.withCredentials = true` を追加
- Orval 生成の `index.ts` も同じグローバル axios を使うため、生成クライアントのリクエストにも自動適用
- Vite dev proxy（Same-Origin）環境での動作に影響なし

## Test plan

- [x] `createClient` 呼び出し後 `axios.defaults.withCredentials === true` になること（新規2件）
- [x] `npm run test`（API: 326件 + Web: 208件）全通過
- [x] 型チェック通過

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)