### PR TITLE
feat: issue#291 API/Web 小修正まとめ

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -63,10 +63,12 @@ async function bootstrap() {
     SwaggerModule.setup("api", app, document);
   }
 
-  await app.listen(3000);
-  app.get(Logger).log("API listening on http://localhost:3000");
+  const port = parseInt(process.env.PORT ?? "3000", 10);
+  await app.listen(port);
+  app.get(Logger).log(`API listening on http://localhost:${port}`);
 }
 
-bootstrap().catch(() => {
+bootstrap().catch((err: unknown) => {
+  console.error("起動に失敗しました:", err);
   process.exitCode = 1;
 });

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -182,6 +182,28 @@ describe("PostsService", () => {
         where: { userId: "user1" },
       });
     });
+
+    it("page=0 を渡しても skip=0 (先頭ページ) として処理される", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.post.count.mockResolvedValue(0);
+
+      await service.findAll(0, 10);
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 10 })
+      );
+    });
+
+    it("page=-1 を渡しても skip=0 (先頭ページ) として処理される", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.post.count.mockResolvedValue(0);
+
+      await service.findAll(-1, 10);
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 10 })
+      );
+    });
   });
 
   // ─── findById ───────────────────────────────────────────────

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -39,6 +39,10 @@ function getMonthRange(date = new Date()) {
   return { start, end };
 }
 
+function setField<T, K extends keyof T>(obj: T, key: K, value: T[K]): void {
+  obj[key] = value;
+}
+
 function isTransactionConflict(error: unknown) {
   return (
     typeof error === "object" &&
@@ -90,14 +94,14 @@ function buildPetDetailUpsertData(postId: string, pd: UpdatePetDetailDto) {
     const val = pd[key];
     if (val !== undefined) {
       const v = transform ? transform(val) : val;
-      (create as Record<string, unknown>)[key] = v;
-      (update as Record<string, unknown>)[key] = v;
+      setField(create, key, v as (typeof create)[typeof key]);
+      setField(update, key, v as (typeof update)[typeof key]);
     }
   }
 
   for (const key of ["name", "color", "age", "features"] as const) {
     if (pd[key] !== undefined)
-      (update as Record<string, unknown>)[key] = pd[key];
+      setField(update, key, pd[key] as (typeof update)[typeof key]);
   }
 
   return { create, update };
@@ -126,9 +130,8 @@ function buildLocationUpsertData(postId: string, loc: UpdateLocationDto) {
   for (const { key, transform } of fields) {
     const val = loc[key];
     if (val !== undefined) {
-      (update as Record<string, unknown>)[key] = transform
-        ? transform(val)
-        : val;
+      const v = transform ? transform(val) : val;
+      setField(update, key, v as (typeof update)[typeof key]);
     }
   }
   return { create, update };
@@ -216,17 +219,12 @@ function buildPetDetailCreateData(
     features: pd.features,
   };
 
-  if (pd.gender !== undefined)
-    (data as Record<string, unknown>).gender = pd.gender as Gender;
-  if (pd.breed !== undefined)
-    (data as Record<string, unknown>).breed = pd.breed;
-  if (pd.size !== undefined) (data as Record<string, unknown>).size = pd.size;
-  if (pd.collar !== undefined)
-    (data as Record<string, unknown>).collar = pd.collar;
-  if (pd.microchip !== undefined)
-    (data as Record<string, unknown>).microchip = pd.microchip;
-  if (pd.neutered !== undefined)
-    (data as Record<string, unknown>).neutered = pd.neutered;
+  if (pd.gender !== undefined) data.gender = pd.gender as Gender;
+  if (pd.breed !== undefined) data.breed = pd.breed;
+  if (pd.size !== undefined) data.size = pd.size;
+  if (pd.collar !== undefined) data.collar = pd.collar;
+  if (pd.microchip !== undefined) data.microchip = pd.microchip;
+  if (pd.neutered !== undefined) data.neutered = pd.neutered;
 
   return data;
 }
@@ -359,7 +357,8 @@ export class PostsService {
   }
 
   async findAll(page = 1, perPage = 10, userId?: string) {
-    const skip = (page - 1) * perPage;
+    const safePage = Math.max(1, page);
+    const skip = (safePage - 1) * perPage;
     const where = userId ? { userId } : {};
     const [items, total] = await Promise.all([
       this.prisma.post.findMany({
@@ -627,7 +626,7 @@ export class PostsService {
       if (count >= MAX_FAVORITES_LIMIT)
         throw new BadRequestException({
           code: ERROR_CODES.POST_FAVORITE_LIMIT,
-          message: "お気に入りは20件までです",
+          message: `お気に入りは${MAX_FAVORITES_LIMIT}件までです`,
         });
       await tx.postFavorite.create({ data: { userId, postId } });
     });

--- a/apps/web/src/auth/AuthProvider.tsx
+++ b/apps/web/src/auth/AuthProvider.tsx
@@ -76,30 +76,31 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({
     refresh().finally(() => setIsRestoring(false));
   }, [refresh]);
 
-  const setToken = (t: string | null) => setTokenState(t);
-  const clearToken = () => {
+  const setToken = useCallback((t: string | null) => setTokenState(t), []);
+  const clearToken = useCallback(() => {
     setTokenState(null);
     navigate("/login");
-  };
+  }, [navigate]);
 
   const payload = decodePayload(token);
   const userId = (payload?.sub as string) ?? null;
   const nickname = (payload?.nickname as string) ?? null;
 
+  const contextValue = React.useMemo(
+    () => ({
+      token,
+      userId,
+      nickname,
+      isRestoring,
+      setToken,
+      clearToken,
+      refresh,
+    }),
+    [token, userId, nickname, isRestoring, setToken, clearToken, refresh]
+  );
+
   return (
-    <AuthContext.Provider
-      value={{
-        token,
-        userId,
-        nickname,
-        isRestoring,
-        setToken,
-        clearToken,
-        refresh,
-      }}
-    >
-      {children}
-    </AuthContext.Provider>
+    <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>
   );
 };
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -67,6 +67,8 @@
 - [x] items と total を返し、投稿者名を authorNickname に詰める
 - [x] userId 指定時は where に userId を含めて検索する
 - [x] userId 指定時でもページネーションが正しく機能する
+- [x] page=0 を渡しても skip=0 (先頭ページ) として処理される
+- [x] page=-1 を渡しても skip=0 (先頭ページ) として処理される
 
 #### findById
 
@@ -508,6 +510,14 @@
 
 - [x] 制限超過時に日本語メッセージ付き ThrottlerException をスローすること
 
+### AuthController (`src/auth/auth.controller.spec.ts`)
+
+#### logout
+
+- [x] clearCookie が refreshTokenCookieOptions と同じ属性で呼ばれること（非production）
+- [x] clearCookie が refreshTokenCookieOptions と同じ属性で呼ばれること（production）
+- [x] Cookie がなければ clearCookie は属性付きで呼ばれ、logout は呼ばれないこと
+
 ---
 
 ### IdentityService (`src/identity/identity.service.spec.ts`)
@@ -515,11 +525,12 @@
 #### login
 
 - [x] 正しいメールとパスワードでAuthResultを返すこと
+- [x] CookieのmaxAgeが30日（ミリ秒）で設定されること
 - [x] DBにはtokenHashが保存され、平文トークンは保存されないこと
 - [x] パスワード不一致でUnauthorizedExceptionを投げること
 - [x] 存在しないメールアドレスでUnauthorizedExceptionを投げること
 - [x] HMACのみで検索し、SHA256フォールバックを行わないこと
-- [x] production環境ではCookieのsecureとsameSiteが適切に設定されること
+- [x] production環境ではCookieのsecure/sameSite/maxAgeが適切に設定されること
 - [x] ログイン成功時に auth.login.success イベントをログ出力すること
 - [x] パスワード不一致時に auth.login.failure イベントをログ出力すること
 - [x] メールアドレス未登録時に auth.login.failure イベントをログ出力すること
@@ -557,6 +568,12 @@
 #### deleteUser
 
 - [x] ユーザーを削除しUserDtoを返すこと
+
+#### refreshTokenCookieOptions
+
+- [x] 非production環境では secure=false, sameSite=lax を返すこと
+- [x] production環境では secure=true, sameSite=none を返すこと
+- [x] maxAge がミリ秒単位で30日に等しいこと
 
 ### emailHashマイグレーション (`src/identity/email-hash-migration.spec.ts`)
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -49,9 +49,15 @@ apps/api/src/
 │   │       ├── ロールが一致する場合は通す
 │   │       ├── ロールが一致しない場合は ForbiddenException をスローする
 │   │       └── ユーザーが未設定の場合は ForbiddenException をスローする
-│   └── throttler.guard.spec.ts
-│       └── AppThrottlerGuard
-│           └── 制限超過時に日本語メッセージ付き ThrottlerException をスローすること
+│   ├── throttler.guard.spec.ts
+│   │   └── AppThrottlerGuard
+│   │       └── 制限超過時に日本語メッセージ付き ThrottlerException をスローすること
+│   └── auth.controller.spec.ts
+│       └── AuthController
+│           └── logout
+│               ├── clearCookie が refreshTokenCookieOptions と同じ属性で呼ばれること（非production）
+│               ├── clearCookie が refreshTokenCookieOptions と同じ属性で呼ばれること（production）
+│               └── Cookie がなければ clearCookie は属性付きで呼ばれ、logout は呼ばれないこと
 ├── identity/
 │   ├── email-hash-migration.spec.ts
 │   │   └── migrateEmailHashToHmac
@@ -220,7 +226,9 @@ apps/api/src/
 │   │   │   ├── ページ3・perPage5 で skip=10 を渡す
 │   │   │   ├── items と total を返し、投稿者名を authorNickname に詰める
 │   │   │   ├── userId 指定時は where に userId を含めて検索する
-│   │   │   └── userId 指定時でもページネーションが正しく機能する
+│   │   │   ├── userId 指定時でもページネーションが正しく機能する
+│   │   │   ├── page=0 を渡しても skip=0 (先頭ページ) として処理される
+│   │   │   └── page=-1 を渡しても skip=0 (先頭ページ) として処理される
 │   │   ├── findById
 │   │   │   └── petDetail/location/images と user.nickname を取得し authorNickname を返す
 │   │   ├── create


### PR DESCRIPTION
## Summary

- `PORT` 環境変数でリッスンポートを変更可能に（未設定時 3000）
- 起動失敗時にエラー内容をログ出力してから終了
- `findAll` の `page` パラメータに負数・0 ガードを追加（先頭ページにクランプ）
- お気に入り上限エラーメッセージを `MAX_FAVORITES_LIMIT` 定数から補間
- `post.service.ts` の `as Record<string, unknown>` キャスト多用を `setField<T, K>` ヘルパで整理
- `AuthProvider` の context value を `useMemo`/`useCallback` でメモ化

## Test plan

- [x] `npm run typecheck:api` — 型エラーなし
- [x] `npm run typecheck:web` — 型エラーなし
- [x] `npm run test` (API 370件 + Web 213件) — 全通過
- [x] `page=0` / `page=-1` の境界値テスト 2件追加
- [x] `tests/TESTS.md` / `tests/TESTS_TREE.md` 更新済み

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)