### PR TITLE
chore: docs/memo/CLAUDE.mdをシンボリックリンク化に伴いgitignoreパターンを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,9 @@ coverage/
 apps/api/debug.log
 apps/api/prisma/dev.db
 apps/api/uploads/
-memo/
+memo
 backups/
-docs/
+docs
 .playwright-mcp/
 .claude/
 .kilo/


### PR DESCRIPTION
## Summary
- `docs/` `memo/` `CLAUDE.md` を個人用プライベートリポジトリ `nextjsproA-notes` に分離し、シンボリックリンクで参照する構成に変更
- `.gitignore` の `docs/` `memo/` パターン（ディレクトリのみマッチ）だとシンボリックリンクを無視できないため、末尾スラッシュを外して修正

## Test plan
- [x] pre-commit hook（lint-staged / typecheck / test）が全て通過済み