### PR TITLE
chore: issue#288 web Dockerfile に CMD を明示

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -28,3 +28,5 @@ FROM nginx:1.29-alpine
 COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/apps/web/dist /usr/share/nginx/html
 EXPOSE 80
+# ベースイメージの CMD と同一だが、起動方法を Dockerfile 単体で読めるよう明示する
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Closes #288

## 概要

Docker Mastery Sec28 のレビュー原則「継承元の CMD でも明示的に書く（Dockerfile 単体で起動方法が分かる）」を apps/web/Dockerfile に反映。

## 変更内容

- `CMD ["nginx", "-g", "daemon off;"]` を明示（nginx:1.29-alpine の継承値と同一、挙動変更なし）

## 動作確認

- [x] `docker compose --profile app build web` 成功
- [x] 再起動後 Web (8080) / プロキシ経由 `/api/health` ともに 200
- [x] `docker inspect` で CMD が `["nginx","-g","daemon off;"]` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)