### PR TITLE
feat: issue#317+318 フォームバリデーション時スクロール・SightingModal UI改善

### DIFF
--- a/apps/web/src/components/SightingModal.test.tsx
+++ b/apps/web/src/components/SightingModal.test.tsx
@@ -1,14 +1,28 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import SightingModal from "./SightingModal";
 
 const mockCreateSighting = vi.fn();
+const mockGetCurrentPosition = vi.fn();
+const { mockReverseGeocode } = vi.hoisted(() => ({
+  mockReverseGeocode:
+    vi.fn<
+      (
+        lat: number,
+        lng: number
+      ) => Promise<{ address?: string; geocodeError?: string }>
+    >(),
+}));
 
 vi.mock("../api/orvalClient", () => ({
   useApiClient: () => ({
     createSighting: mockCreateSighting,
   }),
+}));
+
+vi.mock("../lib/reverseGeocode", () => ({
+  reverseGeocode: mockReverseGeocode,
 }));
 
 function renderModal(props: Partial<Parameters<typeof SightingModal>[0]> = {}) {
@@ -26,13 +40,24 @@ describe("SightingModal", () => {
   beforeEach(() => {
     mockCreateSighting.mockReset();
     mockCreateSighting.mockResolvedValue(undefined);
+    mockReverseGeocode.mockReset();
+    mockReverseGeocode.mockResolvedValue({ address: "埼玉県さいたま市" });
+    mockGetCurrentPosition.mockReset();
+    Object.defineProperty(window.navigator, "geolocation", {
+      configurable: true,
+      value: { getCurrentPosition: mockGetCurrentPosition },
+    });
   });
 
   it("isOpen=true の時、フォームが表示されること", () => {
     renderModal();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByLabelText("緯度")).toBeInTheDocument();
-    expect(screen.getByLabelText("経度")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "地図から選択" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "現在地を使う" })
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("目撃日時")).toBeInTheDocument();
   });
 
@@ -44,14 +69,13 @@ describe("SightingModal", () => {
   it("必須項目を入力して送信すると、createSighting が正しく呼ばれること", async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
-    renderModal({ postId: "post-1", onSuccess });
+    renderModal({
+      postId: "post-1",
+      onSuccess,
+      pickedLocation: { lat: 35.9, lng: 139.6, address: "埼玉県さいたま市" },
+    });
 
-    await user.clear(screen.getByLabelText("緯度"));
-    await user.type(screen.getByLabelText("緯度"), "35.9");
-    await user.clear(screen.getByLabelText("経度"));
-    await user.type(screen.getByLabelText("経度"), "139.6");
     await user.type(screen.getByLabelText("目撃日時"), "2026-04-26T10:00");
-
     await user.click(screen.getByRole("button", { name: "送信" }));
 
     await waitFor(() => {
@@ -76,27 +100,25 @@ describe("SightingModal", () => {
     expect(mockCreateSighting).not.toHaveBeenCalled();
   });
 
-  it("緯度が数値でない時、エラーメッセージが表示されること", async () => {
+  it("位置情報未指定で送信すると「位置情報を指定してください」エラーが表示されること", async () => {
     const user = userEvent.setup();
     renderModal();
 
-    await user.type(screen.getByLabelText("緯度"), "abc");
-    await user.type(screen.getByLabelText("経度"), "139.6");
     await user.type(screen.getByLabelText("目撃日時"), "2026-04-26T10:00");
     await user.click(screen.getByRole("button", { name: "送信" }));
 
     expect(
-      await screen.findByText("緯度は正しい数値を入力してください")
+      await screen.findByText("位置情報を指定してください")
     ).toBeInTheDocument();
     expect(mockCreateSighting).not.toHaveBeenCalled();
   });
 
   it("postId なしで送信すると、postId を含まずに createSighting が呼ばれること", async () => {
     const user = userEvent.setup();
-    renderModal();
+    renderModal({
+      pickedLocation: { lat: 35.9, lng: 139.6 },
+    });
 
-    await user.type(screen.getByLabelText("緯度"), "35.9");
-    await user.type(screen.getByLabelText("経度"), "139.6");
     await user.type(screen.getByLabelText("目撃日時"), "2026-04-26T10:00");
     await user.click(screen.getByRole("button", { name: "送信" }));
 
@@ -145,7 +167,7 @@ describe("SightingModal", () => {
       expect(onSelectFromMap).toHaveBeenCalledTimes(1);
     });
 
-    it("pickedLocation が更新された時、lat/lng/address フィールドに反映されること", async () => {
+    it("pickedLocation が更新された時、選択位置の表示が更新されること", async () => {
       const { rerender } = renderModal();
 
       rerender(
@@ -161,9 +183,7 @@ describe("SightingModal", () => {
         />
       );
 
-      expect(screen.getByLabelText("緯度")).toHaveValue("35.9");
-      expect(screen.getByLabelText("経度")).toHaveValue("139.6");
-      expect(screen.getByLabelText("住所")).toHaveValue("埼玉県さいたま市");
+      expect(await screen.findByText("埼玉県さいたま市")).toBeInTheDocument();
     });
 
     it("pickedLocation に geocodeError がある時、エラーメッセージが表示されること", async () => {
@@ -212,6 +232,56 @@ describe("SightingModal", () => {
       );
 
       expect(screen.getByLabelText("コメント")).toHaveValue("テストコメント");
+    });
+  });
+
+  describe("現在地を使う", () => {
+    it("「現在地を使う」クリックで geolocation が呼ばれ、位置が表示されること", async () => {
+      const user = userEvent.setup();
+      mockGetCurrentPosition.mockImplementation((success: PositionCallback) => {
+        success({
+          coords: {
+            latitude: 35.92,
+            longitude: 139.62,
+            accuracy: 10,
+            altitude: null,
+            altitudeAccuracy: null,
+            heading: null,
+            speed: null,
+            toJSON: () => ({}),
+          },
+          timestamp: Date.now(),
+          toJSON: () => ({}),
+        });
+      });
+
+      renderModal();
+      await user.click(screen.getByRole("button", { name: "現在地を使う" }));
+
+      expect(await screen.findByText("埼玉県さいたま市")).toBeInTheDocument();
+      expect(mockReverseGeocode).toHaveBeenCalledWith(35.92, 139.62);
+    });
+
+    it("geolocation 失敗時、エラーメッセージが表示されること", async () => {
+      const user = userEvent.setup();
+      mockGetCurrentPosition.mockImplementation(
+        (_: unknown, error: PositionErrorCallback) => {
+          error({
+            code: 1,
+            message: "denied",
+            PERMISSION_DENIED: 1,
+            POSITION_UNAVAILABLE: 2,
+            TIMEOUT: 3,
+          });
+        }
+      );
+
+      renderModal();
+      await user.click(screen.getByRole("button", { name: "現在地を使う" }));
+
+      expect(
+        await screen.findByText("現在地の取得に失敗しました")
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/SightingModal.tsx
+++ b/apps/web/src/components/SightingModal.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
+import { MapPin, LocateFixed } from "lucide-react";
 import { useApiClient } from "../api/orvalClient";
+import { reverseGeocode } from "../lib/reverseGeocode";
 import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
 import { toast } from "sonner";
 
@@ -21,8 +23,7 @@ interface SightingModalProps {
 }
 
 interface FormErrors {
-  lat?: string;
-  lng?: string;
+  location?: string;
   sightedAt?: string;
 }
 
@@ -42,29 +43,51 @@ export default function SightingModal({
   const [address, setAddress] = useState("");
   const [comment, setComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLocating, setIsLocating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FormErrors>({});
-  const [hasLocationFromMap, setHasLocationFromMap] = useState(false);
+  const [hasLocation, setHasLocation] = useState(false);
 
   useEffect(() => {
     if (!pickedLocation) return;
     setLat(String(pickedLocation.lat));
     setLng(String(pickedLocation.lng));
-    setHasLocationFromMap(true);
+    setHasLocation(true);
     if (pickedLocation.address !== undefined)
       setAddress(pickedLocation.address);
     if (pickedLocation.geocodeError) setError(pickedLocation.geocodeError);
   }, [pickedLocation]);
 
+  const handleCurrentLocation = () => {
+    if (!navigator.geolocation) {
+      setError("このブラウザでは現在地を取得できません");
+      return;
+    }
+    setIsLocating(true);
+    setError(null);
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        const { latitude, longitude } = position.coords;
+        setLat(String(latitude));
+        setLng(String(longitude));
+        setHasLocation(true);
+        const result = await reverseGeocode(latitude, longitude);
+        if ("address" in result) setAddress(result.address);
+        else setError(result.geocodeError);
+        setIsLocating(false);
+      },
+      () => {
+        setError("現在地の取得に失敗しました");
+        setIsLocating(false);
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+    );
+  };
+
   const validate = (): boolean => {
     const errors: FormErrors = {};
-    if (!lat.trim()) errors.lat = "緯度を入力してください";
-    if (!lng.trim()) errors.lng = "経度を入力してください";
+    if (!lat || !lng) errors.location = "位置情報を指定してください";
     if (!sightedAt) errors.sightedAt = "目撃日時を入力してください";
-    if (lat.trim() && isNaN(parseFloat(lat)))
-      errors.lat = "緯度は正しい数値を入力してください";
-    if (lng.trim() && isNaN(parseFloat(lng)))
-      errors.lng = "経度は正しい数値を入力してください";
     setFieldErrors(errors);
     return Object.keys(errors).length === 0;
   };
@@ -99,7 +122,8 @@ export default function SightingModal({
   const handleClose = () => {
     setFieldErrors({});
     setError(null);
-    setHasLocationFromMap(false);
+    setHasLocation(false);
+    setIsLocating(false);
     onClose();
   };
 
@@ -134,73 +158,64 @@ export default function SightingModal({
           </div>
 
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <button
-              type="button"
-              aria-label="地図から選択"
-              onClick={onSelectFromMap}
-              className="w-full min-h-[44px] rounded-xl border border-primary text-primary font-bold text-sm hover:bg-accent"
-            >
-              地図から選択
-            </button>
-
-            <div className="flex flex-col gap-1">
-              <label
-                htmlFor="sighting-lat"
-                className="text-sm font-bold text-foreground"
-              >
-                緯度
-              </label>
-              <input
-                id="sighting-lat"
-                aria-label="緯度"
-                type="text"
-                inputMode="decimal"
-                value={lat}
-                onChange={(e) => setLat(e.target.value)}
-                readOnly={hasLocationFromMap}
-                className={`border rounded-lg px-3 py-2 text-sm ${hasLocationFromMap ? "bg-muted text-muted-foreground" : ""} ${fieldErrors.lat ? "border-destructive" : ""}`}
-                placeholder="例: 35.9062"
-              />
-              {fieldErrors.lat && (
-                <p className="text-xs text-destructive">{fieldErrors.lat}</p>
+            {/* 位置情報（プライマリアクション） */}
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-bold text-foreground">
+                位置情報 <span className="text-destructive">*</span>
+              </span>
+              <div className="grid grid-cols-2 gap-3">
+                <button
+                  type="button"
+                  aria-label="地図から選択"
+                  onClick={onSelectFromMap}
+                  className="min-h-[52px] rounded-xl bg-primary text-primary-foreground font-bold text-sm flex items-center justify-center gap-2 hover:bg-primary/90 active:scale-[0.98] transition-all"
+                >
+                  <MapPin size={16} aria-hidden="true" />
+                  地図から選択
+                </button>
+                <button
+                  type="button"
+                  aria-label="現在地を使う"
+                  onClick={handleCurrentLocation}
+                  disabled={isLocating}
+                  className="min-h-[52px] rounded-xl border border-primary text-primary font-bold text-sm flex items-center justify-center gap-2 hover:bg-accent disabled:opacity-50 active:scale-[0.98] transition-all"
+                >
+                  <LocateFixed size={16} aria-hidden="true" />
+                  {isLocating ? "取得中…" : "現在地を使う"}
+                </button>
+              </div>
+              {hasLocation && lat && lng && (
+                <div className="flex items-center gap-2 px-3 py-2 bg-muted rounded-xl text-sm">
+                  <MapPin
+                    size={14}
+                    className="text-primary shrink-0"
+                    aria-hidden="true"
+                  />
+                  <span className="text-foreground truncate">
+                    {address ||
+                      `${parseFloat(lat).toFixed(5)}, ${parseFloat(lng).toFixed(5)}`}
+                  </span>
+                </div>
+              )}
+              {fieldErrors.location && (
+                <p className="text-xs text-destructive">
+                  {fieldErrors.location}
+                </p>
               )}
             </div>
 
-            <div className="flex flex-col gap-1">
-              <label
-                htmlFor="sighting-lng"
-                className="text-sm font-bold text-foreground"
-              >
-                経度
-              </label>
-              <input
-                id="sighting-lng"
-                aria-label="経度"
-                type="text"
-                inputMode="decimal"
-                value={lng}
-                onChange={(e) => setLng(e.target.value)}
-                readOnly={hasLocationFromMap}
-                className={`border rounded-lg px-3 py-2 text-sm ${hasLocationFromMap ? "bg-muted text-muted-foreground" : ""} ${fieldErrors.lng ? "border-destructive" : ""}`}
-                placeholder="例: 139.6236"
-              />
-              {fieldErrors.lng && (
-                <p className="text-xs text-destructive">{fieldErrors.lng}</p>
-              )}
-            </div>
-
+            {/* 目撃日時 */}
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="sighting-sightedAt"
                 className="text-sm font-bold text-foreground"
               >
-                目撃日時
+                目撃日時 <span className="text-destructive">*</span>
               </label>
               <input
                 id="sighting-sightedAt"
                 aria-label="目撃日時"
                 type="datetime-local"
-                required
                 value={sightedAt}
                 onChange={(e) => setSightedAt(e.target.value)}
                 className={`border rounded-lg px-3 py-2 text-sm ${fieldErrors.sightedAt ? "border-destructive" : ""}`}
@@ -212,6 +227,7 @@ export default function SightingModal({
               )}
             </div>
 
+            {/* 住所（任意） */}
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="sighting-address"
@@ -230,6 +246,7 @@ export default function SightingModal({
               />
             </div>
 
+            {/* コメント（任意） */}
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="sighting-comment"

--- a/apps/web/src/pages/CreatePost.tsx
+++ b/apps/web/src/pages/CreatePost.tsx
@@ -99,6 +99,7 @@ export default function CreatePost() {
   const api = useApiClient();
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
 
   // PetDetail
   const [name, setName] = useState("");
@@ -212,7 +213,18 @@ export default function CreatePost() {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validate()) return;
+    if (!validate()) {
+      requestAnimationFrame(() => {
+        const el =
+          formRef.current?.querySelector<HTMLElement>(
+            '[aria-invalid="true"]'
+          ) ??
+          formRef.current?.querySelector<HTMLElement>("p.text-destructive");
+        el?.scrollIntoView({ behavior: "smooth", block: "center" });
+        if (el?.matches("input, textarea")) el.focus();
+      });
+      return;
+    }
 
     const normalizedLostDate = new Date(lostDate).toISOString();
 
@@ -267,7 +279,7 @@ export default function CreatePost() {
         </h1>
       </div>
 
-      <form onSubmit={submit} className="space-y-12">
+      <form ref={formRef} onSubmit={submit} className="space-y-12">
         {/* 1. お写真 */}
         <section className="space-y-4">
           <div className="flex items-center gap-2">
@@ -356,6 +368,7 @@ export default function CreatePost() {
                 placeholder="例：レオ"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
+                aria-invalid={!!errors.name}
                 className="h-12 border-none bg-muted rounded-2xl px-4 focus-visible:ring-2 focus-visible:ring-ring"
               />
               {errors.name && (
@@ -426,6 +439,7 @@ export default function CreatePost() {
                 placeholder="例：推定2歳"
                 value={age}
                 onChange={(e) => setAge(e.target.value)}
+                aria-invalid={!!errors.age}
                 className="h-12 border-none bg-muted rounded-2xl px-4 focus-visible:ring-2 focus-visible:ring-ring"
               />
               {errors.age && (
@@ -444,6 +458,7 @@ export default function CreatePost() {
                 placeholder="例：茶トラ、白黒ハチワレ"
                 value={color}
                 onChange={(e) => setColor(e.target.value)}
+                aria-invalid={!!errors.color}
                 className="h-12 border-none bg-muted rounded-2xl px-4 focus-visible:ring-2 focus-visible:ring-ring"
               />
               {errors.color && (
@@ -465,6 +480,7 @@ export default function CreatePost() {
               placeholder="例：かぎしっぽです。少し人見知りですが、おやつを見せると寄ってきます。"
               value={features}
               onChange={(e) => setFeatures(e.target.value)}
+              aria-invalid={!!errors.features}
               className="min-h-[100px] border-none bg-muted rounded-2xl p-4 focus-visible:ring-2 focus-visible:ring-ring resize-none"
             />
             {errors.features && (
@@ -484,6 +500,7 @@ export default function CreatePost() {
               placeholder="例：首輪なし。人懐こい性格で、名前を呼ぶと振り向きます。"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+              aria-invalid={!!errors.description}
               className="min-h-[80px] border-none bg-muted rounded-2xl p-4 focus-visible:ring-2 focus-visible:ring-ring resize-none"
             />
             {errors.description && (
@@ -543,6 +560,7 @@ export default function CreatePost() {
                 type="datetime-local"
                 value={lostDate}
                 onChange={(e) => setLostDate(e.target.value)}
+                aria-invalid={!!errors.lostDate}
                 className="h-12 border-none bg-muted rounded-2xl pl-12 focus-visible:ring-2 focus-visible:ring-ring"
               />
             </div>
@@ -584,6 +602,7 @@ export default function CreatePost() {
                   placeholder="例：さいたま市"
                   value={city}
                   onChange={(e) => setCity(e.target.value)}
+                  aria-invalid={!!errors.city}
                   className="h-12 border-none bg-muted rounded-2xl px-4 focus-visible:ring-2 focus-visible:ring-ring"
                 />
                 {errors.city && (
@@ -603,6 +622,7 @@ export default function CreatePost() {
                 placeholder="例：〇〇1-2-3 〇〇公園付近"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
+                aria-invalid={!!errors.address}
                 className="h-12 border-none bg-muted rounded-2xl px-4 focus-visible:ring-2 focus-visible:ring-ring"
               />
               {errors.address && (

--- a/apps/web/src/pages/EditPost.tsx
+++ b/apps/web/src/pages/EditPost.tsx
@@ -82,6 +82,7 @@ export default function EditPost() {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const mapRef = useRef<LeafletMap | null>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
   const apiRef = useRef(api);
   apiRef.current = api;
 
@@ -160,6 +161,12 @@ export default function EditPost() {
       mapRef.current.flyTo([pinPos.lat, pinPos.lng], 15);
     }
   }, [pinPos]);
+
+  useEffect(() => {
+    if (error) {
+      errorRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [error]);
 
   const handleCurrentLocation = () => {
     if (!navigator.geolocation) {
@@ -285,7 +292,10 @@ export default function EditPost() {
       </div>
 
       {error && (
-        <p className="mb-4 text-sm text-destructive bg-destructive/10 p-3 rounded-xl flex items-start gap-2">
+        <p
+          ref={errorRef}
+          className="mb-4 text-sm text-destructive bg-destructive/10 p-3 rounded-xl flex items-start gap-2"
+        >
           <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
           <span>{error}</span>
         </p>

--- a/apps/web/src/pages/Map.test.tsx
+++ b/apps/web/src/pages/Map.test.tsx
@@ -567,9 +567,7 @@ describe("Map", () => {
       expect(
         await screen.findByRole("heading", { name: "目撃を報告する" })
       ).toBeInTheDocument();
-      expect(screen.getByLabelText("緯度")).toHaveValue("35.91");
-      expect(screen.getByLabelText("経度")).toHaveValue("139.61");
-      expect(screen.getByLabelText("住所")).toHaveValue("埼玉県さいたま市");
+      expect(await screen.findByText("埼玉県さいたま市")).toBeInTheDocument();
     });
 
     it("Nominatim 失敗時、lat/lng セット済みでモーダルが再表示され、エラーメッセージが表示されること", async () => {
@@ -591,9 +589,6 @@ describe("Map", () => {
       expect(
         await screen.findByRole("heading", { name: "目撃を報告する" })
       ).toBeInTheDocument();
-      await waitFor(() => {
-        expect(screen.getByLabelText("緯度")).toHaveValue("35.91");
-      });
       expect(await screen.findByRole("alert")).toHaveTextContent(
         "住所の自動取得に失敗しました。手動で入力してください"
       );

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -22,3 +22,7 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 if (!Element.prototype.setPointerCapture) {
   Element.prototype.setPointerCapture = () => {};
 }
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -1009,18 +1009,20 @@
 - [x] SightingList で削除成功後に onSightingDeleted コールバックが呼ばれること
 - [x] SightingList で削除処理中は確認ダイアログの削除ボタンが無効化されること
 - [x] SightingList で削除 API が失敗した時、エラーメッセージが表示されること
-- [x] SightingModal で isOpen=true の時、フォームが表示されること
+- [x] SightingModal で isOpen=true の時、フォームが表示されること（「地図から選択」「現在地を使う」ボタン含む）
 - [x] SightingModal で postId が渡された時、postId フィールドが非表示であること
 - [x] SightingModal で必須項目を入力して送信すると、createSighting が正しく呼ばれること
 - [x] SightingModal で必須項目未入力で送信しても、createSighting が呼ばれないこと
+- [x] SightingModal で位置情報未指定で送信すると「位置情報を指定してください」エラーが表示されること
 - [x] SightingModal で閉じるボタンを押した時、onClose が呼ばれること
-- [x] SightingModal で緯度が数値でない時、エラーメッセージが表示されること
 - [x] SightingModal で postId なしで送信すると、postId を含まずに createSighting が呼ばれること
 - [x] SightingModal で「地図から選択」ボタンが表示されること（postId あり・なし両方）
 - [x] SightingModal で「地図から選択」クリックで onSelectFromMap が呼ばれること
-- [x] SightingModal で pickedLocation が更新された時、lat/lng/address フィールドに反映されること
+- [x] SightingModal で pickedLocation が更新された時、選択位置の表示が更新されること
 - [x] SightingModal で pickedLocation に geocodeError がある時、エラーメッセージが表示されること
 - [x] SightingModal で forceMount 時、isOpen=false → true でフォーム値が保持されること
+- [x] SightingModal で「現在地を使う」クリックで geolocation が呼ばれ、位置が表示されること
+- [x] SightingModal で geolocation 失敗時、エラーメッセージが表示されること
 - [x] Map で「目撃投稿」ボタンクリックで SightingModal が開くこと
 - [x] Map で「地図から選択」クリック後、「タップして場所を選択」バナーが表示されること
 - [x] Map で地図クリックで lat/lng・住所が SightingModal にセットされ再表示されること

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -731,19 +731,22 @@ apps/web/src/
     │       └── 削除 API が失敗した時、エラーメッセージが表示されること
     ├── components/SightingModal.test.tsx
     │   └── SightingModal
-    │       ├── isOpen=true の時、フォームが表示されること
+    │       ├── isOpen=true の時、フォームが表示されること（「地図から選択」「現在地を使う」ボタン含む）
     │       ├── postId が渡された時、postId フィールドが非表示であること
     │       ├── 必須項目を入力して送信すると、createSighting が正しく呼ばれること
     │       ├── 必須項目未入力で送信しても、createSighting が呼ばれないこと
+    │       ├── 位置情報未指定で送信すると「位置情報を指定してください」エラーが表示されること
     │       ├── 閉じるボタンを押した時、onClose が呼ばれること
-    │       ├── 緯度が数値でない時、エラーメッセージが表示されること
     │       ├── postId なしで送信すると、postId を含まずに createSighting が呼ばれること
-    │       └── 地図から選択
-    │           ├── 「地図から選択」ボタンが表示されること（postId あり・なし両方）
-    │           ├── 「地図から選択」クリックで onSelectFromMap が呼ばれること
-    │           ├── pickedLocation が更新された時、lat/lng/address フィールドに反映されること
-    │           ├── pickedLocation に geocodeError がある時、エラーメッセージが表示されること
-    │           └── forceMount 時、isOpen=false → true でフォーム値が保持されること
+    │       ├── 地図から選択
+    │       │   ├── 「地図から選択」ボタンが表示されること（postId あり・なし両方）
+    │       │   ├── 「地図から選択」クリックで onSelectFromMap が呼ばれること
+    │       │   ├── pickedLocation が更新された時、選択位置の表示が更新されること
+    │       │   ├── pickedLocation に geocodeError がある時、エラーメッセージが表示されること
+    │       │   └── forceMount 時、isOpen=false → true でフォーム値が保持されること
+    │       └── 現在地を使う
+    │           ├── 「現在地を使う」クリックで geolocation が呼ばれ、位置が表示されること
+    │           └── geolocation 失敗時、エラーメッセージが表示されること
     ├── lib/reverseGeocode.test.ts
     │   └── reverseGeocode
     │       ├── 正常時、Nominatim から住所文字列を返すこと


### PR DESCRIPTION
## Summary

- **#317 フォームスクロール**: バリデーション失敗時に `aria-invalid="true"` の最初の要素へ `scrollIntoView`（CreatePost）、`error` state 変化時にエラーバナーへスクロール（EditPost）
- **#318 SightingModal UI再設計**: 緯度/経度の直接入力を廃止し「地図から選択」「現在地を使う」プライマリボタンに変更。位置情報は読み取り専用表示（住所 or 座標）。必須項目に `*` マーク追加
- テスト: SightingModal.test.tsx を新 UI に全面更新（14件）、Map.test.tsx の緯度/経度 input アサーションを位置表示テキスト確認に変更、jsdom の `scrollIntoView` 未実装対策を setup.ts に追加

## Test plan

- [x] API: 388 テスト全合格
- [x] Web: 240 テスト全合格（SightingModal 14件 + EditPost scrollIntoView修正 + Map 2件更新）
- [x] 型チェック: `typecheck:api` / `typecheck:web` 共にエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)