### PR TITLE
fix: Express.Multer.File 型解決を typeRoots から src 内 d.ts 参照に変更

### DIFF
--- a/apps/api/src/types/multer.d.ts
+++ b/apps/api/src/types/multer.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="multer" />

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -10,8 +10,7 @@
     "outDir": "dist",
     "incremental": true,
     "skipLibCheck": true,
-    "strict": false,
-    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+    "strict": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 問題

前の修正（PR #256）で `typeRoots` を追加したが、VPS 環境では npm のパッケージホスティング方式が CI と異なり、TypeScript が `@types/multer` を見つけられないケースがあった。

また VPS に `M package-lock.json` のローカル変更が残っており、`npm ci` が古いロックファイルを使ってインストールしていた。

## 修正内容

- `typeRoots` を tsconfig.json から削除（デフォルトの検索動作に戻す）
- `apps/api/src/types/multer.d.ts` に `/// <reference types="multer" />` を追加
  - TypeScript が `src/**/*` をスキャンする際にこのファイルを処理し、親ディレクトリを遡る標準アルゴリズムで `@types/multer` を確実に発見する

## VPS 側の対処

デプロイ前に以下を実行してください：
```bash
git checkout -- apps/api/package.json package-lock.json
git pull
./scripts/vps-deploy.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)