### PR TITLE
refactor(api): strict: true への段階的移行 (noImplicitAny + strictNullChecks)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -93,6 +93,8 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^11.1.19",
+    "@types/bcrypt": "^6.0.0",
+    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^4.17.21",
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.1.0",

--- a/apps/api/src/auth/jwt-auth.guard.ts
+++ b/apps/api/src/auth/jwt-auth.guard.ts
@@ -7,11 +7,11 @@ export class JwtAuthGuard extends AuthGuard("jwt") {}
 @Injectable()
 export class OptionalJwtAuthGuard extends AuthGuard("jwt") {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handleRequest<TUser = any>(err: any, user: any): TUser {
+  override handleRequest<TUser = any>(err: any, user: any): TUser {
     return (user ?? null) as unknown as TUser;
   }
 
-  canActivate(context: ExecutionContext) {
+  override canActivate(context: ExecutionContext) {
     return super.canActivate(context);
   }
 }

--- a/apps/api/src/auth/roles.guard.spec.ts
+++ b/apps/api/src/auth/roles.guard.spec.ts
@@ -36,7 +36,7 @@ describe("RolesGuard", () => {
     try {
       guard.canActivate(makeContext("user"));
       fail("例外がスローされるべき");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(ForbiddenException);
       const response = (e as ForbiddenException).getResponse();
       expect(response).toMatchObject({
@@ -51,7 +51,7 @@ describe("RolesGuard", () => {
     try {
       guard.canActivate(makeContext(undefined));
       fail("例外がスローされるべき");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(ForbiddenException);
       const response = (e as ForbiddenException).getResponse();
       expect(response).toMatchObject({

--- a/apps/api/src/auth/throttler.guard.spec.ts
+++ b/apps/api/src/auth/throttler.guard.spec.ts
@@ -18,7 +18,7 @@ describe("AppThrottlerGuard", () => {
         guard as unknown as { throwThrottlingException: () => Promise<void> }
       ).throwThrottlingException();
       fail("例外がスローされるべき");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(ThrottlerException);
       expect((e as ThrottlerException).message).toBe(
         "リクエスト数が制限を超えました。しばらく待ってから再試行してください。"

--- a/apps/api/src/auth/throttler.guard.ts
+++ b/apps/api/src/auth/throttler.guard.ts
@@ -13,18 +13,18 @@ const OPT_IN_THROTTLERS = new Set(["login", "register"]);
 
 @Injectable()
 export class AppThrottlerGuard extends ThrottlerGuard {
-  protected async throwThrottlingException(): Promise<void> {
+  protected override async throwThrottlingException(): Promise<void> {
     throw new ThrottlerException(
       "リクエスト数が制限を超えました。しばらく待ってから再試行してください。"
     );
   }
 
-  protected async handleRequest(
+  protected override async handleRequest(
     requestProps: ThrottlerRequest
   ): Promise<boolean> {
     const { context, throttler } = requestProps;
 
-    if (OPT_IN_THROTTLERS.has(throttler.name)) {
+    if (throttler.name !== undefined && OPT_IN_THROTTLERS.has(throttler.name)) {
       const handler = context.getHandler();
       const classRef = context.getClass();
       const metaKey = THROTTLER_LIMIT_PREFIX + throttler.name;

--- a/apps/api/src/common/plan-limits.ts
+++ b/apps/api/src/common/plan-limits.ts
@@ -1,6 +1,11 @@
 import { Plan } from "@prisma/client";
 
-export const PLAN_LIMITS = {
+type PlanLimitEntry = {
+  monthlyPostLimit: number | null;
+  imageUploadLimit: number;
+};
+
+export const PLAN_LIMITS: Record<Plan, PlanLimitEntry> = {
   [Plan.free]: {
     monthlyPostLimit: 3,
     imageUploadLimit: 3,
@@ -9,7 +14,7 @@ export const PLAN_LIMITS = {
     monthlyPostLimit: null,
     imageUploadLimit: 10,
   },
-} as const;
+};
 
 export function getMonthlyPostLimit(plan: Plan): number | null {
   return PLAN_LIMITS[plan].monthlyPostLimit;

--- a/apps/api/src/conversations/conversation.controller.spec.ts
+++ b/apps/api/src/conversations/conversation.controller.spec.ts
@@ -70,7 +70,7 @@ describe("ConversationsController", () => {
   // ─── createMessage ──────────────────────────────────────────
   describe("createMessage", () => {
     it("メッセージ作成後にbroadcastMessageを呼び出すこと", async () => {
-      const message = {
+      const message: Record<string, unknown> = {
         id: "msg-1",
         conversationId: "conv-1",
         senderId: "user-1",
@@ -116,7 +116,7 @@ describe("ConversationsController", () => {
       mockFileStorage.saveFile.mockResolvedValue(
         "uploads/conversations/conv-1/uuid.jpg"
       );
-      const message = {
+      const message: Record<string, unknown> = {
         id: "msg-2",
         conversationId: "conv-1",
         senderId: "user-1",
@@ -151,7 +151,7 @@ describe("ConversationsController", () => {
       try {
         await controller.createMessage(req, "conv-1", {}, file);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -187,7 +187,7 @@ describe("ConversationsController", () => {
       try {
         await controller.createMessage(req, "conv-1", {}, file);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({

--- a/apps/api/src/conversations/conversation.service.spec.ts
+++ b/apps/api/src/conversations/conversation.service.spec.ts
@@ -105,7 +105,7 @@ describe("ConversationsService", () => {
       try {
         await service.create("owner-1", dto);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -125,7 +125,7 @@ describe("ConversationsService", () => {
       try {
         await service.create("owner-1", dto);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -149,7 +149,7 @@ describe("ConversationsService", () => {
       try {
         await service.create("stranger", dto);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -173,7 +173,7 @@ describe("ConversationsService", () => {
       try {
         await service.create("owner-1", dto);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -320,7 +320,7 @@ describe("ConversationsService", () => {
       try {
         await service.createMessage("user-1", "conv-1", {});
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -338,7 +338,7 @@ describe("ConversationsService", () => {
           body: "a".repeat(1001),
         });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -354,7 +354,7 @@ describe("ConversationsService", () => {
       try {
         await service.createMessage("stranger", "conv-1", { body: "test" });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -370,7 +370,7 @@ describe("ConversationsService", () => {
       try {
         await service.createMessage("user-1", "conv-999", { body: "test" });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -464,7 +464,7 @@ describe("ConversationsService", () => {
       try {
         await service.findMessages("stranger", "conv-1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -480,7 +480,7 @@ describe("ConversationsService", () => {
       try {
         await service.findMessages("user-1", "conv-999");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -558,7 +558,7 @@ describe("ConversationsService", () => {
       try {
         await service.findOneForUser("stranger", "conv-1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -600,7 +600,7 @@ describe("ConversationsService", () => {
       try {
         await service.markAsRead("stranger", "conv-1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -616,7 +616,7 @@ describe("ConversationsService", () => {
       try {
         await service.markAsRead("user-1", "conv-999");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({

--- a/apps/api/src/conversations/conversation.service.ts
+++ b/apps/api/src/conversations/conversation.service.ts
@@ -30,7 +30,7 @@ export class ConversationsService {
           sighterId: sighting.userId,
         },
       });
-    } catch (e) {
+    } catch (e: unknown) {
       if (
         e instanceof Prisma.PrismaClientKnownRequestError &&
         e.code === "P2002"
@@ -150,7 +150,8 @@ export class ConversationsService {
     });
 
     return conversations.map((conv) =>
-      this.buildConversationItem(conv, userId)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.buildConversationItem(conv as any, userId)
     );
   }
 
@@ -184,7 +185,8 @@ export class ConversationsService {
       });
 
     return {
-      ...this.buildConversationItem(conv, userId),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...this.buildConversationItem(conv as any, userId),
       postStatus: conv.post.status ?? null,
     };
   }

--- a/apps/api/src/filters/prisma-client-exception.filter.spec.ts
+++ b/apps/api/src/filters/prisma-client-exception.filter.spec.ts
@@ -29,7 +29,7 @@ describe("PrismaClientExceptionFilter", () => {
       try {
         filter.catch(err, host);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -51,7 +51,7 @@ describe("PrismaClientExceptionFilter", () => {
       try {
         filter.catch(err, host);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ConflictException);
         const response = (e as ConflictException).getResponse();
         expect(response).toMatchObject({

--- a/apps/api/src/health/prisma-health.indicator.spec.ts
+++ b/apps/api/src/health/prisma-health.indicator.spec.ts
@@ -39,7 +39,7 @@ describe("PrismaHealthIndicator", () => {
     try {
       await indicator.pingCheck("database");
       fail("HealthCheckError がスローされるべき");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(HealthCheckError);
       const err = e as HealthCheckError;
       expect(err.causes).not.toHaveProperty("database.message");

--- a/apps/api/src/health/uploads-health.indicator.ts
+++ b/apps/api/src/health/uploads-health.indicator.ts
@@ -23,7 +23,7 @@ export class UploadsHealthIndicator extends HealthIndicator {
       fs.writeFileSync(tmpFile, "ok");
       fs.unlinkSync(tmpFile);
       return this.getStatus(key, true);
-    } catch (e) {
+    } catch (e: unknown) {
       throw new HealthCheckError(
         "uploadsディレクトリ書き込みチェック失敗",
         this.getStatus(key, false, { message: (e as Error).message })

--- a/apps/api/src/identity/email-hash-migration.spec.ts
+++ b/apps/api/src/identity/email-hash-migration.spec.ts
@@ -109,7 +109,7 @@ describe("migrateEmailHashToHmac", () => {
 
   describe("スキップケース", () => {
     it("emailEncryptedがnullのユーザーはスキップされること", async () => {
-      const users = [
+      const users: Record<string, unknown>[] = [
         { id: "user-3", emailEncrypted: null, emailHash: "any-hash" },
       ];
       const prisma = makePrisma(users);

--- a/apps/api/src/identity/identity.service.spec.ts
+++ b/apps/api/src/identity/identity.service.spec.ts
@@ -134,7 +134,7 @@ describe("IdentityService", () => {
       try {
         await service.login("user@example.com", "wrongpassword");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -151,7 +151,7 @@ describe("IdentityService", () => {
       try {
         await service.login("user@example.com", "wrongpassword");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -173,7 +173,7 @@ describe("IdentityService", () => {
       try {
         await service.login("no@example.com", "password");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -189,7 +189,7 @@ describe("IdentityService", () => {
       try {
         await service.login("no@example.com", "password");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -319,7 +319,7 @@ describe("IdentityService", () => {
       try {
         await service.refresh("nonexistent");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -339,7 +339,7 @@ describe("IdentityService", () => {
       try {
         await service.refresh("old-token");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -364,7 +364,7 @@ describe("IdentityService", () => {
       try {
         await service.refresh("old-refresh-token");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -389,7 +389,7 @@ describe("IdentityService", () => {
       try {
         await service.refresh("old-refresh-token");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -493,7 +493,7 @@ describe("IdentityService", () => {
       try {
         await service.register("dup@example.com", "pass", "nick");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ConflictException);
         const response = (e as ConflictException).getResponse();
         expect(response).toMatchObject({
@@ -512,7 +512,7 @@ describe("IdentityService", () => {
       try {
         await service.register("a@example.com", "pass", "dup");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ConflictException);
         const response = (e as ConflictException).getResponse();
         expect(response).toMatchObject({

--- a/apps/api/src/identity/identity.service.ts
+++ b/apps/api/src/identity/identity.service.ts
@@ -256,7 +256,7 @@ export class IdentityService extends IIdentityService {
     });
     return users.map((u) => ({
       id: u.id,
-      email: this.decryptSafely(u.emailEncrypted),
+      email: this.decryptSafely(u.emailEncrypted) ?? "",
       nickname: u.nickname,
       role: u.role,
       createdAt: u.createdAt,
@@ -276,7 +276,7 @@ export class IdentityService extends IIdentityService {
     });
     return {
       id: user.id,
-      email: this.decryptSafely(user.emailEncrypted),
+      email: this.decryptSafely(user.emailEncrypted) ?? "",
       nickname: user.nickname,
       role: user.role,
       createdAt: user.createdAt,

--- a/apps/api/src/identity/key-versioning-migration.spec.ts
+++ b/apps/api/src/identity/key-versioning-migration.spec.ts
@@ -46,7 +46,9 @@ describe("migrateKeyVersioning", () => {
     });
 
     it("emailEncryptedがnullのユーザーはスキップされること", async () => {
-      const users = [{ id: "u3", emailEncrypted: null }];
+      const users: Record<string, unknown>[] = [
+        { id: "u3", emailEncrypted: null },
+      ];
       const prisma = makePrisma(users);
 
       const result = await migrateKeyVersioning(prisma as never);

--- a/apps/api/src/logger/logger.redact.spec.ts
+++ b/apps/api/src/logger/logger.redact.spec.ts
@@ -1,4 +1,4 @@
-import * as pino from "pino";
+import pino from "pino";
 import { Writable } from "stream";
 import { REDACT_PATHS } from "./logger.module";
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,7 +4,7 @@ import { NestExpressApplication } from "@nestjs/platform-express";
 import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { ValidationPipe } from "@nestjs/common";
-import * as cookieParser from "cookie-parser";
+import cookieParser from "cookie-parser";
 import helmet from "helmet";
 import * as path from "path";
 import { Logger } from "nestjs-pino";

--- a/apps/api/src/posts/file-storage.service.spec.ts
+++ b/apps/api/src/posts/file-storage.service.spec.ts
@@ -97,7 +97,7 @@ describe("FileStorageService", () => {
       try {
         await service.saveFile("post-1", makeFile());
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         expect((e as BadRequestException).message).toBe(
           "画像処理に失敗しました"

--- a/apps/api/src/posts/post.controller.spec.ts
+++ b/apps/api/src/posts/post.controller.spec.ts
@@ -8,7 +8,9 @@ import {
 import { PostsController, imageFileFilter } from "./post.controller";
 import { PostsService } from "./post.service";
 
-const makePost = (overrides = {}) => ({
+const makePost = (
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> => ({
   id: "post1",
   title: "Title",
   description: "Content",
@@ -105,7 +107,7 @@ describe("PostsController", () => {
       try {
         await controller.list("1", "10", "true", {} as any);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(UnauthorizedException);
         const response = (e as UnauthorizedException).getResponse();
         expect(response).toMatchObject({
@@ -455,7 +457,11 @@ describe("PostsController", () => {
   describe("imageFileFilter", () => {
     it("fileがnullの時、cb(null, false)を呼ぶこと", () => {
       const cb = jest.fn();
-      imageFileFilter({} as Express.Request, null, cb);
+      imageFileFilter(
+        {} as Express.Request,
+        null as unknown as Express.Multer.File,
+        cb
+      );
       expect(cb).toHaveBeenCalledWith(null, false);
     });
 

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -100,7 +100,7 @@ describe("PostsService", () => {
     });
 
     it("items と total を返し、投稿者名を authorNickname に詰める", async () => {
-      const posts = [
+      const posts: Record<string, unknown>[] = [
         {
           id: "1",
           title: "T",
@@ -112,7 +112,7 @@ describe("PostsService", () => {
           updatedAt: new Date(),
           petDetail: null,
           location: null,
-          images: [],
+          images: [] as any[],
           user: { nickname: "Alice" },
         },
       ];
@@ -134,7 +134,7 @@ describe("PostsService", () => {
             updatedAt: posts[0].updatedAt,
             petDetail: null,
             location: null,
-            images: [],
+            images: [] as any[],
             authorNickname: "Alice",
           },
         ],
@@ -191,7 +191,7 @@ describe("PostsService", () => {
         id: "post1",
         petDetail: { name: "Mimi" },
         location: { city: "さいたま市" },
-        images: [],
+        images: [] as any[],
         user: { nickname: "Alice" },
       };
       mockPrisma.post.findUnique.mockResolvedValue(post);
@@ -211,7 +211,7 @@ describe("PostsService", () => {
         id: "post1",
         petDetail: { name: "Mimi" },
         location: { city: "さいたま市" },
-        images: [],
+        images: [] as any[],
         authorNickname: "Alice",
       });
     });
@@ -222,7 +222,7 @@ describe("PostsService", () => {
       try {
         await service.findById("no-such");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -250,11 +250,11 @@ describe("PostsService", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      const withIncludes = {
+      const withIncludes: Record<string, unknown> = {
         ...created,
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       };
       mockPrisma.post.create.mockResolvedValue(created);
       mockPrisma.post.findUnique.mockResolvedValue(withIncludes);
@@ -287,11 +287,11 @@ describe("PostsService", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      const withIncludes = {
+      const withIncludes: Record<string, unknown> = {
         ...created,
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       };
       mockPrisma.post.create.mockResolvedValue(created);
       mockPrisma.post.findUnique.mockResolvedValue(withIncludes);
@@ -329,7 +329,7 @@ describe("PostsService", () => {
         ...created,
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
       mockPrisma.image.create.mockResolvedValue({});
       const files = [
@@ -354,7 +354,7 @@ describe("PostsService", () => {
         id: "post1",
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
       mockPrisma.image.create.mockResolvedValue({});
       const files = [
@@ -378,7 +378,7 @@ describe("PostsService", () => {
         id: "post1",
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
       const files = Array.from(
         { length: 4 },
@@ -392,7 +392,7 @@ describe("PostsService", () => {
           files
         );
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -409,7 +409,7 @@ describe("PostsService", () => {
         id: "post1",
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
       mockPrisma.image.create.mockResolvedValue({});
       const files = Array.from(
@@ -431,7 +431,7 @@ describe("PostsService", () => {
       try {
         await service.create("u1", { description: "C" } as any);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -455,7 +455,7 @@ describe("PostsService", () => {
           files
         );
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -481,7 +481,7 @@ describe("PostsService", () => {
         ...created,
         petDetail: {},
         location: {},
-        images: [],
+        images: [] as any[],
       });
       mockPrisma.petDetail.create.mockResolvedValue({});
       mockPrisma.location.create.mockResolvedValue({});
@@ -526,7 +526,7 @@ describe("PostsService", () => {
         id: "post1",
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
 
       await service.create("u1", { description: "C", lostDate: "2024-06-15" });
@@ -579,7 +579,7 @@ describe("PostsService", () => {
           lostDate: "2026-04-21",
         });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -610,7 +610,7 @@ describe("PostsService", () => {
         id: "post1",
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
       const monthStart = new Date(
         Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
@@ -656,7 +656,7 @@ describe("PostsService", () => {
         ...created,
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
       mockPrisma.$transaction
         .mockRejectedValueOnce(conflictError)
@@ -682,7 +682,7 @@ describe("PostsService", () => {
         ...created,
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
     });
 
@@ -703,7 +703,7 @@ describe("PostsService", () => {
         ...created,
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       });
 
       await service.create("u1", {
@@ -723,7 +723,7 @@ describe("PostsService", () => {
       id: "post1",
       userId: "user1",
       status: "lost",
-      images: [],
+      images: [] as any[],
     };
 
     it("画像を追加できる", async () => {
@@ -765,7 +765,7 @@ describe("PostsService", () => {
       try {
         await service.addImages("post1", "user1", files);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -809,7 +809,7 @@ describe("PostsService", () => {
       try {
         await service.addImages("post1", "user1", files);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -825,7 +825,7 @@ describe("PostsService", () => {
       try {
         await service.addImages("post1", "other-user", []);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -841,7 +841,7 @@ describe("PostsService", () => {
       try {
         await service.addImages("no-such", "user1", []);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -866,7 +866,7 @@ describe("PostsService", () => {
       try {
         await service.addImages("post1", "user1", files);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -925,7 +925,7 @@ describe("PostsService", () => {
       try {
         await service.removeImage("post1", "img1", "other-user");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -941,7 +941,7 @@ describe("PostsService", () => {
       try {
         await service.removeImage("no-such", "img1", "user1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -961,7 +961,7 @@ describe("PostsService", () => {
       try {
         await service.removeImage("post1", "img1", "user1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -996,7 +996,7 @@ describe("PostsService", () => {
       try {
         await service.removeImage("post1", "img1", "other-user", false);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
       }
     });
@@ -1004,7 +1004,7 @@ describe("PostsService", () => {
 
   // ─── update ─────────────────────────────────────────────────
   describe("update", () => {
-    const existingPost = {
+    const existingPost: Record<string, unknown> = {
       id: "post1",
       title: "Old",
       description: "Old description",
@@ -1018,12 +1018,12 @@ describe("PostsService", () => {
     };
 
     it("オーナーが更新でき、petDetail/location/images を含むレスポンスを返す", async () => {
-      const updatedWithIncludes = {
+      const updatedWithIncludes: Record<string, unknown> = {
         ...existingPost,
         title: "New",
         petDetail: null,
         location: null,
-        images: [],
+        images: [] as any[],
       };
       mockPrisma.post.findUnique
         .mockResolvedValueOnce(existingPost) // オーナー確認
@@ -1050,7 +1050,7 @@ describe("PostsService", () => {
           postType: "cat",
           petDetail: null,
           location: null,
-          images: [],
+          images: [] as any[],
         });
       mockPrisma.post.update.mockResolvedValue({});
 
@@ -1069,7 +1069,7 @@ describe("PostsService", () => {
       try {
         await service.update("post1", "other-user", { title: "Hacked" });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -1085,7 +1085,7 @@ describe("PostsService", () => {
       try {
         await service.update("no-such-post", "user1", { title: "X" });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(HttpException);
         const response = (e as HttpException).getResponse();
         expect(response).toMatchObject({
@@ -1103,7 +1103,7 @@ describe("PostsService", () => {
           lostDate: new Date("2024-06-15"),
           petDetail: null,
           location: null,
-          images: [],
+          images: [] as any[],
         });
       mockPrisma.post.update.mockResolvedValue({});
 
@@ -1124,7 +1124,7 @@ describe("PostsService", () => {
           status: "resolved",
           petDetail: null,
           location: null,
-          images: [],
+          images: [] as any[],
         });
       mockPrisma.post.update.mockResolvedValue({});
 
@@ -1149,7 +1149,7 @@ describe("PostsService", () => {
           resolvedAt: null,
           petDetail: null,
           location: null,
-          images: [],
+          images: [] as any[],
         });
       mockPrisma.post.update.mockResolvedValue({});
 
@@ -1169,7 +1169,7 @@ describe("PostsService", () => {
           ...existingPost,
           petDetail: { name: "Mimi" },
           location: null,
-          images: [],
+          images: [] as any[],
         });
       mockPrisma.post.update.mockResolvedValue({});
       mockPrisma.petDetail.upsert.mockResolvedValue({});
@@ -1196,7 +1196,7 @@ describe("PostsService", () => {
       try {
         await service.update("post1", "user1", { petDetail: { name: "Mimi" } });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -1214,7 +1214,7 @@ describe("PostsService", () => {
           location: { city: "さいたま市" },
         });
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -1231,7 +1231,7 @@ describe("PostsService", () => {
           ...existingPost,
           petDetail: null,
           location: { city: "さいたま市" },
-          images: [],
+          images: [] as any[],
         });
       mockPrisma.post.update.mockResolvedValue({});
       mockPrisma.location.upsert.mockResolvedValue({});
@@ -1268,7 +1268,7 @@ describe("PostsService", () => {
       lostDate: new Date(),
       createdAt: new Date(),
       updatedAt: new Date(),
-      images: [],
+      images: [] as any[],
     };
 
     it("オーナーが削除できる", async () => {
@@ -1309,7 +1309,7 @@ describe("PostsService", () => {
       try {
         await service.remove("post1", "other-user");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -1325,7 +1325,7 @@ describe("PostsService", () => {
       try {
         await service.remove("no-such-post", "user1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(HttpException);
         const response = (e as HttpException).getResponse();
         expect(response).toMatchObject({
@@ -1366,7 +1366,7 @@ describe("PostsService", () => {
           files
         );
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         expect((e as BadRequestException).message).toBe(
           "画像処理に失敗しました。ファイルが破損または無効な形式です。"
@@ -1415,7 +1415,7 @@ describe("PostsService", () => {
       try {
         await service.toggleFavorite(postOwner, postId);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -1433,7 +1433,7 @@ describe("PostsService", () => {
       try {
         await service.toggleFavorite(otherUser, postId);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -1449,7 +1449,7 @@ describe("PostsService", () => {
       try {
         await service.toggleFavorite(otherUser, postId);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -305,7 +305,7 @@ export class PostsService {
           }
         );
         break;
-      } catch (e) {
+      } catch (e: unknown) {
         if (isTransactionConflict(e) && attempt < MAX_TRANSACTION_RETRIES - 1) {
           continue;
         }
@@ -345,7 +345,7 @@ export class PostsService {
           url: this.prefixImageUrl(img.url),
         })),
       };
-    } catch (e) {
+    } catch (e: unknown) {
       for (const url of savedUrls) {
         try {
           this.fileStorage.deleteFile(url);
@@ -496,7 +496,7 @@ export class PostsService {
           url: this.prefixImageUrl(img.url),
         })),
       };
-    } catch (error) {
+    } catch (error: unknown) {
       for (const url of savedUrls) {
         try {
           this.fileStorage.deleteFile(url);

--- a/apps/api/src/sentry/sentry.filter.ts
+++ b/apps/api/src/sentry/sentry.filter.ts
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/nestjs";
 
 @Catch()
 export class SentryFilter extends BaseExceptionFilter {
-  catch(exception: unknown, host: ArgumentsHost): void {
+  override catch(exception: unknown, host: ArgumentsHost): void {
     const is4xx =
       exception instanceof HttpException && exception.getStatus() < 500;
 

--- a/apps/api/src/shared/image-processing.service.spec.ts
+++ b/apps/api/src/shared/image-processing.service.spec.ts
@@ -96,7 +96,7 @@ describe("ImageProcessingService", () => {
     try {
       await service.process(Buffer.from("bad"));
       fail("例外がスローされるべき");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(BadRequestException);
       const response = (e as BadRequestException).getResponse();
       expect(response).toMatchObject({

--- a/apps/api/src/shared/image-processing.service.ts
+++ b/apps/api/src/shared/image-processing.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from "@nestjs/common";
-import * as sharp from "sharp";
+import sharp from "sharp";
 import { ERROR_CODES } from "../common/error-codes";
 
 @Injectable()

--- a/apps/api/src/sightings/sighting.service.spec.ts
+++ b/apps/api/src/sightings/sighting.service.spec.ts
@@ -112,7 +112,7 @@ describe("SightingsService", () => {
       try {
         await service.create("other-user", dtoWithEmptyPostId as never);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -135,7 +135,7 @@ describe("SightingsService", () => {
       try {
         await service.create("owner-1", dto);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -151,7 +151,7 @@ describe("SightingsService", () => {
       try {
         await service.create("other-user", dto);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -227,7 +227,7 @@ describe("SightingsService", () => {
       try {
         await service.findOne("nonexistent");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -262,7 +262,7 @@ describe("SightingsService", () => {
       try {
         await service.remove("other-user", "s-1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -278,7 +278,7 @@ describe("SightingsService", () => {
       try {
         await service.remove("user-1", "s-1");
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({
@@ -344,7 +344,7 @@ describe("SightingsService", () => {
       try {
         await service.toggleFavorite(userId, sightingId);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(ForbiddenException);
         const response = (e as ForbiddenException).getResponse();
         expect(response).toMatchObject({
@@ -362,7 +362,7 @@ describe("SightingsService", () => {
       try {
         await service.toggleFavorite(userId, sightingId);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(BadRequestException);
         const response = (e as BadRequestException).getResponse();
         expect(response).toMatchObject({
@@ -378,7 +378,7 @@ describe("SightingsService", () => {
       try {
         await service.toggleFavorite(userId, sightingId);
         fail("例外がスローされるべき");
-      } catch (e) {
+      } catch (e: unknown) {
         expect(e).toBeInstanceOf(NotFoundException);
         const response = (e as NotFoundException).getResponse();
         expect(response).toMatchObject({

--- a/apps/api/src/users/user.controller.spec.ts
+++ b/apps/api/src/users/user.controller.spec.ts
@@ -24,7 +24,7 @@ describe("UsersController", () => {
     try {
       await controller.register(dto);
       fail("例外がスローされるべき");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(BadRequestException);
       const response = (e as BadRequestException).getResponse();
       expect(response).toMatchObject({

--- a/apps/api/test/app.e2e.ts
+++ b/apps/api/test/app.e2e.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
-import * as request from "supertest";
-import * as cookieParser from "cookie-parser";
+import request from "supertest";
+import cookieParser from "cookie-parser";
 import { AppModule } from "../src/app.module";
 import { PrismaService } from "../src/prisma.service";
 

--- a/apps/api/test/health.e2e.ts
+++ b/apps/api/test/health.e2e.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
-import * as request from "supertest";
-import * as cookieParser from "cookie-parser";
+import request from "supertest";
+import cookieParser from "cookie-parser";
 import { AppModule } from "../src/app.module";
 import { PrismaService } from "../src/prisma.service";
 

--- a/apps/api/test/throttler.e2e.ts
+++ b/apps/api/test/throttler.e2e.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
-import * as request from "supertest";
-import * as cookieParser from "cookie-parser";
+import request from "supertest";
+import cookieParser from "cookie-parser";
 import { getOptionsToken } from "@nestjs/throttler";
 import { AppModule } from "../src/app.module";
 import { PrismaService } from "../src/prisma.service";

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,17 +1,25 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
+    "target": "ES2022",
     "declaration": true,
-    "removeComments": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "target": "ES2021",
     "sourceMap": true,
     "outDir": "dist",
     "incremental": true,
+    "removeComments": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": false,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "strict": false
+    "moduleResolution": "node"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,8 @@
       },
       "devDependencies": {
         "@nestjs/testing": "^11.1.19",
+        "@types/bcrypt": "^6.0.0",
+        "@types/cookie-parser": "^1.4.10",
         "@types/express": "^4.17.21",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
@@ -9534,6 +9536,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -9563,6 +9575,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cookiejar": {


### PR DESCRIPTION
## Summary

`apps/api/tsconfig.json` を `strict: true` ベースに移行（ADR-0008）。全3ステップで段階的に型安全性を強化。

### 変更内容

**Step 1: `noImplicitAny` 有効化**
- `catch(e)` → `catch(e: unknown)`（本番5件 + テスト68件）
- `esModuleInterop` 対応（`cookie-parser`, `sharp`, `pino` の import 修正）
- `noImplicitOverride` 対応（Guards, Filter に `override` 追加）
- テスト fixture の object literal 型注釈追加

**Step 2: `strictNullChecks` 有効化**
- `decryptSafely` の `null` 戻り値に `?? ""` 追加
- `throttler.name` の `undefined` チェック追加
- Prisma リレーション型不一致に `as any` キャスト
- `imageFileFilter` の null 引数にキャスト追加

### 最終 tsconfig

```jsonc
{
  "strict": true,
  "strictPropertyInitialization": false,  // DTO required フィールド用。恒久的に false
  "strictNullChecks": true,
  "noImplicitAny": true,
  "noImplicitOverride": true,
  "noFallthroughCasesInSwitch": true,
  "esModuleInterop": true,
  "forceConsistentCasingInFileNames": true
}
```

### 検証

- `npm run typecheck:api` → pass
- `npm run lint:api` → 0 errors
- `npm run test` → pass

Closes #264