### PR TITLE
chore: 実ドメインを汎用プレースホルダに置換

### DIFF
--- a/apps/api/src/common/cors.spec.ts
+++ b/apps/api/src/common/cors.spec.ts
@@ -1,12 +1,12 @@
 import { isOriginAllowed } from "./cors";
 
-const allowedOrigins = ["https://finder.miyaoo.com"];
+const allowedOrigins = ["https://your-domain.example.com"];
 
 describe("isOriginAllowed", () => {
   describe("本番環境 (isDev=false)", () => {
     it("許可オリジンからのリクエストを許可すること", () => {
       expect(
-        isOriginAllowed("https://finder.miyaoo.com", false, allowedOrigins)
+        isOriginAllowed("https://your-domain.example.com", false, allowedOrigins)
       ).toBe(true);
     });
 
@@ -46,7 +46,7 @@ describe("isOriginAllowed", () => {
 
     it("許可オリジンを許可すること", () => {
       expect(
-        isOriginAllowed("https://finder.miyaoo.com", true, allowedOrigins)
+        isOriginAllowed("https://your-domain.example.com", true, allowedOrigins)
       ).toBe(true);
     });
 

--- a/scripts/vps-deploy.sh
+++ b/scripts/vps-deploy.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="${PROJECT_DIR:-$(dirname "$SCRIPT_DIR")}"
 export PROJECT_DIR
 PM2_NAME="${PM2_NAME:-api}"
-DOMAIN="${DOMAIN:-finder.miyaoo.com}"
+DOMAIN="${DOMAIN:-your-domain.example.com}"
 SKIP_BACKUP="${SKIP_BACKUP:-false}"
 SKIP_WEB="${SKIP_WEB:-false}"
 SKIP_ROLLBACK="${SKIP_ROLLBACK:-false}"
@@ -38,14 +38,14 @@ Options:
   --skip-backup         デプロイ前のバックアップをスキップ
   --skip-web            Webフロントエンドのビルド・デプロイをスキップ（APIのみ更新）
   --skip-rollback       ヘルスチェック失敗時の自動ロールバックを無効化
-  --domain DOMAIN       ヘルスチェック対象のドメイン（デフォルト: finder.miyaoo.com）
+  --domain DOMAIN       ヘルスチェック対象のドメイン（デフォルト: your-domain.example.com）
   --pm2-name NAME       PM2 プロセス名（デフォルト: api）
   --help, -h            このヘルプを表示
 
 Environment Variables:
   PROJECT_DIR           プロジェクトルートパス（未設定時はスクリプト位置から自動検出）
   PM2_NAME              PM2 プロセス名（デフォルト: api）
-  DOMAIN                本番ドメイン（デフォルト: finder.miyaoo.com）
+  DOMAIN                本番ドメイン（デフォルト: your-domain.example.com）
   SKIP_BACKUP           true でバックアップをスキップ
   SKIP_WEB              true で Web デプロイをスキップ
   SKIP_ROLLBACK         true で自動ロールバックを無効化

--- a/scripts/vps-health-check.sh
+++ b/scripts/vps-health-check.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # PM2 / API / Web サイト / SSL 証明書期限 / ディスク容量 を確認
 # =============================================================================
 
-DOMAIN="${DOMAIN:-finder.miyaoo.com}"
+DOMAIN="${DOMAIN:-your-domain.example.com}"
 PM2_NAME="${PM2_NAME:-api}"
 VERBOSE="${VERBOSE:-false}"
 


### PR DESCRIPTION
## 概要
CORS設定およびデプロイスクリプト内の実ドメインを汎用プレースホルダ `your-domain.example.com` に置換。

## 変更ファイル
- `apps/api/src/common/cors.spec.ts` — CORS 許可オリジン（3箇所）
- `scripts/vps-deploy.sh` — デフォルトドメイン設定（3箇所: 変数・ヘルプ・環境変数ドキュメント）
- `scripts/vps-health-check.sh` — デフォルトドメイン設定（1箇所）

## 補足
- `*.miyaoo.test`（テスト用 `.test` TLD）は RFC 6761 予約済みのテスト用ドメインのため、そのまま維持