### PR TITLE
chore: .mcp.json を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ apps/api/scripts/decrypt-emails.ts
 *storybook.log
 storybook-static
 kilo.json
+.mcp.json


### PR DESCRIPTION
PAT を含むため git 管理外に設定。