### PR TITLE
fix: issue#308 flaky テスト安定化（タイムアウト延長・pre-commit 最適化）

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 npx lint-staged
 npm run typecheck:api
 npm run typecheck:web
-npm run test
+npm run test:pre-commit

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:related": "vitest run --changed HEAD",
     "test:ui": "vitest --ui",
     "test:e2e": "npx playwright test --project=chromium --reporter=list",
     "storybook": "storybook dev -p 6006",

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -60,7 +60,7 @@ describe("App", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: "ログイン" })
+      await screen.findByRole("button", { name: "ログイン" }, { timeout: 5000 })
     ).toBeInTheDocument();
   });
 
@@ -73,7 +73,11 @@ describe("App", () => {
     );
 
     expect(
-      await screen.findByText("まだ迷い猫投稿はありません")
+      await screen.findByText(
+        "まだ迷い猫投稿はありません",
+        {},
+        { timeout: 5000 }
+      )
     ).toBeInTheDocument();
   });
 
@@ -86,7 +90,7 @@ describe("App", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: "ログイン" })
+      await screen.findByRole("button", { name: "ログイン" }, { timeout: 5000 })
     ).toBeInTheDocument();
   });
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -17,6 +17,6 @@ export default defineConfig({
     setupFiles: "./src/test/setup.ts",
     include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     exclude: ["node_modules", "dist", "tests/**/*"],
-    testTimeout: 10000,
+    testTimeout: 15000,
   },
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "npm run test:api && npm run test:web",
     "test:api": "npm run test --workspace=apps/api",
     "test:web": "npm run test:run --workspace=apps/web",
+    "test:web:related": "npm run test:related --workspace=apps/web",
+    "test:pre-commit": "npm run test:api && npm run test:web:related",
     "test:contract": "npm run dredd",
     "test:ci": "npm run test && npm run test:contract",
     "test:e2e": "npm run test:e2e:web && npm run test:e2e:api",


### PR DESCRIPTION
## Summary

- **App.test.tsx**: 全 `findBy*` クエリに `{ timeout: 5000 }` を明示。lazy import + Suspense の並列実行時に認証状態復元が findBy のデフォルトタイムアウトを超過していた
- **vitest.config.ts**: `testTimeout` を 10000 → 15000 に引き上げ（CreatePost 長時間テストのタイムアウト対策）
- **pre-commit 最適化**: `npm run test`（全件）→ `npm run test:pre-commit`（変更ファイル関連のみ）に変更。`vitest run --changed HEAD` で staged ファイルに関連するテストのみ実行するため、小規模コミット時の待ち時間を大幅短縮

## Test plan

- [x] API: 388 テスト全合格
- [x] Web: 240 テスト全合格
- [x] pre-commit フック正常動作確認

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)