### PR TITLE
fix: issue#290 Refresh Cookie の maxAge ミリ秒化と clearCookie 属性統一

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -1,0 +1,80 @@
+import { ConfigService } from "@nestjs/config";
+import { AuthController } from "./auth.controller";
+import {
+  IIdentityService,
+  refreshTokenCookieOptions,
+} from "../identity/identity.service";
+
+const mockIdentity = {
+  login: jest.fn(),
+  refresh: jest.fn(),
+  logout: jest.fn(),
+} as unknown as jest.Mocked<IIdentityService>;
+
+function mockConfig(env: string) {
+  return {
+    get: jest.fn((key: string) => {
+      if (key === "NODE_ENV") return env;
+      return undefined;
+    }),
+    getOrThrow: jest.fn(),
+  } as unknown as ConfigService;
+}
+
+describe("AuthController", () => {
+  let controller: AuthController;
+
+  describe("logout", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("clearCookie が refreshTokenCookieOptions と同じ属性で呼ばれること（非production）", async () => {
+      controller = new AuthController(mockIdentity, mockConfig("test"));
+      const res = {
+        clearCookie: jest.fn(),
+      } as any;
+      const req = {
+        cookies: { refreshToken: "some-token" },
+      } as any;
+
+      await controller.logout(req, res);
+
+      const expected = refreshTokenCookieOptions(false);
+      expect(res.clearCookie).toHaveBeenCalledWith("refreshToken", expected);
+    });
+
+    it("clearCookie が refreshTokenCookieOptions と同じ属性で呼ばれること（production）", async () => {
+      controller = new AuthController(mockIdentity, mockConfig("production"));
+      const res = {
+        clearCookie: jest.fn(),
+      } as any;
+      const req = {
+        cookies: { refreshToken: "some-token" },
+      } as any;
+
+      await controller.logout(req, res);
+
+      const expected = refreshTokenCookieOptions(true);
+      expect(res.clearCookie).toHaveBeenCalledWith("refreshToken", expected);
+    });
+
+    it("Cookie がなければ clearCookie は属性付きで呼ばれ、logout は呼ばれないこと", async () => {
+      controller = new AuthController(mockIdentity, mockConfig("test"));
+      const res = {
+        clearCookie: jest.fn(),
+      } as any;
+      const req = {
+        cookies: {},
+      } as any;
+
+      await controller.logout(req, res);
+
+      expect(mockIdentity.logout).not.toHaveBeenCalled();
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        "refreshToken",
+        refreshTokenCookieOptions(false)
+      );
+    });
+  });
+});

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -10,7 +10,11 @@ import {
 } from "@nestjs/common";
 import { ApiTags, ApiResponse } from "@nestjs/swagger";
 import { SkipThrottle, Throttle } from "@nestjs/throttler";
-import { IIdentityService } from "../identity/identity.service";
+import { ConfigService } from "@nestjs/config";
+import {
+  IIdentityService,
+  refreshTokenCookieOptions,
+} from "../identity/identity.service";
 import { LoginDto } from "./dto/login.dto";
 import {
   AccessTokenResponseDto,
@@ -21,7 +25,10 @@ import { Request, Response } from "express";
 @ApiTags("auth")
 @Controller("auth")
 export class AuthController {
-  constructor(private readonly identity: IIdentityService) {}
+  constructor(
+    private readonly identity: IIdentityService,
+    private readonly config: ConfigService
+  ) {}
 
   @Post("login")
   @Throttle({ login: {} })
@@ -63,7 +70,8 @@ export class AuthController {
     const cookies = req.cookies as Record<string, string> | undefined;
     const token = cookies?.refreshToken;
     if (token) await this.identity.logout(token);
-    res.clearCookie("refreshToken", { path: "/" });
+    const isProd = this.config.get<string>("NODE_ENV") === "production";
+    res.clearCookie("refreshToken", refreshTokenCookieOptions(isProd));
     return { ok: true };
   }
 

--- a/apps/api/src/identity/identity.service.spec.ts
+++ b/apps/api/src/identity/identity.service.spec.ts
@@ -3,7 +3,11 @@ import { JwtService } from "@nestjs/jwt";
 import { ConfigService } from "@nestjs/config";
 import * as bcrypt from "bcrypt";
 import { Logger } from "nestjs-pino";
-import { IdentityService } from "./identity.service";
+import {
+  IdentityService,
+  refreshTokenCookieOptions,
+  REFRESH_TOKEN_MAX_AGE_MS,
+} from "./identity.service";
 import { CryptoService } from "./crypto.service";
 import { PrismaService } from "../prisma.service";
 
@@ -97,6 +101,9 @@ describe("IdentityService", () => {
       expect(result.setCookies[0].value).toBe("a".repeat(96));
       expect(result.setCookies[0].options.httpOnly).toBe(true);
       expect(result.setCookies[0].options.sameSite).toBe("lax");
+      expect(result.setCookies[0].options.maxAge).toBe(
+        60 * 60 * 24 * 30 * 1000
+      );
     });
 
     it("ログイン成功時に auth.login.success イベントをログ出力すること", async () => {
@@ -251,6 +258,9 @@ describe("IdentityService", () => {
 
       expect(result.setCookies[0].options.secure).toBe(true);
       expect(result.setCookies[0].options.sameSite).toBe("none");
+      expect(result.setCookies[0].options.maxAge).toBe(
+        60 * 60 * 24 * 30 * 1000
+      );
     });
   });
 
@@ -558,6 +568,36 @@ describe("IdentityService", () => {
 
       expect(result.id).toBe("u1");
       expect(result.nickname).toBe("Alice");
+    });
+  });
+
+  describe("refreshTokenCookieOptions", () => {
+    it("非production環境では secure=false, sameSite=lax を返すこと", () => {
+      const opts = refreshTokenCookieOptions(false);
+
+      expect(opts.secure).toBe(false);
+      expect(opts.sameSite).toBe("lax");
+      expect(opts.httpOnly).toBe(true);
+      expect(opts.path).toBe("/");
+      expect(opts.maxAge).toBe(REFRESH_TOKEN_MAX_AGE_MS);
+      expect(opts.maxAge).toBe(60 * 60 * 24 * 30 * 1000);
+    });
+
+    it("production環境では secure=true, sameSite=none を返すこと", () => {
+      const opts = refreshTokenCookieOptions(true);
+
+      expect(opts.secure).toBe(true);
+      expect(opts.sameSite).toBe("none");
+      expect(opts.httpOnly).toBe(true);
+      expect(opts.path).toBe("/");
+      expect(opts.maxAge).toBe(REFRESH_TOKEN_MAX_AGE_MS);
+    });
+
+    it("maxAge がミリ秒単位で30日に等しいこと", () => {
+      const opts = refreshTokenCookieOptions(false);
+      const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+
+      expect(opts.maxAge).toBe(thirtyDaysMs);
     });
   });
 });

--- a/apps/api/src/identity/identity.service.ts
+++ b/apps/api/src/identity/identity.service.ts
@@ -12,6 +12,18 @@ import { PrismaService } from "../prisma.service";
 import { CryptoService } from "./crypto.service";
 import { ERROR_CODES } from "../common/error-codes";
 
+export const REFRESH_TOKEN_MAX_AGE_MS = 60 * 60 * 24 * 30 * 1000;
+
+export function refreshTokenCookieOptions(isProd: boolean) {
+  return {
+    httpOnly: true,
+    secure: isProd,
+    sameSite: (isProd ? "none" : "lax") as "lax" | "none",
+    path: "/",
+    maxAge: REFRESH_TOKEN_MAX_AGE_MS,
+  };
+}
+
 export interface CookieSpec {
   name: string;
   value: string;
@@ -93,7 +105,7 @@ export class IdentityService extends IIdentityService {
       data: {
         tokenHash,
         userId: user.id,
-        expiresAt: new Date(Date.now() + 60 * 60 * 24 * 30 * 1000),
+        expiresAt: new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS),
       },
     });
     const payload = {
@@ -148,7 +160,7 @@ export class IdentityService extends IIdentityService {
       data: {
         tokenHash: newHash,
         userId: rec.userId,
-        expiresAt: new Date(Date.now() + 60 * 60 * 24 * 30 * 1000),
+        expiresAt: new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS),
       },
     });
     const payload = {
@@ -310,13 +322,7 @@ export class IdentityService extends IIdentityService {
     return {
       name: "refreshToken",
       value: token,
-      options: {
-        httpOnly: true,
-        secure: isProd,
-        sameSite: isProd ? "none" : "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-      },
+      options: refreshTokenCookieOptions(isProd),
     };
   }
 }

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -92,11 +92,12 @@ apps/api/src/
 │   │   └── IdentityService
 │   │       ├── login
 │   │       │   ├── 正しいメールとパスワードでAuthResultを返すこと
+│   │       │   ├── CookieのmaxAgeが30日（ミリ秒）で設定されること
 │   │       │   ├── DBにはtokenHashが保存され、平文トークンは保存されないこと
 │   │       │   ├── パスワード不一致でUnauthorizedExceptionを投げること
 │   │       │   ├── 存在しないメールアドレスでUnauthorizedExceptionを投げること
 │   │       │   ├── HMACのみで検索し、SHA256フォールバックを行わないこと
-│   │       │   ├── production環境ではCookieのsecureとsameSiteが適切に設定されること
+│   │       │   ├── production環境ではCookieのsecure/sameSite/maxAgeが適切に設定されること
 │   │       │   ├── ログイン成功時に auth.login.success イベントをログ出力すること
 │   │       │   ├── パスワード不一致時に auth.login.failure イベントをログ出力すること
 │   │       │   ├── メールアドレス未登録時に auth.login.failure イベントをログ出力すること
@@ -122,8 +123,12 @@ apps/api/src/
 │   │       │   └── 登録成功時に auth.register.success イベントをログ出力すること
 │   │       ├── findAll
 │   │       │   └── 全ユーザーをパスワードなしで返すこと
-│   │       └── deleteUser
-│   │           └── ユーザーを削除しUserDtoを返すこと
+│   │       ├── deleteUser
+│   │       │   └── ユーザーを削除しUserDtoを返すこと
+│   │       └── refreshTokenCookieOptions
+│   │           ├── 非production環境では secure=false, sameSite=lax を返すこと
+│   │           ├── production環境では secure=true, sameSite=none を返すこと
+│   │           └── maxAge がミリ秒単位で30日に等しいこと
 │   └── crypto.service.spec.ts
 │       └── CryptoService
 │           ├── normalizeEmail


### PR DESCRIPTION
## Summary

- `buildRefreshCookie` の `maxAge` を秒→ミリ秒に修正。従来は `60*60*24*30`（≒43分）で Cookie が失効しており、DB のトークン有効期限（30日）と乖離していた
- `REFRESH_TOKEN_MAX_AGE_MS` 定数と `refreshTokenCookieOptions(isProd)` 共有関数を導入し、Cookie 発行・削除・DB の `expiresAt` を単一定数に集約
- logout の `clearCookie` を発行時と同じ `secure`/`sameSite`/`path` 属性で呼ぶよう修正（属性不一致だと一部ブラウザで Cookie が削除されない）

## Test plan

- [x] `refreshTokenCookieOptions` 単体テスト 3件追加（非production / production / maxAge ミリ秒検証）
- [x] `AuthController.logout` テスト 3件追加（新規 spec: clearCookie 属性検証 ×2 + Cookie なしケース）
- [x] login / production テストに maxAge=30日ミリ秒の検証を追加
- [x] `npm run typecheck:api` / 全テストスイート（pre-commit フック）通過
- [x] `tests/TESTS.md` / `tests/TESTS_TREE.md` 更新済み

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)