### PR TITLE
chore: 未使用の apps/web/src/api/client.ts を削除

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,5 +1,0 @@
-// Placeholder: generated client will live in packages/api-client
-// Import generated client here when available, or use axios as fallback.
-import axios from "axios";
-
-export const api = axios.create({});


### PR DESCRIPTION
## 概要

`apps/web/src/api/client.ts` は axios インスタンスをエクスポートしているが、どのファイルからも import されていないデッドコード。削除してコードベースをクリーンにする。

## 変更内容

- `apps/web/src/api/client.ts` を削除
- `grep` で `api/client` の参照がないことを確認済み

## テスト結果

- `npm run typecheck:web` 通過
- `npm run test --workspace=apps/web` 全208テスト通過