### PR TITLE
feat: 投稿詳細・目撃一覧にニックネームを表示する

### DIFF
--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -164,10 +164,10 @@ describe("SightingsService", () => {
 
   // ─── findByPost ─────────────────────────────────────────────
   describe("findByPost", () => {
-    it("postIdに紐づくSighting一覧をcreatedAt降順で返すこと", async () => {
+    it("postIdに紐づくSighting一覧をニックネーム付きで返すこと", async () => {
       const sightings = [
-        { id: "s-2", postId: "post-1" },
-        { id: "s-1", postId: "post-1" },
+        { id: "s-2", postId: "post-1", user: { nickname: "ニック2" } },
+        { id: "s-1", postId: "post-1", user: { nickname: "ニック1" } },
       ];
       mockPrisma.sighting.findMany.mockResolvedValue(sightings);
 
@@ -176,8 +176,11 @@ describe("SightingsService", () => {
       expect(mockPrisma.sighting.findMany).toHaveBeenCalledWith({
         where: { postId: "post-1" },
         orderBy: { createdAt: "desc" },
+        include: { user: { select: { nickname: true } } },
       });
       expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ id: "s-2", nickname: "ニック2" });
+      expect(result[1]).toMatchObject({ id: "s-1", nickname: "ニック1" });
     });
   });
 

--- a/apps/api/src/sightings/sighting.service.ts
+++ b/apps/api/src/sightings/sighting.service.ts
@@ -59,10 +59,15 @@ export class SightingsService {
   }
 
   async findByPost(postId: string) {
-    return this.prisma.sighting.findMany({
+    const sightings = await this.prisma.sighting.findMany({
       where: { postId },
       orderBy: { createdAt: "desc" },
+      include: { user: { select: { nickname: true } } },
     });
+    return sightings.map(({ user, ...rest }) => ({
+      ...rest,
+      nickname: user.nickname,
+    }));
   }
 
   async toggleFavorite(userId: string, sightingId: string) {

--- a/apps/web/src/components/PostDetailSheet.tsx
+++ b/apps/web/src/components/PostDetailSheet.tsx
@@ -194,6 +194,13 @@ export default function PostDetailSheet({
                 </p>
               )}
 
+              {/* 投稿者 */}
+              {post.authorNickname && (
+                <p className="text-xs text-muted-foreground mb-2">
+                  投稿者: {post.authorNickname}
+                </p>
+              )}
+
               {/* ステータスバッジ */}
               {post.status && (
                 <span

--- a/apps/web/src/components/SightingList.tsx
+++ b/apps/web/src/components/SightingList.tsx
@@ -99,6 +99,11 @@ export default function SightingList({
                     {s.comment}
                   </p>
                 )}
+                {s.nickname && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    報告者: {s.nickname}
+                  </p>
+                )}
               </div>
               <div className="flex items-center gap-1 shrink-0">
                 {currentUserId === s.userId && (

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -209,7 +209,7 @@
 
 #### findByPost
 
-- [x] postIdに紐づくSighting一覧をcreatedAt降順で返すこと
+- [x] postIdに紐づくSighting一覧をニックネーム付きで返すこと
 
 #### remove
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -401,7 +401,7 @@ apps/api/src/
 │   │   │   ├── 投稿者本人が自分のPostにSightingを作成しようとすると ForbiddenException
 │   │   │   └── 存在しないPostにSightingを作成しようとすると NotFoundException
 │   │   ├── findByPost
-│   │   │   └── postIdに紐づくSighting一覧をcreatedAt降順で返すこと
+│   │   │   └── postIdに紐づくSighting一覧をニックネーム付きで返すこと
 │   │   ├── findOne
 │   │   │   ├── 指定IDの目撃情報を報告者のニックネーム付きで返すこと
 │   │   │   └── 存在しないIDを指定するとNotFoundExceptionを送出すること


### PR DESCRIPTION
## Summary

- `SightingsService.findByPost()` がユーザーニックネームを返していなかったバグを修正
- `SightingList` コンポーネントで各目撃アイテムに「報告者: ニックネーム」を表示
- `PostDetailSheet` の投稿詳細セクションに「投稿者: ニックネーム」を表示

## Test plan

- [x] `sighting.service.spec.ts` の `findByPost` テストをニックネーム付き返却の検証に更新（全326テスト通過）
- [x] 型チェック通過（`typecheck:api` / `typecheck:web`）
- [x] Web ユニットテスト 213件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)