### PR TITLE
feat: issue#240 isRestoring 中の白画面をスピナー表示に置き換える

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "@/auth/AuthProvider";
 import App from "@/App";
 import React, { useEffect } from "react";
+import { authControllerRefresh } from "../../../packages/api-client/src/index";
 
 vi.mock("../../../packages/api-client/src/index", () => ({
   authControllerRefresh: vi.fn().mockRejectedValue(new Error("no cookie")),
@@ -86,6 +87,22 @@ describe("App", () => {
 
     expect(
       await screen.findByRole("button", { name: "ログイン" })
+    ).toBeInTheDocument();
+  });
+
+  it("isRestoring: true の間、PrivateRoute はスピナーを表示すること", () => {
+    vi.mocked(authControllerRefresh).mockImplementation(
+      () => new Promise(() => {})
+    );
+    const Wrapper = createWrapper(null, "/posts");
+    render(
+      <Wrapper>
+        <App />
+      </Wrapper>
+    );
+
+    expect(
+      screen.getByRole("status", { name: "読み込み中" })
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,23 +8,25 @@ const Posts = React.lazy(() => import("./pages/Posts"));
 const CreatePost = React.lazy(() => import("./pages/CreatePost"));
 const EditPost = React.lazy(() => import("./pages/EditPost"));
 const Conversations = React.lazy(() => import("./pages/Conversations"));
-const ConversationChat = React.lazy(
-  () => import("./pages/ConversationChat")
-);
+const ConversationChat = React.lazy(() => import("./pages/ConversationChat"));
 const Login = React.lazy(() => import("./pages/LoginWithAuth"));
 const Register = React.lazy(() => import("./pages/Register"));
 
 function PageFallback() {
   return (
     <div className="flex h-screen items-center justify-center bg-background">
-      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      <div
+        role="status"
+        aria-label="読み込み中"
+        className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-primary"
+      />
     </div>
   );
 }
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { token, isRestoring } = useAuth();
-  if (isRestoring) return null;
+  if (isRestoring) return <PageFallback />;
   return token ? <>{children}</> : <Navigate to="/login" replace />;
 }
 


### PR DESCRIPTION
## Summary
- `PrivateRoute` が `isRestoring: true` の間 `null` を返していたため白画面になっていた問題を修正
- `PageFallback`（スピナー）を返すよう変更し、`role="status"` + `aria-label` を追加

## Test plan
- [x] `isRestoring: true` の間スピナーが表示されること（新規テスト追加）
- [x] 既存テスト 213 件全通過
- [x] `npm run test` 通過

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)