### PR TITLE
feat: Posts画面の新規投稿ボタン削除と空メッセージ変更

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -73,7 +73,7 @@ describe("App", () => {
     );
 
     expect(
-      await screen.findByRole("link", { name: "新規投稿" })
+      await screen.findByText("まだ迷い猫投稿はありません")
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/Posts.test.tsx
+++ b/apps/web/src/pages/Posts.test.tsx
@@ -330,9 +330,7 @@ describe("Posts", () => {
       });
       render(<Posts />, { wrapper: createWrapper() });
       expect(
-        screen.getByText(
-          "まだ投稿がありません。新規投稿ボタンから投稿を作成してみましょう。"
-        )
+        screen.getByText("まだ迷い猫投稿はありません")
       ).toBeInTheDocument();
     });
   });

--- a/apps/web/src/pages/Posts.tsx
+++ b/apps/web/src/pages/Posts.tsx
@@ -130,12 +130,6 @@ export default function Posts() {
               {nickname}様の投稿
             </span>
           )}
-          <Link
-            to="/create"
-            className="inline-flex items-center rounded-full bg-primary px-5 py-2 min-h-[44px] text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-          >
-            新規投稿
-          </Link>
         </div>
 
         {/* カードグリッド */}
@@ -279,7 +273,7 @@ export default function Posts() {
 
         {!hasNextPage && allItems.length === 0 && (
           <p className="mt-12 text-center text-muted-foreground">
-            まだ投稿がありません。新規投稿ボタンから投稿を作成してみましょう。
+            まだ迷い猫投稿はありません
           </p>
         )}
 


### PR DESCRIPTION
## Summary
- Posts（自分の投稿）画面の右上にある青色「新規投稿」ボタンを削除
- 投稿0件時の空メッセージを「まだ迷い猫投稿はありません」に変更
- Appテストの投稿画面アサーションも合わせて修正

## Changes
| ファイル | 変更 |
|---------|------|
| `apps/web/src/pages/Posts.tsx` | 新規投稿ボタン（Link to /create）を削除、空メッセージ変更 |
| `apps/web/src/pages/Posts.test.tsx` | 空メッセージテストの期待値を更新 |
| `apps/web/src/App.test.tsx` | 認証済みPosts表示確認のアサーションを修正 |