### PR TITLE
fix: デプロイスクリプトで pull 前の package.json / lockfile 自動リセット

### DIFF
--- a/scripts/vps-deploy.sh
+++ b/scripts/vps-deploy.sh
@@ -155,6 +155,7 @@ fi
 # 2. Git 更新 ------------------------------------------------------------------------
 echo ""
 echo "Step 2/10: Git 更新"
+git checkout -- apps/api/package.json package-lock.json 2>/dev/null || true
 git fetch origin
 git checkout main
 git pull --ff-only origin main


### PR DESCRIPTION
## 概要
VPS デプロイ時に `npm install` で変更された `apps/api/package.json` / `package-lock.json` が次回 `git pull` で衝突する問題を解消。

## 変更内容
`scripts/vps-deploy.sh` の Git 更新ステップで、`git pull` の前に `git checkout -- apps/api/package.json package-lock.json` を実行し、前回の `npm install` によるローカル変更を自動破棄する。

`2>/dev/null || true` 付きで、ファイルが存在しない/変更がない場合もエラー停止しない。