### PR TITLE
perf: TanStack Query の staleTime 設定と queryKey 一元管理を導入

### DIFF
--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -8,6 +8,7 @@ import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
 import SightingList from "./SightingList";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { PREFECTURE_LABELS } from "../lib/constants";
+import { QUERY_KEYS } from "../lib/queryKeys";
 import { useApiClient } from "../api/orvalClient";
 
 interface PostDetailSheetProps {
@@ -64,7 +65,7 @@ export default function PostDetailSheet({
     markerType === "post" ? post?.title || "迷い猫投稿" : "目撃情報";
 
   const { data: sightingDetail } = useQuery({
-    queryKey: ["sighting", sightingId],
+    queryKey: QUERY_KEYS.sighting(sightingId!),
     queryFn: () => api.getSighting(sightingId!),
     enabled: markerType === "sighting" && !!sightingId,
   });

--- a/apps/web/src/components/SightingList.tsx
+++ b/apps/web/src/components/SightingList.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { SightingResponseDto } from "../../../../packages/api-client/src/index";
 import { useApiClient } from "../api/orvalClient";
+import { QUERY_KEYS } from "../lib/queryKeys";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -45,7 +46,7 @@ export default function SightingList({
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: sightings, isLoading } = useQuery({
-    queryKey: ["sightings", postId],
+    queryKey: QUERY_KEYS.sightings(postId),
     queryFn: () => api.findSightingsByPost(postId),
   });
 

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -1,0 +1,10 @@
+export const QUERY_KEYS = {
+  posts: () => ["posts"] as const,
+  postsInfinite: () => ["posts", "infinite"] as const,
+  sightings: (postId: string) => ["sightings", postId] as const,
+  sighting: (sightingId: string) => ["sighting", sightingId] as const,
+  conversations: () => ["conversations"] as const,
+  conversation: (id: string) => ["conversation", id] as const,
+  messages: (id: string) => ["messages", id] as const,
+  unreadCount: () => ["unread-count"] as const,
+} as const;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,6 +9,7 @@ import { AuthProvider } from "./auth/AuthProvider";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      staleTime: 30_000,
       retry: (failureCount, error) => {
         if ((error as { status?: number })?.status === 429) return false;
         return failureCount < 3;

--- a/apps/web/src/pages/ConversationChat.tsx
+++ b/apps/web/src/pages/ConversationChat.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { ChevronLeft, ImageIcon, X, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { createConversationSocket } from "../lib/conversationSocket";
+import { QUERY_KEYS } from "../lib/queryKeys";
 import { useApiClient } from "../api/orvalClient";
 import { useAuth } from "../auth/AuthProvider";
 import type { MessageResponseDto } from "../../../../packages/api-client/src/index";
@@ -55,7 +56,7 @@ export default function ConversationChat() {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const { data: conversation } = useQuery({
-    queryKey: ["conversation", id],
+    queryKey: QUERY_KEYS.conversation(id!),
     queryFn: () => client.getConversation(id!),
     enabled: !!id,
   });
@@ -66,7 +67,7 @@ export default function ConversationChat() {
     error,
     refetch: refetchMessages,
   } = useQuery({
-    queryKey: ["messages", id],
+    queryKey: QUERY_KEYS.messages(id!),
     queryFn: () => client.getMessages(id!),
     enabled: !!id,
   });

--- a/apps/web/src/pages/Conversations.tsx
+++ b/apps/web/src/pages/Conversations.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useApiClient } from "../api/orvalClient";
 import { useAuth } from "../auth/AuthProvider";
 import BottomNav from "../components/BottomNav";
+import { QUERY_KEYS } from "../lib/queryKeys";
 import type { ConversationListItemDto } from "../../../../packages/api-client/src/index";
 
 export function formatDate(dateStr: string): string {
@@ -30,8 +31,9 @@ export default function Conversations() {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["conversations"],
+    queryKey: QUERY_KEYS.conversations(),
     queryFn: () => client.listConversations(),
+    staleTime: 5_000,
     refetchInterval: (query) => (query.state.error ? false : 5000),
   });
 

--- a/apps/web/src/pages/Map.tsx
+++ b/apps/web/src/pages/Map.tsx
@@ -16,6 +16,7 @@ import { useApiClient } from "../api/orvalClient";
 import PostDetailSheet from "../components/PostDetailSheet";
 import SightingModal from "../components/SightingModal";
 import { reverseGeocode } from "../lib/reverseGeocode";
+import { QUERY_KEYS } from "../lib/queryKeys";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -134,10 +135,11 @@ export default function Map() {
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
 
   const { data: unreadData } = useQuery({
-    queryKey: ["unread-count"],
+    queryKey: QUERY_KEYS.unreadCount(),
     queryFn: () => api.getUnreadCount(),
     enabled: !!currentUserId,
-    refetchInterval: 30000,
+    staleTime: 10_000,
+    refetchInterval: 30_000,
   });
 
   // flyTo on initial load from query params

--- a/apps/web/src/pages/Posts.tsx
+++ b/apps/web/src/pages/Posts.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { MapPinned } from "lucide-react";
 import { useAuth } from "../auth/AuthProvider";
 import BottomNav from "../components/BottomNav";
+import { QUERY_KEYS } from "../lib/queryKeys";
 
 const PER_PAGE = 5;
 
@@ -41,7 +42,7 @@ export default function Posts() {
     isLoading,
     isError,
   } = useInfiniteQuery({
-    queryKey: ["posts", "infinite"],
+    queryKey: QUERY_KEYS.postsInfinite(),
     queryFn: ({ pageParam }: { pageParam: number }) =>
       api.listPosts(pageParam, PER_PAGE, true),
     initialPageParam: 1,
@@ -61,7 +62,7 @@ export default function Posts() {
     async (id: string) => {
       try {
         await api.deletePost(id);
-        queryClient.invalidateQueries({ queryKey: ["posts"] });
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.posts() });
         toast.success("削除しました");
       } catch (e) {
         toast.error("削除に失敗しました");


### PR DESCRIPTION
## 概要

TanStack Query のキャッシュ戦略を整備し、過剰フェッチ防止と queryKey 管理の一元化を行う。

## 変更内容

### 1. staleTime 設定
- `QueryClient` の `defaultOptions.queries.staleTime` にグローバル値 `30_000ms` を設定
- 未読数 (`unreadCount`): `staleTime: 10_000` + `refetchInterval: 30_000`
- 会話一覧 (`conversations`): `staleTime: 5_000` + `refetchInterval: 5_000`

### 2. QUERY_KEYS 定数の一元管理
- `apps/web/src/lib/queryKeys.ts` を新規作成
- 全8種の queryKey を定数として集約: `posts`, `postsInfinite`, `sightings`, `sighting`, `conversations`, `conversation`, `messages`, `unreadCount`
- 全コンポーネントの `useQuery` / `useInfiniteQuery` / `invalidateQueries` を `QUERY_KEYS` 定数に置換

## テスト結果

- `npm run typecheck:web` 通過
- `npm run test --workspace=apps/web` 全208テスト通過