### PR TITLE
fix: rollup-plugin-visualizer をオプショナル化し VPS ビルドエラーを修正

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,18 +1,27 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
+async function getVisualizerPlugin(): Promise<Plugin | null> {
+  try {
+    const { visualizer } = await import("rollup-plugin-visualizer");
+    return visualizer({
+      filename: "dist/stats.html",
+      open: false,
+      gzipSize: true,
+      brotliSize: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
 export default defineConfig(async () => {
-  const { visualizer } = await import("rollup-plugin-visualizer");
+  const visualizerPlugin = await getVisualizerPlugin();
   return {
     plugins: [
       react(),
-      visualizer({
-        filename: "dist/stats.html",
-        open: false,
-        gzipSize: true,
-        brotliSize: true,
-      }),
+      ...(visualizerPlugin ? [visualizerPlugin] : []),
     ],
     server: {
       port: 5173,


### PR DESCRIPTION
## 概要
VPS デプロイ時に Web ビルドが "Cannot find package 'rollup-plugin-visualizer'" で失敗する問題を修正。

## 原因
`rollup-plugin-visualizer@7.0.1` は Node >= 22 が必須。VPS の Node 20 ではエンジン要件不一致でインストールされず、vite.config.ts の動的インポートが失敗していた。

## 変更内容
`apps/web/vite.config.ts` の `rollup-plugin-visualizer` インポートを try-catch でラップし、パッケージが存在しない場合はスキップするよう修正。本プラグインはバンドルサイズ可視化用の開発補助ツールであり、本番ビルドに必須ではない。
