### PR TITLE
fix: ログイン失敗時にaxiosの英語エラーメッセージが表示される問題を修正 (#316)

### DIFF
--- a/apps/web/src/pages/LoginWithAuth.test.tsx
+++ b/apps/web/src/pages/LoginWithAuth.test.tsx
@@ -98,4 +98,66 @@ describe("LoginWithAuth", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("APIから返された日本語エラーメッセージを表示すること", async () => {
+    mockLogin.mockRejectedValue({
+      response: {
+        status: 401,
+        data: { message: "認証情報が正しくありません" },
+      },
+    });
+    const user = userEvent.setup();
+    render(<LoginWithAuth />);
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com"
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrongpass");
+    await user.click(screen.getByRole("button", { name: /ログイン/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("認証情報が正しくありません")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("APIがerrorフィールドでエラーメッセージを返した場合それを使用すること", async () => {
+    mockLogin.mockRejectedValue({
+      response: { status: 401, data: { error: "無効なリクエストです" } },
+    });
+    const user = userEvent.setup();
+    render(<LoginWithAuth />);
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com"
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrongpass");
+    await user.click(screen.getByRole("button", { name: /ログイン/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("無効なリクエストです")).toBeInTheDocument();
+    });
+  });
+
+  it("APIメッセージがない場合フォールバック日本語メッセージを表示すること", async () => {
+    mockLogin.mockRejectedValue(new Error("Network Error"));
+    const user = userEvent.setup();
+    render(<LoginWithAuth />);
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com"
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrongpass");
+    await user.click(screen.getByRole("button", { name: /ログイン/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/メールアドレスまたはパスワードが正しくありません/i)
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/pages/LoginWithAuth.tsx
+++ b/apps/web/src/pages/LoginWithAuth.tsx
@@ -30,14 +30,16 @@ export default function LoginWithAuth() {
         setAuthError("ログインに失敗しました");
       }
     } catch (err: unknown) {
-      const status =
-        err && typeof err === "object" && "response" in err
-          ? (err as { response?: { status?: number } }).response?.status
-          : undefined;
-      const msg =
-        err && typeof err === "object" && "message" in err
-          ? String((err as { message: unknown }).message)
-          : String(err);
+      const axiosErr = err as {
+        response?: {
+          status?: number;
+          data?: { message?: string; error?: string };
+        };
+        message?: string;
+      };
+      const status = axiosErr.response?.status;
+      const apiMessage =
+        axiosErr.response?.data?.message || axiosErr.response?.data?.error;
       if (status === 429) {
         setAuthError(
           "リクエスト回数が多すぎます。しばらく待ってから再試行してください。"
@@ -48,9 +50,7 @@ export default function LoginWithAuth() {
         );
       } else {
         setAuthError(
-          msg === "Unauthorized"
-            ? "メールアドレスまたはパスワードが正しくありません"
-            : `エラー: ${msg}`
+          apiMessage || "メールアドレスまたはパスワードが正しくありません"
         );
       }
     } finally {


### PR DESCRIPTION
## Summary

- `LoginWithAuth.tsx` の catch ブロックで、API が返す `err.response.data.message` の日本語メッセージを優先表示するよう修正
- `err.response.data.error` もフォールバックとして考慮
- API メッセージがない場合は日本語フォールバック「メールアドレスまたはパスワードが正しくありません」を表示
- Register.tsx は既に適切に対応済み（変更不要）

## 変更ファイル

- `apps/web/src/pages/LoginWithAuth.tsx` — catch ブロックのエラーメッセージ抽出ロジック改善
- `apps/web/src/pages/LoginWithAuth.test.tsx` — テスト追加（API 日本語メッセージ・error フィールド・フォールバック）

## テスト

```sh
✓ フォームが正しくレンダリングされること
✓ パスワード表示トグルで入力欄のtype属性が切り替わること
✓ 正常ログイン時、マップ画面（/）にリダイレクトすること
✓ 認証エラー時、フォーム上部にエラーバナーが表示されること
✓ APIから返された日本語エラーメッセージを表示すること (new)
✓ APIがerrorフィールドでエラーメッセージを返した場合それを使用すること (new)
✓ APIメッセージがない場合フォールバック日本語メッセージを表示すること (new)
```

Closes #316