### PR TITLE
fix: issue#291 perPage 負数ガードと PORT 解決の堅牢化（コードレビュー指摘対応）

### DIFF
--- a/apps/api/src/common/port.spec.ts
+++ b/apps/api/src/common/port.spec.ts
@@ -1,0 +1,33 @@
+import { resolvePort } from "./port";
+
+describe("resolvePort", () => {
+  it("未設定（undefined）の時はデフォルトの 3000 を返すこと", () => {
+    expect(resolvePort(undefined)).toBe(3000);
+  });
+
+  it("空文字の時はデフォルトの 3000 を返すこと", () => {
+    expect(resolvePort("")).toBe(3000);
+  });
+
+  it("数値文字列の時はその値を返すこと", () => {
+    expect(resolvePort("8080")).toBe(8080);
+  });
+
+  it("非数値文字列の時はデフォルトの 3000 を返すこと", () => {
+    expect(resolvePort("abc")).toBe(3000);
+  });
+
+  it("0 以下の時はデフォルトの 3000 を返すこと", () => {
+    expect(resolvePort("0")).toBe(3000);
+    expect(resolvePort("-1")).toBe(3000);
+  });
+
+  it("65535 を超える時はデフォルトの 3000 を返すこと", () => {
+    expect(resolvePort("65536")).toBe(3000);
+  });
+
+  it("ポート範囲の境界値（1 と 65535）はそのまま返すこと", () => {
+    expect(resolvePort("1")).toBe(1);
+    expect(resolvePort("65535")).toBe(65535);
+  });
+});

--- a/apps/api/src/common/port.ts
+++ b/apps/api/src/common/port.ts
@@ -1,0 +1,9 @@
+const DEFAULT_PORT = 3000;
+
+export function resolvePort(raw: string | undefined): number {
+  const parsed = parseInt(raw ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return DEFAULT_PORT;
+  }
+  return parsed;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,6 +10,7 @@ import * as path from "path";
 import { Logger } from "nestjs-pino";
 import { applyParameterExamples } from "./common/openapi-document";
 import { isOriginAllowed } from "./common/cors";
+import { resolvePort } from "./common/port";
 import { assertSecrets } from "./common/startup-guard";
 
 async function bootstrap() {
@@ -63,7 +64,7 @@ async function bootstrap() {
     SwaggerModule.setup("api", app, document);
   }
 
-  const port = parseInt(process.env.PORT ?? "3000", 10);
+  const port = resolvePort(process.env.PORT);
   await app.listen(port);
   app.get(Logger).log(`API listening on http://localhost:${port}`);
 }

--- a/apps/api/src/posts/post.service.spec.ts
+++ b/apps/api/src/posts/post.service.spec.ts
@@ -204,6 +204,50 @@ describe("PostsService", () => {
         expect.objectContaining({ skip: 0, take: 10 })
       );
     });
+
+    it("perPage=-5 かつ page=2 でも skip が負にならず take=1 にクランプされる", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.post.count.mockResolvedValue(0);
+
+      await service.findAll(2, -5);
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 1, take: 1 })
+      );
+    });
+
+    it("perPage=0 でも take=1 にクランプされる", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.post.count.mockResolvedValue(0);
+
+      await service.findAll(1, 0);
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 1 })
+      );
+    });
+
+    it("page/perPage が NaN でもデフォルト値 (skip=0, take=10) で処理される", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.post.count.mockResolvedValue(0);
+
+      await service.findAll(NaN, NaN);
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 10 })
+      );
+    });
+
+    it("page/perPage が小数でも整数に切り捨てて処理される", async () => {
+      mockPrisma.post.findMany.mockResolvedValue([]);
+      mockPrisma.post.count.mockResolvedValue(0);
+
+      await service.findAll(2.7, 5.9);
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 5, take: 5 })
+      );
+    });
   });
 
   // ─── findById ───────────────────────────────────────────────

--- a/apps/api/src/posts/post.service.ts
+++ b/apps/api/src/posts/post.service.ts
@@ -357,13 +357,16 @@ export class PostsService {
   }
 
   async findAll(page = 1, perPage = 10, userId?: string) {
-    const safePage = Math.max(1, page);
-    const skip = (safePage - 1) * perPage;
+    const safePage = Number.isFinite(page) ? Math.max(1, Math.trunc(page)) : 1;
+    const safePerPage = Number.isFinite(perPage)
+      ? Math.max(1, Math.trunc(perPage))
+      : 10;
+    const skip = (safePage - 1) * safePerPage;
     const where = userId ? { userId } : {};
     const [items, total] = await Promise.all([
       this.prisma.post.findMany({
         skip,
-        take: perPage,
+        take: safePerPage,
         where,
         orderBy: { createdAt: "desc" },
         include: {

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -58,6 +58,16 @@
 - [x] 用途別の OpenAPI 例示 ID が重複しないこと
 - [x] 汎用 ID 例示は投稿 ID 例示と一致すること
 
+### resolvePort (`src/common/port.spec.ts`)
+
+- [x] 未設定（undefined）の時はデフォルトの 3000 を返すこと
+- [x] 空文字の時はデフォルトの 3000 を返すこと
+- [x] 数値文字列の時はその値を返すこと
+- [x] 非数値文字列の時はデフォルトの 3000 を返すこと
+- [x] 0 以下の時はデフォルトの 3000 を返すこと
+- [x] 65535 を超える時はデフォルトの 3000 を返すこと
+- [x] ポート範囲の境界値（1 と 65535）はそのまま返すこと
+
 ### PostsService (`src/posts/post.service.spec.ts`)
 
 #### findAll
@@ -69,6 +79,10 @@
 - [x] userId 指定時でもページネーションが正しく機能する
 - [x] page=0 を渡しても skip=0 (先頭ページ) として処理される
 - [x] page=-1 を渡しても skip=0 (先頭ページ) として処理される
+- [x] perPage=-5 かつ page=2 でも skip が負にならず take=1 にクランプされる
+- [x] perPage=0 でも take=1 にクランプされる
+- [x] page/perPage が NaN でもデフォルト値 (skip=0, take=10) で処理される
+- [x] page/perPage が小数でも整数に切り捨てて処理される
 
 #### findById
 

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -38,10 +38,19 @@ apps/api/src/
 │   │           ├── localhost の任意ポートを許可すること
 │   │           ├── 許可オリジンを許可すること
 │   │           └── 未知の非 localhost オリジンを拒否すること
-│   └── openapi-examples.spec.ts
-│       └── OpenAPI example IDs
-│           ├── 用途別の OpenAPI 例示 ID が重複しないこと
-│           └── 汎用 ID 例示は投稿 ID 例示と一致すること
+│   ├── openapi-examples.spec.ts
+│   │   └── OpenAPI example IDs
+│   │       ├── 用途別の OpenAPI 例示 ID が重複しないこと
+│   │       └── 汎用 ID 例示は投稿 ID 例示と一致すること
+│   └── port.spec.ts
+│       └── resolvePort
+│           ├── 未設定（undefined）の時はデフォルトの 3000 を返すこと
+│           ├── 空文字の時はデフォルトの 3000 を返すこと
+│           ├── 数値文字列の時はその値を返すこと
+│           ├── 非数値文字列の時はデフォルトの 3000 を返すこと
+│           ├── 0 以下の時はデフォルトの 3000 を返すこと
+│           ├── 65535 を超える時はデフォルトの 3000 を返すこと
+│           └── ポート範囲の境界値（1 と 65535）はそのまま返すこと
 ├── auth/
 │   ├── roles.guard.spec.ts
 │   │   └── RolesGuard
@@ -228,7 +237,11 @@ apps/api/src/
 │   │   │   ├── userId 指定時は where に userId を含めて検索する
 │   │   │   ├── userId 指定時でもページネーションが正しく機能する
 │   │   │   ├── page=0 を渡しても skip=0 (先頭ページ) として処理される
-│   │   │   └── page=-1 を渡しても skip=0 (先頭ページ) として処理される
+│   │   │   ├── page=-1 を渡しても skip=0 (先頭ページ) として処理される
+│   │   │   ├── perPage=-5 かつ page=2 でも skip が負にならず take=1 にクランプされる
+│   │   │   ├── perPage=0 でも take=1 にクランプされる
+│   │   │   ├── page/perPage が NaN でもデフォルト値 (skip=0, take=10) で処理される
+│   │   │   └── page/perPage が小数でも整数に切り捨てて処理される
 │   │   ├── findById
 │   │   │   └── petDetail/location/images と user.nickname を取得し authorNickname を返す
 │   │   ├── create


### PR DESCRIPTION
## Summary

PR #299 のコードレビューで見つかった2件の修正。

- **perPage 負数で 500 が再現する経路を解消**: `GET /api/posts?page=2&perPage=-5` で skip が負数になり Prisma バリデーションエラー（500）が発生していた。`findAll` で page / perPage 両方を `Number.isFinite` + `Math.trunc` + 下限1でクランプし、ガード責務を service 側に集約
- **PORT 解決の堅牢化**: `PORT=""` や非数値で `parseInt` が NaN になり起動クラッシュしていた。`resolvePort` ヘルパ（`common/port.ts`）に抽出し、空文字・非数値・範囲外（<1, >65535）はデフォルト 3000 にフォールバック

## Test plan

- [x] findAll 境界値テスト 4件追加（perPage=-5×page=2 / perPage=0 / NaN / 小数）
- [x] resolvePort テスト 7件追加（undefined / 空文字 / 数値 / 非数値 / 0以下 / 65536以上 / 境界値 1・65535）
- [x] `npm run typecheck:api` / 全テストスイート（pre-commit フック）通過
- [x] tests/TESTS.md / tests/TESTS_TREE.md 更新済み

Refs #291 (PR #299 のフォローアップ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)