### PR TITLE
fix: @types/multer 依存を排除し Express.Multer.File を直接宣言

### DIFF
--- a/apps/api/src/types/multer.d.ts
+++ b/apps/api/src/types/multer.d.ts
@@ -1,1 +1,20 @@
-/// <reference types="multer" />
+declare global {
+  namespace Express {
+    namespace Multer {
+      interface File {
+        fieldname: string;
+        originalname: string;
+        encoding: string;
+        mimetype: string;
+        size: number;
+        destination: string;
+        filename: string;
+        path: string;
+        buffer: Buffer;
+        stream: NodeJS.ReadableStream;
+      }
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## 原因

VPS の `npm ci` では `@types/multer` が `apps/api/node_modules/@types/` に展開されていなかった。
前の修正（#257）で追加した `src/types/multer.d.ts` が `/// <reference types="multer" />` のみだったため、VPS ビルドで `Cannot find namespace 'Express'` が発生。

## 修正内容

`src/types/multer.d.ts` を `@types/multer` に依存しない独自の `Express.Multer.File` 型定義に変更。
`@types/multer` がインストールされていない環境でも `tsc -p tsconfig.build.json` が通る。

## Test plan
- [x] ローカル `tsc -p tsconfig.build.json --noEmit` エラーなし
- [x] ユニットテスト 354件 通過
- [x] Web テスト 213件 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)