### PR TITLE
feat: ログイン画面にデモユーザーのプリフィルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 dist/
 build/
 .env
+.env.local
+.env.*.local
 .vscode/
 .DS_Store
 npm-debug.log

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -10,6 +10,11 @@
 # ---------- build: Vite ビルド ----------
 FROM node:22-slim AS build
 ENV HUSKY=0
+# デモユーザーのプリフィル用（VITE_ プレフィックスは Vite ビルド時に埋め込まれる）
+ARG VITE_DEMO_EMAIL=demo@finder.miyaoo.com
+ARG VITE_DEMO_PASSWORD=Demo1234!
+ENV VITE_DEMO_EMAIL=$VITE_DEMO_EMAIL
+ENV VITE_DEMO_PASSWORD=$VITE_DEMO_PASSWORD
 WORKDIR /app
 
 COPY package.json package-lock.json ./

--- a/apps/web/src/pages/LoginWithAuth.test.tsx
+++ b/apps/web/src/pages/LoginWithAuth.test.tsx
@@ -67,10 +67,12 @@ describe("LoginWithAuth", () => {
     const user = userEvent.setup();
     render(<LoginWithAuth />);
 
+    await user.clear(screen.getByLabelText("メールアドレス"));
     await user.type(
       screen.getByLabelText("メールアドレス"),
       "test@example.com"
     );
+    await user.clear(screen.getByLabelText("パスワード"));
     await user.type(screen.getByLabelText("パスワード"), "password123");
     await user.click(screen.getByRole("button", { name: /ログイン/i }));
 
@@ -85,10 +87,12 @@ describe("LoginWithAuth", () => {
     const user = userEvent.setup();
     render(<LoginWithAuth />);
 
+    await user.clear(screen.getByLabelText("メールアドレス"));
     await user.type(
       screen.getByLabelText("メールアドレス"),
       "test@example.com"
     );
+    await user.clear(screen.getByLabelText("パスワード"));
     await user.type(screen.getByLabelText("パスワード"), "wrongpass");
     await user.click(screen.getByRole("button", { name: /ログイン/i }));
 
@@ -109,10 +113,12 @@ describe("LoginWithAuth", () => {
     const user = userEvent.setup();
     render(<LoginWithAuth />);
 
+    await user.clear(screen.getByLabelText("メールアドレス"));
     await user.type(
       screen.getByLabelText("メールアドレス"),
       "test@example.com"
     );
+    await user.clear(screen.getByLabelText("パスワード"));
     await user.type(screen.getByLabelText("パスワード"), "wrongpass");
     await user.click(screen.getByRole("button", { name: /ログイン/i }));
 
@@ -130,10 +136,12 @@ describe("LoginWithAuth", () => {
     const user = userEvent.setup();
     render(<LoginWithAuth />);
 
+    await user.clear(screen.getByLabelText("メールアドレス"));
     await user.type(
       screen.getByLabelText("メールアドレス"),
       "test@example.com"
     );
+    await user.clear(screen.getByLabelText("パスワード"));
     await user.type(screen.getByLabelText("パスワード"), "wrongpass");
     await user.click(screen.getByRole("button", { name: /ログイン/i }));
 
@@ -147,10 +155,12 @@ describe("LoginWithAuth", () => {
     const user = userEvent.setup();
     render(<LoginWithAuth />);
 
+    await user.clear(screen.getByLabelText("メールアドレス"));
     await user.type(
       screen.getByLabelText("メールアドレス"),
       "test@example.com"
     );
+    await user.clear(screen.getByLabelText("パスワード"));
     await user.type(screen.getByLabelText("パスワード"), "wrongpass");
     await user.click(screen.getByRole("button", { name: /ログイン/i }));
 

--- a/apps/web/src/pages/LoginWithAuth.tsx
+++ b/apps/web/src/pages/LoginWithAuth.tsx
@@ -8,8 +8,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 export default function LoginWithAuth() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [email, setEmail] = useState(import.meta.env.VITE_DEMO_EMAIL ?? "");
+  const [password, setPassword] = useState(
+    import.meta.env.VITE_DEMO_PASSWORD ?? ""
+  );
   const [showPassword, setShowPassword] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_DEMO_EMAIL?: string;
+  readonly VITE_DEMO_PASSWORD?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- ログイン画面を開くとデモユーザーの認証情報が自動入力される
- `VITE_DEMO_EMAIL` / `VITE_DEMO_PASSWORD` 環境変数で制御
- Dockerfile に ARG/ENV を追加し、ビルド時に埋め込む

## Test plan
- [x] 全テスト通過（388 API + 11 Web）
- [x] ローカルでログイン画面のプリフィル動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)