### PR TITLE
fix: Map マーカーエンドポイントのレートリミット復元 (#279)

### DIFF
--- a/apps/api/src/map/map.controller.spec.ts
+++ b/apps/api/src/map/map.controller.spec.ts
@@ -1,0 +1,31 @@
+import { MapController } from "./map.controller";
+
+const THROTTLER_SKIP = "THROTTLER:SKIP";
+const THROTTLER_LIMIT = "THROTTLER:LIMIT";
+const THROTTLER_TTL = "THROTTLER:TTL";
+
+describe("MapController", () => {
+  describe("getMarkers スロットル設定", () => {
+    const handler = MapController.prototype.getMarkers;
+
+    it("@SkipThrottle が public に設定されていないこと", () => {
+      const skip = Reflect.getMetadata(THROTTLER_SKIP + "public", handler);
+      expect(skip).not.toBe(true);
+    });
+
+    it("@SkipThrottle が default に設定されていないこと", () => {
+      const skip = Reflect.getMetadata(THROTTLER_SKIP + "default", handler);
+      expect(skip).not.toBe(true);
+    });
+
+    it("public スロットルの limit が 600 であること", () => {
+      const limit = Reflect.getMetadata(THROTTLER_LIMIT + "public", handler);
+      expect(limit).toBe(600);
+    });
+
+    it("public スロットルの ttl が 60000 であること", () => {
+      const ttl = Reflect.getMetadata(THROTTLER_TTL + "public", handler);
+      expect(ttl).toBe(60000);
+    });
+  });
+});

--- a/apps/api/src/map/map.controller.ts
+++ b/apps/api/src/map/map.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Query } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
-import { SkipThrottle } from "@nestjs/throttler";
+import { Throttle } from "@nestjs/throttler";
 import { GetMarkersQueryDto } from "./dto/get-markers-query.dto";
 import { MapMarkerDto } from "./dto/marker-response.dto";
 import { MapService } from "./map.service";
@@ -11,7 +11,7 @@ export class MapController {
   constructor(private readonly mapService: MapService) {}
 
   @Get("markers")
-  @SkipThrottle({ default: true, public: true })
+  @Throttle({ public: { limit: 600, ttl: 60000 } })
   @ApiResponse({ status: 200, type: MapMarkerDto, isArray: true })
   getMarkers(@Query() query: GetMarkersQueryDto): Promise<MapMarkerDto[]> {
     return this.mapService.getMarkers(query);

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -486,6 +486,17 @@
 
 ---
 
+### MapController (`src/map/map.controller.spec.ts`)
+
+#### getMarkers スロットル設定
+
+- [x] @SkipThrottle が public に設定されていないこと
+- [x] @SkipThrottle が default に設定されていないこと
+- [x] public スロットルの limit が 600 であること
+- [x] public スロットルの ttl が 60000 であること
+
+---
+
 ### RolesGuard (`src/auth/roles.guard.spec.ts`)
 
 - [x] @Roles デコレータがない場合は通す

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -322,18 +322,24 @@ apps/api/src/
 │           ├── オーナー以外は ForbiddenException を伝播する
 │           └── 存在しない投稿は HttpException を伝播する
 ├── map/
-│   └── map.service.spec.ts
-│       └── getMarkers
-│           ├── bbox内のPostマーカーが type='post' で返ること
-│           ├── bbox内のSightingマーカーが type='sighting' で返ること
-│           ├── standalone Sighting は statusなしで lost として返ること
-│           ├── statusフィルタ指定時にPostクエリのwhereにstatusが含まれること
-│           ├── statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
-│           ├── bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
-│           ├── bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
-│           ├── bboxクエリが文字列でも数値フィルタとして渡ること
-│           ├── 空白文字列と非有限数はbboxフィルタに含めないこと
-│           └── フィルタなしで全マーカー（Post+Sighting）が返ること
+│   ├── map.service.spec.ts
+│   │   └── getMarkers
+│   │       ├── bbox内のPostマーカーが type='post' で返ること
+│   │       ├── bbox内のSightingマーカーが type='sighting' で返ること
+│   │       ├── standalone Sighting は statusなしで lost として返ること
+│   │       ├── statusフィルタ指定時にPostクエリのwhereにstatusが含まれること
+│   │       ├── statusフィルタ指定時にSightingクエリのwhereにpost.statusが含まれること
+│   │       ├── bboxクエリ条件がPostのlocation.lat/lngフィルタとして渡ること
+│   │       ├── bboxクエリ条件がSightingのlat/lngフィルタとして渡ること
+│   │       ├── bboxクエリが文字列でも数値フィルタとして渡ること
+│   │       ├── 空白文字列と非有限数はbboxフィルタに含めないこと
+│   │       └── フィルタなしで全マーカー（Post+Sighting）が返ること
+│   └── map.controller.spec.ts
+│       └── getMarkers スロットル設定
+│           ├── @SkipThrottle が public に設定されていないこと
+│           ├── @SkipThrottle が default に設定されていないこと
+│           ├── public スロットルの limit が 600 であること
+│           └── public スロットルの ttl が 60000 であること
 ├── conversations/
 │   ├── dto/
 │   │   └── create-message.dto.spec.ts


### PR DESCRIPTION
## Summary

- `GET /map/markers` の `@SkipThrottle({ default: true, public: true })` を廃止
- `@Throttle({ public: { limit: 600, ttl: 60000 } })` に置き換え（10req/s = モバイルパン操作を許容しつつスクレイピング・DoS防止）
- `map.controller.spec.ts` 新規追加（4件）

## Test plan

- [x] `@SkipThrottle` が public/default に設定されていないこと
- [x] public スロットルの limit が 600・ttl が 60000 であること
- [x] 全テスト 362件 (API) + 213件 (Web) パス

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)