### PR TITLE
fix: tailwindcss-animate を dependencies に移動し VPS Web ビルドエラーを修正

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "autoprefixer": "^10.5.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^3.4.19",
+    "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2"
   },
   "devDependencies": {
@@ -51,7 +52,6 @@
     "playwright": "^1.35.0",
     "postcss": "^8.5.10",
     "rollup-plugin-visualizer": "^7.0.1",
-    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.0.0",
     "vite": "^8.0.11",
     "vitest": "^4.1.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3983,6 +3983,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^3.4.19",
+        "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2"
       },
       "devDependencies": {
@@ -4000,7 +4001,6 @@
         "playwright": "^1.35.0",
         "postcss": "^8.5.10",
         "rollup-plugin-visualizer": "^7.0.1",
-        "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.0.0",
         "vite": "^8.0.11",
         "vitest": "^4.1.4"
@@ -18281,7 +18281,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
       "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"


### PR DESCRIPTION
## Summary
- `tailwindcss-animate` が `devDependencies` にあったため、VPS 上の `npm ci` でインストールされず Vite ビルドが失敗していた
- `apps/web/package.json` で `tailwindcss-animate` を `devDependencies` → `dependencies` に移動
- `autoprefixer` や `tailwindcss` と同様、Tailwind ビルド時に必須のプラグインは `dependencies` に置くのが正しい