### PR TITLE
security(api): ランタイム安全性強化 (forbidNonWhitelisted + env検証 + DTOバリデーション)

### DIFF
--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsString, MinLength } from "class-validator";
+import { IsEmail, IsString, MaxLength, MinLength } from "class-validator";
 
 export class LoginDto {
   @ApiProperty({ example: "seed-owner@finder.miyaoo.test" })
@@ -9,5 +9,6 @@ export class LoginDto {
   @ApiProperty({ example: "Password123!", minLength: 8 })
   @IsString()
   @MinLength(8)
+  @MaxLength(100)
   password: string;
 }

--- a/apps/api/src/common/startup-guard.spec.ts
+++ b/apps/api/src/common/startup-guard.spec.ts
@@ -26,12 +26,49 @@ describe("assertSecrets", () => {
     ).toThrow("JWT_SECRET");
   });
 
-  it("本番かつ強い JWT_SECRET なら throw しない", () => {
+  it("本番かつ強い JWT_SECRET かつ必要なシークレットが揃っていれば throw しない", () => {
     expect(() =>
       assertSecrets({
         NODE_ENV: "production",
         JWT_SECRET: "super-secret-random-value-abc123XYZ!@#",
+        ENCRYPTION_KEY_V1: "encryption-key-at-least-32-chars-long!!",
+        HMAC_SECRET: "hmac-secret-value-here",
+        DATABASE_URL: "postgresql://localhost:5432/mydb",
       })
     ).not.toThrow();
+  });
+
+  it("本番かつ ENCRYPTION_KEY_V1 が短すぎるなら throw する", () => {
+    expect(() =>
+      assertSecrets({
+        NODE_ENV: "production",
+        JWT_SECRET: "super-secret-random-value-abc123XYZ!@#",
+        ENCRYPTION_KEY_V1: "short",
+        HMAC_SECRET: "hmac-secret",
+        DATABASE_URL: "postgresql://localhost:5432/mydb",
+      })
+    ).toThrow("ENCRYPTION_KEY_V1");
+  });
+
+  it("本番かつ HMAC_SECRET が未設定なら throw する", () => {
+    expect(() =>
+      assertSecrets({
+        NODE_ENV: "production",
+        JWT_SECRET: "super-secret-random-value-abc123XYZ!@#",
+        ENCRYPTION_KEY_V1: "encryption-key-at-least-32-chars-long!!",
+        DATABASE_URL: "postgresql://localhost:5432/mydb",
+      })
+    ).toThrow("HMAC_SECRET");
+  });
+
+  it("本番かつ DATABASE_URL が未設定なら throw する", () => {
+    expect(() =>
+      assertSecrets({
+        NODE_ENV: "production",
+        JWT_SECRET: "super-secret-random-value-abc123XYZ!@#",
+        ENCRYPTION_KEY_V1: "encryption-key-at-least-32-chars-long!!",
+        HMAC_SECRET: "hmac-secret",
+      })
+    ).toThrow("DATABASE_URL");
   });
 });

--- a/apps/api/src/common/startup-guard.ts
+++ b/apps/api/src/common/startup-guard.ts
@@ -1,9 +1,26 @@
 export function assertSecrets(env: NodeJS.ProcessEnv = process.env): void {
   if (env.NODE_ENV !== "production") return;
-  const secret = env.JWT_SECRET ?? "";
-  if (!secret || secret.includes("change-me")) {
+
+  const jwtSecret = env.JWT_SECRET ?? "";
+  if (!jwtSecret || jwtSecret.includes("change-me")) {
     throw new Error(
       "本番環境では JWT_SECRET に安全なランダム値を設定してください"
     );
+  }
+
+  const encryptionKey = env.ENCRYPTION_KEY_V1 ?? "";
+  if (!encryptionKey || encryptionKey.length < 32) {
+    throw new Error(
+      "本番環境では ENCRYPTION_KEY_V1 に32文字以上の安全な値を設定してください"
+    );
+  }
+
+  const hmacSecret = env.HMAC_SECRET ?? "";
+  if (!hmacSecret) {
+    throw new Error("本番環境では HMAC_SECRET を設定してください");
+  }
+
+  if (!env.DATABASE_URL) {
+    throw new Error("本番環境では DATABASE_URL を設定してください");
   }
 }

--- a/apps/api/src/conversations/dto/create-conversation.dto.ts
+++ b/apps/api/src/conversations/dto/create-conversation.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString } from "class-validator";
+import { IsNotEmpty, IsString } from "class-validator";
 import {
   OPENAPI_POST_ID_EXAMPLE,
   OPENAPI_SIGHTING_ID_EXAMPLE,
@@ -8,9 +8,11 @@ import {
 export class CreateConversationDto {
   @ApiProperty({ example: OPENAPI_POST_ID_EXAMPLE })
   @IsString()
+  @IsNotEmpty()
   postId: string;
 
   @ApiProperty({ example: OPENAPI_SIGHTING_ID_EXAMPLE })
   @IsString()
+  @IsNotEmpty()
   sightingId: string;
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -19,7 +19,13 @@ async function bootstrap() {
   });
   app.useLogger(app.get(Logger));
   app.use(helmet());
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    })
+  );
   app.setGlobalPrefix("api");
   app.useStaticAssets(path.join(__dirname, "..", "uploads"), {
     prefix: "/uploads",

--- a/apps/api/src/posts/dto/create-post.dto.ts
+++ b/apps/api/src/posts/dto/create-post.dto.ts
@@ -11,6 +11,8 @@ import {
   IsNumber,
   IsBoolean,
   IsEnum,
+  Max,
+  Min,
 } from "class-validator";
 
 export class CreatePetDetailDto {
@@ -39,8 +41,8 @@ export class CreateLocationDto {
   @ApiProperty({ enum: ["saitama"] }) @IsEnum(["saitama"]) prefecture: string;
   @ApiProperty() @IsString() city: string;
   @ApiProperty() @IsString() address: string;
-  @ApiProperty() @IsNumber() lat: number;
-  @ApiProperty() @IsNumber() lng: number;
+  @ApiProperty() @IsNumber() @Min(-90) @Max(90) lat: number;
+  @ApiProperty() @IsNumber() @Min(-180) @Max(180) lng: number;
 }
 
 export class CreatePostDto {

--- a/apps/api/src/posts/dto/update-post.dto.ts
+++ b/apps/api/src/posts/dto/update-post.dto.ts
@@ -12,6 +12,8 @@ import {
   IsBoolean,
   IsEnum,
   ValidateIf,
+  Max,
+  Min,
 } from "class-validator";
 
 export class UpdatePetDetailDto {
@@ -43,8 +45,18 @@ export class UpdateLocationDto {
   prefecture?: string;
   @ApiProperty({ required: false }) @IsOptional() @IsString() city?: string;
   @ApiProperty({ required: false }) @IsOptional() @IsString() address?: string;
-  @ApiProperty({ required: false }) @IsOptional() @IsNumber() lat?: number;
-  @ApiProperty({ required: false }) @IsOptional() @IsNumber() lng?: number;
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat?: number;
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng?: number;
 }
 
 export class UpdatePostDto {

--- a/apps/api/src/sightings/dto/create-sighting.dto.ts
+++ b/apps/api/src/sightings/dto/create-sighting.dto.ts
@@ -5,6 +5,8 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  Max,
+  Min,
 } from "class-validator";
 import { OPENAPI_POST_ID_EXAMPLE } from "../../common/openapi-examples";
 
@@ -14,8 +16,12 @@ export class CreateSightingDto {
   @IsString()
   @IsNotEmpty()
   postId?: string;
-  @ApiProperty({ example: 35.8617 }) @IsNumber() lat: number;
-  @ApiProperty({ example: 139.6455 }) @IsNumber() lng: number;
+  @ApiProperty({ example: 35.8617 }) @IsNumber() @Min(-90) @Max(90) lat: number;
+  @ApiProperty({ example: 139.6455 })
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng: number;
   @ApiProperty({ required: false, example: "Saitama City, Urawa-ku" })
   @IsOptional()
   @IsString()

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,18 +1,27 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
+async function getVisualizerPlugin(): Promise<Plugin | null> {
+  try {
+    const { visualizer } = await import("rollup-plugin-visualizer");
+    return visualizer({
+      filename: "dist/stats.html",
+      open: false,
+      gzipSize: true,
+      brotliSize: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
 export default defineConfig(async () => {
-  const { visualizer } = await import("rollup-plugin-visualizer");
+  const visualizerPlugin = await getVisualizerPlugin();
   return {
     plugins: [
       react(),
-      visualizer({
-        filename: "dist/stats.html",
-        open: false,
-        gzipSize: true,
-        brotliSize: true,
-      }),
+      ...(visualizerPlugin ? [visualizerPlugin] : []),
     ],
     server: {
       port: 5173,


### PR DESCRIPTION
## Summary

`forbidNonWhitelisted` 有効化、環境変数検証の強化、DTO バリデーションの追加によるランタイム安全性の強化。

### 修正内容

1. **ValidationPipe に `forbidNonWhitelisted: true` 追加** — DTO 未定義プロパティの送信を 400 エラーに

2. **環境変数検証の強化** — `startup-guard.ts` に以下を追加
   - `ENCRYPTION_KEY_V1` の存在・32文字以上の長さチェック
   - `HMAC_SECRET` の存在チェック
   - `DATABASE_URL` の存在チェック

3. **DTO バリデーション強化**
   - `LoginDto.password` に `@MaxLength(100)`（DoS 防止）
   - `CreateLocationDto` / `UpdateLocationDto` の `lat` に `@Min(-90) @Max(90)`、`lng` に `@Min(-180) @Max(180)`
   - `CreateSightingDto` の `lat`/`lng` に範囲制約
   - `CreateConversationDto` に `@IsNotEmpty()` 追加

### 検証

- typecheck:api → pass
- lint:api → 0 errors
- test:api → pass

Closes #271