### PR TITLE
fix: issue#252 セキュリティ修正 P3/P4（docker-compose 環境変数化・JWT_SECRET 起動チェック）

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,6 +1,13 @@
 # Database
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nestjs_dev"
 
+# Docker Compose (docker-compose.yml で参照。未設定時はデフォルト値を使用)
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="change-me-in-production"
+POSTGRES_DB="nestjs_dev"
+PGADMIN_DEFAULT_EMAIL="admin@example.com"
+PGADMIN_DEFAULT_PASSWORD="change-me-in-production"
+
 # JWT
 JWT_SECRET="change-me-in-production"
 

--- a/apps/api/src/common/startup-guard.spec.ts
+++ b/apps/api/src/common/startup-guard.spec.ts
@@ -1,0 +1,37 @@
+import { assertSecrets } from "./startup-guard";
+
+describe("assertSecrets", () => {
+  it("development では何もしない", () => {
+    expect(() =>
+      assertSecrets({ NODE_ENV: "development", JWT_SECRET: "change-me" })
+    ).not.toThrow();
+  });
+
+  it("NODE_ENV 未設定では何もしない", () => {
+    expect(() => assertSecrets({ JWT_SECRET: "change-me" })).not.toThrow();
+  });
+
+  it("本番かつ JWT_SECRET が未設定なら throw する", () => {
+    expect(() => assertSecrets({ NODE_ENV: "production" })).toThrow(
+      "JWT_SECRET"
+    );
+  });
+
+  it("本番かつ JWT_SECRET が change-me を含むなら throw する", () => {
+    expect(() =>
+      assertSecrets({
+        NODE_ENV: "production",
+        JWT_SECRET: "change-me-in-production",
+      })
+    ).toThrow("JWT_SECRET");
+  });
+
+  it("本番かつ強い JWT_SECRET なら throw しない", () => {
+    expect(() =>
+      assertSecrets({
+        NODE_ENV: "production",
+        JWT_SECRET: "super-secret-random-value-abc123XYZ!@#",
+      })
+    ).not.toThrow();
+  });
+});

--- a/apps/api/src/common/startup-guard.ts
+++ b/apps/api/src/common/startup-guard.ts
@@ -1,0 +1,9 @@
+export function assertSecrets(env: NodeJS.ProcessEnv = process.env): void {
+  if (env.NODE_ENV !== "production") return;
+  const secret = env.JWT_SECRET ?? "";
+  if (!secret || secret.includes("change-me")) {
+    throw new Error(
+      "本番環境では JWT_SECRET に安全なランダム値を設定してください"
+    );
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,7 +10,10 @@ import * as path from "path";
 import { Logger } from "nestjs-pino";
 import { applyParameterExamples } from "./common/openapi-document";
 import { isOriginAllowed } from "./common/cors";
+import { assertSecrets } from "./common/startup-guard";
+
 async function bootstrap() {
+  assertSecrets();
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
   });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "dist",
     "incremental": true,
     "skipLibCheck": true,
-    "strict": false
+    "strict": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     container_name: nestjs_db
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: nestjs_dev
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-nestjs_dev}
     ports:
       - "5432:5432"
     volumes:
@@ -17,8 +17,8 @@ services:
     container_name: nestjs_pgadmin
     restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@example.com
-      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
     ports:
       - "5050:80"
     depends_on:

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -11,6 +11,16 @@
 
 ---
 
+### assertSecrets (`src/common/startup-guard.spec.ts`)
+
+- [x] development では何もしない
+- [x] NODE_ENV 未設定では何もしない
+- [x] 本番かつ JWT_SECRET が未設定なら throw する
+- [x] 本番かつ JWT_SECRET が change-me を含むなら throw する
+- [x] 本番かつ強い JWT_SECRET なら throw しない
+
+---
+
 ### isOriginAllowed (`src/common/cors.spec.ts`)
 
 #### 本番環境 (isDev=false)

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -5,6 +5,13 @@ apps/api/src/
 ├── common/
 │   ├── error-codes.ts
 │   │   └── 40種のエラーコード定数 (E_AUTH_*, E_POST_*, E_USER_*, E_CONV_*, E_SIGHTING_*, E_RESOURCE_*, E_FILE_*, E_IMAGE_*, E_RATE_LIMIT, E_VALIDATION, E_INTERNAL)
+│   ├── startup-guard.spec.ts
+│   │   └── assertSecrets
+│   │       ├── development では何もしない
+│   │       ├── NODE_ENV 未設定では何もしない
+│   │       ├── 本番かつ JWT_SECRET が未設定なら throw する
+│   │       ├── 本番かつ JWT_SECRET が change-me を含むなら throw する
+│   │       └── 本番かつ強い JWT_SECRET なら throw しない
 │   ├── cors.spec.ts
 │   │   └── isOriginAllowed
 │   │       ├── 本番環境 (isDev=false)


### PR DESCRIPTION
## 対応内容

### [L] docker-compose 認証情報の環境変数化 (P3)
- `docker-compose.yml` の `POSTGRES_PASSWORD: postgres` / `PGADMIN_DEFAULT_PASSWORD: admin` をハードコードから環境変数注入に変更
- フォールバック付き (`${POSTGRES_PASSWORD:-postgres}`) なので既存の開発環境はそのまま動作する
- `.env.example` に `POSTGRES_PASSWORD` 等の項目を追記（本番では必ず上書きすること）

### [P] 起動時 JWT_SECRET デフォルト値チェック (P4)
- `NODE_ENV=production` かつ `JWT_SECRET` が未設定または `change-me` を含む場合、起動時に即 throw して起動を拒否する
- ロジックを `common/startup-guard.ts` に切り出してユニットテスト5件を追加

## テスト
- API: 354件 passed（+5件）
- Web: 213件 passed

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)